### PR TITLE
ci: add codegen drift gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,32 @@ jobs:
       # it only because of Colima socket-mount limits).
       - run: go test -tags integration -count=1 ./...
 
+  codegen-drift:
+    name: codegen drift
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.23'
+          cache: true
+      - uses: bufbuild/buf-action@v1
+        with:
+          setup_only: true
+      - name: Regenerate protobuf bindings
+        run: buf generate
+      - name: Regenerate GraphQL bindings
+        working-directory: internal/query
+        run: go run github.com/99designs/gqlgen generate
+      - name: Fail if generated code drifted
+        run: |
+          if ! git diff --exit-code; then
+            echo "::error::Generated code is out of date. Run 'make proto && make gqlgen' locally and commit the result."
+            git diff --stat
+            exit 1
+          fi
+
   web:
     name: web build
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Closes #9. Adds a \`codegen-drift\` job to the CI pipeline so PRs that edit \`proto/event.proto\` or \`internal/query/schema.graphql\` without re-running codegen are caught at PR time, not at merge time.

## What it does

1. Installs \`buf\` via \`bufbuild/buf-action\`.
2. Runs \`buf generate\` (regenerates \`internal/pb/*.pb.go\`).
3. Runs \`go run github.com/99designs/gqlgen generate\` in \`internal/query\` (regenerates \`generated.go\`, \`models_gen.go\`; merges into \`schema.resolvers.go\`).
4. \`git diff --exit-code\` — non-zero if any tracked file changed. Error message names the local commands the author should run.

## Why a separate PR

Per #9: depends on the base CI workflow landing first. With #13 merged, the \`.github/workflows/ci.yml\` baseline exists; this PR just adds one more job to it.

## Test plan

- [ ] All five existing jobs (go-test x2, golangci-lint, integration, web) still pass.
- [ ] New \`codegen-drift\` job passes on this PR (current generated files are in sync).
- [ ] Future PRs that mutate proto or graphql schema without regenerating will be blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)