### PR TITLE
feat(webhooks): GitHub pull_request webhook receiver (M2-A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ make web-build         # TS 类型检查 + Vite 打包
 - `AGENT_LENS_PG_DSN`（默认本地 compose 配置）
 - `AGENT_LENS_TOKEN`：bearer token；空则 `/v1` 不鉴权（dev 默认）。配置后 hook 与浏览器都需带 `Authorization: Bearer <token>`
 - `AGENT_LENS_PLAYGROUND`：设为 `true` 才挂载 `/v1/playground`（默认 off，避免生产暴露 introspection）
+- `AGENT_LENS_GH_WEBHOOK_SECRET`：GitHub webhook 共享密钥；空则 `/webhooks/github` 不挂载。设置后 server 用 HMAC-SHA256 校验 `X-Hub-Signature-256`
 
 **Hook (`agent-lens-hook`)**
 - `AGENT_LENS_URL`（默认 `http://localhost:8787`）
@@ -78,6 +79,19 @@ make web-build         # TS 类型检查 + Vite 打包
 - `AGENT_LENS_CURSOR_DIR`（默认 `~/.agent-lens/cursors`，存 transcript 增量读 cursor）
 
 Stop hook 会读 `transcript_path` 提取 `thinking` / `text` content blocks（仅当本轮启用 extended thinking 时有 thinking）。HTTP 失败时回落 `~/.agent-lens/sessions/<sid>.ndjson` 文件 sink。
+
+## 接入 GitHub（M2-A：PR 事件）
+
+1. 在 server 端设环境变量 `AGENT_LENS_GH_WEBHOOK_SECRET=<random>`，然后启动 / 重启 `agent-lens`
+2. 在被观测仓库的 GitHub 设置 → Webhooks → Add webhook：
+   - Payload URL：`https://<your-server>/webhooks/github`
+   - Content type：`application/json`
+   - Secret：与 `AGENT_LENS_GH_WEBHOOK_SECRET` 相同
+   - 选 "Let me select individual events" → 勾 `Pull requests`
+3. PR 事件（opened / synchronize / closed / reopened / etc）会作为 `kind=pr` 事件流入 session `github-pr:<owner>/<repo>#<number>`，UI 中输入这个 session id 即可查看 PR 时间线
+4. PR head commit SHA 写入 `refs[git:<sha>]`，等 M2-B linking worker 上线后会自动与本地 commit hook 上报的 COMMIT 事件串联
+
+`pull_request_review` 与 `push` 事件留给 M2-D。GitHub Actions build 事件留给 M2-C。
 
 ## 模块名
 

--- a/cmd/agent-lens/main.go
+++ b/cmd/agent-lens/main.go
@@ -63,11 +63,17 @@ func main() {
 		query.RegisterRoutes(sub, st)
 	})
 
+	// /webhooks/github is always mounted so operators get an
+	// actionable 503 when the secret is missing (rather than a bare
+	// chi 404 that's indistinguishable from a typo).
 	if secret := os.Getenv("AGENT_LENS_GH_WEBHOOK_SECRET"); secret != "" {
 		r.Post("/webhooks/github", githubwh.NewHandler(secret, ingestH).ServeHTTP)
 		slog.Info("github webhook enabled", "path", "/webhooks/github")
 	} else {
-		slog.Info("AGENT_LENS_GH_WEBHOOK_SECRET unset; /webhooks/github not registered")
+		r.Post("/webhooks/github", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "webhook receiver disabled (AGENT_LENS_GH_WEBHOOK_SECRET unset)", http.StatusServiceUnavailable)
+		})
+		slog.Info("AGENT_LENS_GH_WEBHOOK_SECRET unset; /webhooks/github returns 503")
 	}
 
 	srv := &http.Server{

--- a/cmd/agent-lens/main.go
+++ b/cmd/agent-lens/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/dongqiu/agent-lens/internal/ingest"
 	"github.com/dongqiu/agent-lens/internal/query"
 	"github.com/dongqiu/agent-lens/internal/store"
+	githubwh "github.com/dongqiu/agent-lens/internal/webhooks/github"
 )
 
 func main() {
@@ -50,11 +51,24 @@ func main() {
 	if token == "" {
 		slog.Warn("AGENT_LENS_TOKEN is empty; /v1 endpoints are unauthenticated")
 	}
+
+	// One Handler, shared between the HTTP NDJSON path and any other
+	// in-process producers (e.g. webhook receivers) so the head-hash
+	// cache stays authoritative.
+	ingestH := ingest.NewHandler(st)
+
 	r.Route("/v1", func(sub chi.Router) {
 		sub.Use(auth.RequireToken(token))
-		ingest.RegisterRoutes(sub, st)
+		sub.Post("/events", ingestH.IngestNDJSON)
 		query.RegisterRoutes(sub, st)
 	})
+
+	if secret := os.Getenv("AGENT_LENS_GH_WEBHOOK_SECRET"); secret != "" {
+		r.Post("/webhooks/github", githubwh.NewHandler(secret, ingestH).ServeHTTP)
+		slog.Info("github webhook enabled", "path", "/webhooks/github")
+	} else {
+		slog.Info("AGENT_LENS_GH_WEBHOOK_SECRET unset; /webhooks/github not registered")
+	}
 
 	srv := &http.Server{
 		Addr:              addr,

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -1,6 +1,10 @@
 // Package ingest accepts NDJSON event streams over HTTP and persists them
 // via store.Store. Each line in the request body is one JSON event.
 //
+// The package also exposes a programmatic Append entry point so other
+// in-process producers (webhook receivers, background workers) can enter
+// the same hash-chain pipeline without re-marshaling through the HTTP path.
+//
 // Concurrency model: a single handler-wide mutex serializes the
 // "load head → compute hash → append → update cache" sequence so
 // concurrent appends to the same session never fork the chain. The
@@ -49,49 +53,44 @@ var validKinds = map[string]struct{}{
 	"decision":    {},
 }
 
-// RegisterRoutes wires the ingest endpoints onto r. It is the primary
-// entry point used by the main server. NewRouter wraps it for tests and
-// standalone embedding.
-func RegisterRoutes(r chi.Router, st store.Store) {
-	h := &handler{st: st, heads: map[string]string{}}
-	r.Post("/events", h.ingest)
-}
-
-func NewRouter(st store.Store) http.Handler {
-	r := chi.NewRouter()
-	RegisterRoutes(r, st)
-	return r
-}
-
-type handler struct {
+// Handler owns the per-session head-hash cache and is the single writer
+// into the store. Construct one per process and share it between every
+// ingest path (HTTP NDJSON, webhook, programmatic) so the cache stays
+// authoritative.
+type Handler struct {
 	st    store.Store
 	mu    sync.Mutex
-	heads map[string]string // session_id -> last appended hash; cache backed by store.HeadHash
+	heads map[string]string
 }
 
-// wireEvent is the JSON shape accepted on the wire. It mirrors
+func NewHandler(st store.Store) *Handler {
+	return &Handler{st: st, heads: map[string]string{}}
+}
+
+// WireEvent is the JSON shape accepted on the wire. It mirrors
 // proto/event.proto but uses json.RawMessage for payload so we don't
 // re-marshal user content before hashing.
-type wireEvent struct {
+type WireEvent struct {
 	ID        string          `json:"id,omitempty"`
 	TS        time.Time       `json:"ts"`
 	SessionID string          `json:"session_id"`
 	TurnID    string          `json:"turn_id,omitempty"`
-	Actor     wireActor       `json:"actor"`
+	Actor     WireActor       `json:"actor"`
 	Kind      string          `json:"kind"`
 	Payload   json.RawMessage `json:"payload,omitempty"`
 	Parents   []string        `json:"parents,omitempty"`
 	Refs      []string        `json:"refs,omitempty"`
 }
 
-type wireActor struct {
+type WireActor struct {
 	Type  string `json:"type"`
 	ID    string `json:"id"`
 	Model string `json:"model,omitempty"`
 }
 
-func (h *handler) ingest(w http.ResponseWriter, r *http.Request) {
-	defer r.Body.Close()
+// IngestNDJSON is the chi-compatible HTTP handler for POST /v1/events.
+func (h *Handler) IngestNDJSON(w http.ResponseWriter, r *http.Request) {
+	defer func() { _ = r.Body.Close() }()
 	scanner := bufio.NewScanner(r.Body)
 	scanner.Buffer(make([]byte, 1<<20), 8<<20) // 8 MiB max line
 
@@ -101,12 +100,12 @@ func (h *handler) ingest(w http.ResponseWriter, r *http.Request) {
 		if len(line) == 0 {
 			continue
 		}
-		var ev wireEvent
+		var ev WireEvent
 		if err := json.Unmarshal(line, &ev); err != nil {
 			http.Error(w, "bad ndjson line: "+err.Error(), http.StatusBadRequest)
 			return
 		}
-		if err := h.appendOne(r.Context(), &ev); err != nil {
+		if err := h.Append(r.Context(), &ev); err != nil {
 			h.writeAppendError(w, err)
 			return
 		}
@@ -121,11 +120,11 @@ func (h *handler) ingest(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]any{"accepted": accepted})
 }
 
-// appendOne validates an event, computes its hash chain entry, persists
+// Append validates an event, computes its hash chain entry, persists
 // it, and advances the in-memory head cache. The lock spans only the
 // load-prev → compute → append → cache update sequence; canonical
 // marshaling happens before the lock since it does not depend on prev.
-func (h *handler) appendOne(ctx context.Context, in *wireEvent) error {
+func (h *Handler) Append(ctx context.Context, in *WireEvent) error {
 	if err := validateWireEvent(in); err != nil {
 		return err
 	}
@@ -177,7 +176,7 @@ func (h *handler) appendOne(ctx context.Context, in *wireEvent) error {
 	return nil
 }
 
-func validateWireEvent(in *wireEvent) error {
+func validateWireEvent(in *WireEvent) error {
 	if in.SessionID == "" || in.Kind == "" || in.Actor.Type == "" {
 		return errMissingField
 	}
@@ -187,7 +186,7 @@ func validateWireEvent(in *wireEvent) error {
 	return nil
 }
 
-func (h *handler) writeAppendError(w http.ResponseWriter, err error) {
+func (h *Handler) writeAppendError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, errMissingField), errors.Is(err, errInvalidKind):
 		http.Error(w, err.Error(), http.StatusBadRequest)
@@ -197,4 +196,19 @@ func (h *handler) writeAppendError(w http.ResponseWriter, err error) {
 		slog.Error("ingest append", "err", err)
 		http.Error(w, "store error", http.StatusInternalServerError)
 	}
+}
+
+// RegisterRoutes wires the ingest endpoints onto r. Used by
+// `internal/ingest`'s own tests via NewRouter; production callers
+// (cmd/agent-lens) construct a Handler explicitly so they can share
+// it with other producers.
+func RegisterRoutes(r chi.Router, st store.Store) {
+	h := NewHandler(st)
+	r.Post("/events", h.IngestNDJSON)
+}
+
+func NewRouter(st store.Store) http.Handler {
+	r := chi.NewRouter()
+	RegisterRoutes(r, st)
+	return r
 }

--- a/internal/ingest/handler_test.go
+++ b/internal/ingest/handler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -259,3 +260,77 @@ func TestIngestReturns409OnDuplicateID(t *testing.T) {
 	}
 }
 
+
+// TestAppendDirectChainsAndDedupes exercises the public Handler.Append
+// contract: chained writes preserve the per-session head, validation
+// rejects unknown kinds, and a duplicate ID surfaces ErrDuplicate
+// without advancing the head cache.
+func TestAppendDirectChainsAndDedupes(t *testing.T) {
+	st := store.NewMemory()
+	h := NewHandler(st)
+	ctx := context.Background()
+
+	a := &WireEvent{
+		ID:        "01HAPPENDA",
+		SessionID: "s-direct",
+		Actor:     WireActor{Type: "human", ID: "alice"},
+		Kind:      "prompt",
+	}
+	b := &WireEvent{
+		ID:        "01HAPPENDB",
+		SessionID: "s-direct",
+		Actor:     WireActor{Type: "human", ID: "alice"},
+		Kind:      "prompt",
+	}
+	if err := h.Append(ctx, a); err != nil {
+		t.Fatalf("append a: %v", err)
+	}
+	if err := h.Append(ctx, b); err != nil {
+		t.Fatalf("append b: %v", err)
+	}
+
+	got, err := st.ListBySession(ctx, "s-direct", 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d events, want 2", len(got))
+	}
+	if got[1].PrevHash != got[0].Hash {
+		t.Errorf("chain broken: got[1].prev = %q, want %q", got[1].PrevHash, got[0].Hash)
+	}
+
+	// Invalid kind rejected by validation.
+	bad := &WireEvent{
+		SessionID: "s-direct",
+		Actor:     WireActor{Type: "human", ID: "alice"},
+		Kind:      "bogus",
+	}
+	if err := h.Append(ctx, bad); !errors.Is(err, errInvalidKind) {
+		t.Errorf("invalid kind err = %v, want errInvalidKind", err)
+	}
+
+	// Duplicate ID returns ErrDuplicate; head cache must not advance
+	// past the failed insert.
+	dup := *a
+	if err := h.Append(ctx, &dup); !errors.Is(err, store.ErrDuplicate) {
+		t.Errorf("duplicate id err = %v, want ErrDuplicate", err)
+	}
+
+	c := &WireEvent{
+		ID:        "01HAPPENDC",
+		SessionID: "s-direct",
+		Actor:     WireActor{Type: "human", ID: "alice"},
+		Kind:      "prompt",
+	}
+	if err := h.Append(ctx, c); err != nil {
+		t.Fatalf("append c: %v", err)
+	}
+	all, _ := st.ListBySession(ctx, "s-direct", 0)
+	if len(all) != 3 {
+		t.Fatalf("got %d events, want 3", len(all))
+	}
+	if all[2].PrevHash != all[1].Hash {
+		t.Errorf("chain forked after failed insert: got[2].prev = %q, want %q", all[2].PrevHash, all[1].Hash)
+	}
+}

--- a/internal/webhooks/github/handler.go
+++ b/internal/webhooks/github/handler.go
@@ -1,0 +1,71 @@
+// Package github receives GitHub webhook deliveries, verifies the
+// shared-secret HMAC, maps known event types into wire events, and
+// forwards them through the ingest pipeline. M2-A handles
+// `pull_request`; later slices add review and push events.
+package github
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/dongqiu/agent-lens/internal/ingest"
+)
+
+// Handler is the http.Handler for POST /webhooks/github.
+type Handler struct {
+	secret  []byte
+	ingest  *ingest.Handler
+	maxBody int64
+}
+
+func NewHandler(secret string, h *ingest.Handler) *Handler {
+	return &Handler{
+		secret:  []byte(secret),
+		ingest:  h,
+		maxBody: 5 << 20, // 5 MiB; GitHub caps at 25 MiB but our PR events are small
+	}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, h.maxBody))
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+
+	if !verifySignature(h.secret, body, r.Header.Get("X-Hub-Signature-256")) {
+		http.Error(w, "bad signature", http.StatusUnauthorized)
+		return
+	}
+
+	switch r.Header.Get("X-GitHub-Event") {
+	case "ping":
+		// GitHub sends this on webhook creation; just ack.
+		w.WriteHeader(http.StatusOK)
+		return
+	case "pull_request":
+		ev, err := mapPullRequest(body)
+		if err != nil {
+			slog.Warn("github pull_request map", "err", err)
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := h.ingest.Append(r.Context(), ev); err != nil {
+			slog.Error("github pull_request append", "err", err)
+			http.Error(w, "store error", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusAccepted)
+	default:
+		// Unrecognized event types are not an error; GitHub may send
+		// many we don't (yet) care about. Just ack so it doesn't retry.
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/internal/webhooks/github/handler.go
+++ b/internal/webhooks/github/handler.go
@@ -5,11 +5,13 @@
 package github
 
 import (
+	"errors"
 	"io"
 	"log/slog"
 	"net/http"
 
 	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dongqiu/agent-lens/internal/store"
 )
 
 // Handler is the http.Handler for POST /webhooks/github.
@@ -45,24 +47,34 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	deliveryID := r.Header.Get("X-GitHub-Delivery")
+
 	switch r.Header.Get("X-GitHub-Event") {
 	case "ping":
 		// GitHub sends this on webhook creation; just ack.
 		w.WriteHeader(http.StatusOK)
 		return
 	case "pull_request":
-		ev, err := mapPullRequest(body)
+		ev, err := mapPullRequest(body, deliveryID)
 		if err != nil {
-			slog.Warn("github pull_request map", "err", err)
+			slog.Warn("github pull_request map", "delivery", deliveryID, "err", err)
 			http.Error(w, err.Error(), http.StatusBadRequest)
 			return
 		}
-		if err := h.ingest.Append(r.Context(), ev); err != nil {
-			slog.Error("github pull_request append", "err", err)
+		switch err := h.ingest.Append(r.Context(), ev); {
+		case err == nil:
+			slog.Info("github pull_request accepted", "delivery", deliveryID, "session", ev.SessionID)
+			w.WriteHeader(http.StatusAccepted)
+		case errors.Is(err, store.ErrDuplicate):
+			// GitHub redeliveries land here. The delivery UUID is the
+			// event ID, so this is a true duplicate; ack 200 so GitHub
+			// stops retrying without surfacing as a webhook failure.
+			slog.Info("github pull_request duplicate", "delivery", deliveryID, "session", ev.SessionID)
+			w.WriteHeader(http.StatusOK)
+		default:
+			slog.Error("github pull_request append", "delivery", deliveryID, "err", err)
 			http.Error(w, "store error", http.StatusInternalServerError)
-			return
 		}
-		w.WriteHeader(http.StatusAccepted)
 	default:
 		// Unrecognized event types are not an error; GitHub may send
 		// many we don't (yet) care about. Just ack so it doesn't retry.

--- a/internal/webhooks/github/handler_test.go
+++ b/internal/webhooks/github/handler_test.go
@@ -1,0 +1,192 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dongqiu/agent-lens/internal/store"
+)
+
+const samplePullRequestOpened = `{
+  "action": "opened",
+  "number": 42,
+  "pull_request": {
+    "title": "Add a button",
+    "html_url": "https://github.com/acme/widget/pull/42",
+    "state": "open",
+    "user": {"login": "alice"},
+    "head": {"sha": "deadbeefcafe1234567890abcdef0123456789ab", "ref": "feature/button"},
+    "base": {"ref": "main"}
+  },
+  "repository": {"full_name": "acme/widget"},
+  "sender": {"login": "alice"}
+}`
+
+func sign(secret, body []byte) string {
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(body)
+	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func TestVerifySignature(t *testing.T) {
+	secret := []byte("topsecret")
+	body := []byte(`{"x":1}`)
+	good := sign(secret, body)
+
+	if !verifySignature(secret, body, good) {
+		t.Error("good signature rejected")
+	}
+	if verifySignature(secret, body, "sha256=00") {
+		t.Error("wrong signature accepted")
+	}
+	if verifySignature(secret, body, "") {
+		t.Error("empty header accepted")
+	}
+	if verifySignature(secret, body, "sha1=abc") {
+		t.Error("wrong scheme accepted")
+	}
+	if verifySignature([]byte(""), body, good) {
+		t.Error("empty secret accepted")
+	}
+}
+
+func TestMapPullRequestOpened(t *testing.T) {
+	ev, err := mapPullRequest([]byte(samplePullRequestOpened))
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if ev.Kind != "pr" {
+		t.Errorf("kind = %q, want pr", ev.Kind)
+	}
+	if ev.SessionID != "github-pr:acme/widget#42" {
+		t.Errorf("session_id = %q", ev.SessionID)
+	}
+	if ev.Actor.Type != "human" || ev.Actor.ID != "alice" {
+		t.Errorf("actor = %+v", ev.Actor)
+	}
+	if len(ev.Refs) != 1 || ev.Refs[0] != "git:deadbeefcafe1234567890abcdef0123456789ab" {
+		t.Errorf("refs = %+v", ev.Refs)
+	}
+	if !bytes.Contains(ev.Payload, []byte(`"action":"opened"`)) {
+		t.Errorf("payload missing action: %s", ev.Payload)
+	}
+	if !bytes.Contains(ev.Payload, []byte(`"head_branch":"feature/button"`)) {
+		t.Errorf("payload missing head_branch: %s", ev.Payload)
+	}
+}
+
+func TestMapPullRequestRejectsMalformed(t *testing.T) {
+	if _, err := mapPullRequest([]byte(`not json`)); err == nil {
+		t.Error("malformed json accepted")
+	}
+	// Missing repository / number.
+	if _, err := mapPullRequest([]byte(`{"action":"opened"}`)); err == nil {
+		t.Error("missing repository accepted")
+	}
+}
+
+func TestHandlerHappyPath(t *testing.T) {
+	st := store.NewMemory()
+	ingestH := ingest.NewHandler(st)
+	h := NewHandler("topsecret", ingestH)
+
+	body := []byte(samplePullRequestOpened)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	req.Header.Set("X-Hub-Signature-256", sign([]byte("topsecret"), body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+
+	events, err := st.ListBySession(context.Background(), "github-pr:acme/widget#42", 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].Kind != "pr" {
+		t.Errorf("event kind = %q", events[0].Kind)
+	}
+	if events[0].PrevHash != "" {
+		t.Errorf("first event prev_hash = %q, want empty", events[0].PrevHash)
+	}
+	if events[0].Hash == "" {
+		t.Errorf("event hash empty")
+	}
+}
+
+func TestHandlerRejectsBadSignature(t *testing.T) {
+	st := store.NewMemory()
+	h := NewHandler("topsecret", ingest.NewHandler(st))
+
+	body := []byte(samplePullRequestOpened)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	req.Header.Set("X-Hub-Signature-256", "sha256=deadbeef")
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rec.Code)
+	}
+	events, _ := st.ListBySession(context.Background(), "github-pr:acme/widget#42", 0)
+	if len(events) != 0 {
+		t.Errorf("rejected webhook still appended %d events", len(events))
+	}
+}
+
+func TestHandlerPing(t *testing.T) {
+	st := store.NewMemory()
+	h := NewHandler("topsecret", ingest.NewHandler(st))
+
+	body := []byte(`{"zen":"Practicality beats purity."}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "ping")
+	req.Header.Set("X-Hub-Signature-256", sign([]byte("topsecret"), body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", rec.Code)
+	}
+}
+
+func TestHandlerIgnoresUnknownEvent(t *testing.T) {
+	st := store.NewMemory()
+	h := NewHandler("topsecret", ingest.NewHandler(st))
+
+	body := []byte(`{"some":"thing"}`)
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issue_comment")
+	req.Header.Set("X-Hub-Signature-256", sign([]byte("topsecret"), body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d, want 204", rec.Code)
+	}
+}
+
+func TestHandlerRejectsGet(t *testing.T) {
+	st := store.NewMemory()
+	h := NewHandler("topsecret", ingest.NewHandler(st))
+
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/github", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rec.Code)
+	}
+}

--- a/internal/webhooks/github/handler_test.go
+++ b/internal/webhooks/github/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -19,8 +20,11 @@ const samplePullRequestOpened = `{
   "number": 42,
   "pull_request": {
     "title": "Add a button",
+    "body": "Implements the checkout button.",
     "html_url": "https://github.com/acme/widget/pull/42",
     "state": "open",
+    "draft": false,
+    "labels": [{"name": "enhancement"}],
     "user": {"login": "alice"},
     "head": {"sha": "deadbeefcafe1234567890abcdef0123456789ab", "ref": "feature/button"},
     "base": {"ref": "main"}
@@ -29,10 +33,23 @@ const samplePullRequestOpened = `{
   "sender": {"login": "alice"}
 }`
 
+const sampleDeliveryID = "11111111-2222-3333-4444-555555555555"
+
 func sign(secret, body []byte) string {
 	mac := hmac.New(sha256.New, secret)
 	mac.Write(body)
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func deliverPR(t *testing.T, h *Handler, body []byte, deliveryID, secret string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "pull_request")
+	req.Header.Set("X-GitHub-Delivery", deliveryID)
+	req.Header.Set("X-Hub-Signature-256", sign([]byte(secret), body))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
 }
 
 func TestVerifySignature(t *testing.T) {
@@ -57,16 +74,19 @@ func TestVerifySignature(t *testing.T) {
 	}
 }
 
-func TestMapPullRequestOpened(t *testing.T) {
-	ev, err := mapPullRequest([]byte(samplePullRequestOpened))
+func TestMapPullRequestSetsDerivedFields(t *testing.T) {
+	ev, err := mapPullRequest([]byte(samplePullRequestOpened), sampleDeliveryID)
 	if err != nil {
 		t.Fatalf("map: %v", err)
 	}
 	if ev.Kind != "pr" {
 		t.Errorf("kind = %q, want pr", ev.Kind)
 	}
-	if ev.SessionID != "github-pr:acme/widget#42" {
-		t.Errorf("session_id = %q", ev.SessionID)
+	if ev.SessionID != "github-pr:acme/widget/42" {
+		t.Errorf("session_id = %q (must use slash-separated number, not #)", ev.SessionID)
+	}
+	if ev.ID != sampleDeliveryID {
+		t.Errorf("id = %q, want delivery uuid %q", ev.ID, sampleDeliveryID)
 	}
 	if ev.Actor.Type != "human" || ev.Actor.ID != "alice" {
 		t.Errorf("actor = %+v", ev.Actor)
@@ -74,20 +94,45 @@ func TestMapPullRequestOpened(t *testing.T) {
 	if len(ev.Refs) != 1 || ev.Refs[0] != "git:deadbeefcafe1234567890abcdef0123456789ab" {
 		t.Errorf("refs = %+v", ev.Refs)
 	}
-	if !bytes.Contains(ev.Payload, []byte(`"action":"opened"`)) {
-		t.Errorf("payload missing action: %s", ev.Payload)
+}
+
+func TestMapPullRequestPayloadPassesThroughVerbatim(t *testing.T) {
+	ev, err := mapPullRequest([]byte(samplePullRequestOpened), sampleDeliveryID)
+	if err != nil {
+		t.Fatalf("map: %v", err)
 	}
-	if !bytes.Contains(ev.Payload, []byte(`"head_branch":"feature/button"`)) {
-		t.Errorf("payload missing head_branch: %s", ev.Payload)
+	// Every original field must be present; the mapper must not curate.
+	var got map[string]any
+	if err := json.Unmarshal(ev.Payload, &got); err != nil {
+		t.Fatalf("payload not valid JSON: %v", err)
+	}
+	if got["action"] != "opened" {
+		t.Errorf("action = %v, want opened", got["action"])
+	}
+	pr, ok := got["pull_request"].(map[string]any)
+	if !ok {
+		t.Fatalf("pull_request not an object: %T", got["pull_request"])
+	}
+	if pr["body"] != "Implements the checkout button." {
+		t.Errorf("body = %v", pr["body"])
+	}
+	if pr["draft"] != false {
+		t.Errorf("draft = %v", pr["draft"])
+	}
+	if labels, _ := pr["labels"].([]any); len(labels) != 1 {
+		t.Errorf("labels = %v, want one entry", pr["labels"])
+	}
+	head, _ := pr["head"].(map[string]any)
+	if head["ref"] != "feature/button" {
+		t.Errorf("head.ref = %v", head["ref"])
 	}
 }
 
 func TestMapPullRequestRejectsMalformed(t *testing.T) {
-	if _, err := mapPullRequest([]byte(`not json`)); err == nil {
+	if _, err := mapPullRequest([]byte(`not json`), sampleDeliveryID); err == nil {
 		t.Error("malformed json accepted")
 	}
-	// Missing repository / number.
-	if _, err := mapPullRequest([]byte(`{"action":"opened"}`)); err == nil {
+	if _, err := mapPullRequest([]byte(`{"action":"opened"}`), sampleDeliveryID); err == nil {
 		t.Error("missing repository accepted")
 	}
 }
@@ -98,31 +143,43 @@ func TestHandlerHappyPath(t *testing.T) {
 	h := NewHandler("topsecret", ingestH)
 
 	body := []byte(samplePullRequestOpened)
-	req := httptest.NewRequest(http.MethodPost, "/webhooks/github", bytes.NewReader(body))
-	req.Header.Set("X-GitHub-Event", "pull_request")
-	req.Header.Set("X-Hub-Signature-256", sign([]byte("topsecret"), body))
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-
+	rec := deliverPR(t, h, body, sampleDeliveryID, "topsecret")
 	if rec.Code != http.StatusAccepted {
 		t.Fatalf("status = %d, want 202", rec.Code)
 	}
 
-	events, err := st.ListBySession(context.Background(), "github-pr:acme/widget#42", 0)
+	events, err := st.ListBySession(context.Background(), "github-pr:acme/widget/42", 0)
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
 	if len(events) != 1 {
 		t.Fatalf("got %d events, want 1", len(events))
 	}
+	if events[0].ID != sampleDeliveryID {
+		t.Errorf("event id = %q, want %q", events[0].ID, sampleDeliveryID)
+	}
 	if events[0].Kind != "pr" {
 		t.Errorf("event kind = %q", events[0].Kind)
 	}
-	if events[0].PrevHash != "" {
-		t.Errorf("first event prev_hash = %q, want empty", events[0].PrevHash)
+}
+
+func TestHandlerDuplicateDeliveryReturns200(t *testing.T) {
+	st := store.NewMemory()
+	h := NewHandler("topsecret", ingest.NewHandler(st))
+	body := []byte(samplePullRequestOpened)
+
+	first := deliverPR(t, h, body, sampleDeliveryID, "topsecret")
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first delivery status = %d, want 202", first.Code)
 	}
-	if events[0].Hash == "" {
-		t.Errorf("event hash empty")
+	second := deliverPR(t, h, body, sampleDeliveryID, "topsecret")
+	if second.Code != http.StatusOK {
+		t.Errorf("duplicate delivery status = %d, want 200", second.Code)
+	}
+
+	events, _ := st.ListBySession(context.Background(), "github-pr:acme/widget/42", 0)
+	if len(events) != 1 {
+		t.Errorf("duplicate delivery created extra events: %d", len(events))
 	}
 }
 
@@ -140,7 +197,7 @@ func TestHandlerRejectsBadSignature(t *testing.T) {
 	if rec.Code != http.StatusUnauthorized {
 		t.Errorf("status = %d, want 401", rec.Code)
 	}
-	events, _ := st.ListBySession(context.Background(), "github-pr:acme/widget#42", 0)
+	events, _ := st.ListBySession(context.Background(), "github-pr:acme/widget/42", 0)
 	if len(events) != 0 {
 		t.Errorf("rejected webhook still appended %d events", len(events))
 	}

--- a/internal/webhooks/github/mapper.go
+++ b/internal/webhooks/github/mapper.go
@@ -8,27 +8,20 @@ import (
 	"github.com/dongqiu/agent-lens/internal/ingest"
 )
 
-// pullRequestPayload is the subset of the GitHub `pull_request` webhook
-// payload we read. Unrecognized fields are ignored; the original payload
-// is preserved verbatim in the wire event's payload field so consumers
-// can introspect the full GitHub state.
+// pullRequestPayload is the subset of GitHub's `pull_request` webhook
+// payload that we read to derive session_id / actor / refs. The wire
+// event's payload field receives the FULL webhook body verbatim so
+// consumers can navigate any field GitHub sent (labels, reviewers,
+// draft status, mergeable, etc.) without us pre-curating.
 type pullRequestPayload struct {
-	Action      string `json:"action"`
-	Number      int    `json:"number"`
+	Number      int `json:"number"`
 	PullRequest struct {
-		Title   string `json:"title"`
-		HTMLURL string `json:"html_url"`
-		State   string `json:"state"`
-		User    struct {
+		User struct {
 			Login string `json:"login"`
 		} `json:"user"`
 		Head struct {
 			SHA string `json:"sha"`
-			Ref string `json:"ref"`
 		} `json:"head"`
-		Base struct {
-			Ref string `json:"ref"`
-		} `json:"base"`
 	} `json:"pull_request"`
 	Repository struct {
 		FullName string `json:"full_name"`
@@ -38,12 +31,16 @@ type pullRequestPayload struct {
 	} `json:"sender"`
 }
 
-// mapPullRequest turns a parsed pull_request webhook payload into a
-// wire event. session_id stays stable across the PR lifetime
-// (`github-pr:<owner>/<repo>#<number>`) so all actions on a PR group
-// in the timeline. The head commit SHA is also recorded as a ref so
-// the M2-B linking worker can correlate with COMMIT events.
-func mapPullRequest(raw json.RawMessage) (*ingest.WireEvent, error) {
+// mapPullRequest derives a wire event from a `pull_request` webhook
+// body. deliveryID (from the X-GitHub-Delivery header) is set as the
+// event ID so duplicate deliveries hit ErrDuplicate at the store
+// layer; if empty, the ingest pipeline assigns a ULID.
+//
+// session_id: `github-pr:<owner>/<repo>/<number>`. Slashes are
+// query-string-safe, so the format survives `?session=...` in the
+// Lens UI URL — the previous `#`-separated form was eaten by the
+// browser as a fragment.
+func mapPullRequest(raw json.RawMessage, deliveryID string) (*ingest.WireEvent, error) {
 	var p pullRequestPayload
 	if err := json.Unmarshal(raw, &p); err != nil {
 		return nil, fmt.Errorf("decode pull_request: %w", err)
@@ -57,36 +54,21 @@ func mapPullRequest(raw json.RawMessage) (*ingest.WireEvent, error) {
 		actorID = p.PullRequest.User.Login
 	}
 
-	payload, err := json.Marshal(map[string]any{
-		"action":      p.Action,
-		"number":      p.Number,
-		"title":       p.PullRequest.Title,
-		"url":         p.PullRequest.HTMLURL,
-		"state":       p.PullRequest.State,
-		"head_sha":    p.PullRequest.Head.SHA,
-		"head_branch": p.PullRequest.Head.Ref,
-		"base_branch": p.PullRequest.Base.Ref,
-		"repo":        p.Repository.FullName,
-		"author":      p.PullRequest.User.Login,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("encode payload: %w", err)
-	}
-
 	var refs []string
 	if p.PullRequest.Head.SHA != "" {
 		refs = []string{"git:" + p.PullRequest.Head.SHA}
 	}
 
 	return &ingest.WireEvent{
+		ID:        deliveryID,
 		TS:        time.Now().UTC(),
-		SessionID: fmt.Sprintf("github-pr:%s#%d", p.Repository.FullName, p.Number),
+		SessionID: fmt.Sprintf("github-pr:%s/%d", p.Repository.FullName, p.Number),
 		Actor: ingest.WireActor{
 			Type: "human",
 			ID:   actorID,
 		},
 		Kind:    "pr",
-		Payload: payload,
+		Payload: raw,
 		Refs:    refs,
 	}, nil
 }

--- a/internal/webhooks/github/mapper.go
+++ b/internal/webhooks/github/mapper.go
@@ -1,0 +1,92 @@
+package github
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/dongqiu/agent-lens/internal/ingest"
+)
+
+// pullRequestPayload is the subset of the GitHub `pull_request` webhook
+// payload we read. Unrecognized fields are ignored; the original payload
+// is preserved verbatim in the wire event's payload field so consumers
+// can introspect the full GitHub state.
+type pullRequestPayload struct {
+	Action      string `json:"action"`
+	Number      int    `json:"number"`
+	PullRequest struct {
+		Title   string `json:"title"`
+		HTMLURL string `json:"html_url"`
+		State   string `json:"state"`
+		User    struct {
+			Login string `json:"login"`
+		} `json:"user"`
+		Head struct {
+			SHA string `json:"sha"`
+			Ref string `json:"ref"`
+		} `json:"head"`
+		Base struct {
+			Ref string `json:"ref"`
+		} `json:"base"`
+	} `json:"pull_request"`
+	Repository struct {
+		FullName string `json:"full_name"`
+	} `json:"repository"`
+	Sender struct {
+		Login string `json:"login"`
+	} `json:"sender"`
+}
+
+// mapPullRequest turns a parsed pull_request webhook payload into a
+// wire event. session_id stays stable across the PR lifetime
+// (`github-pr:<owner>/<repo>#<number>`) so all actions on a PR group
+// in the timeline. The head commit SHA is also recorded as a ref so
+// the M2-B linking worker can correlate with COMMIT events.
+func mapPullRequest(raw json.RawMessage) (*ingest.WireEvent, error) {
+	var p pullRequestPayload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, fmt.Errorf("decode pull_request: %w", err)
+	}
+	if p.Repository.FullName == "" || p.Number == 0 {
+		return nil, fmt.Errorf("pull_request missing repository.full_name or number")
+	}
+
+	actorID := p.Sender.Login
+	if actorID == "" {
+		actorID = p.PullRequest.User.Login
+	}
+
+	payload, err := json.Marshal(map[string]any{
+		"action":      p.Action,
+		"number":      p.Number,
+		"title":       p.PullRequest.Title,
+		"url":         p.PullRequest.HTMLURL,
+		"state":       p.PullRequest.State,
+		"head_sha":    p.PullRequest.Head.SHA,
+		"head_branch": p.PullRequest.Head.Ref,
+		"base_branch": p.PullRequest.Base.Ref,
+		"repo":        p.Repository.FullName,
+		"author":      p.PullRequest.User.Login,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("encode payload: %w", err)
+	}
+
+	var refs []string
+	if p.PullRequest.Head.SHA != "" {
+		refs = []string{"git:" + p.PullRequest.Head.SHA}
+	}
+
+	return &ingest.WireEvent{
+		TS:        time.Now().UTC(),
+		SessionID: fmt.Sprintf("github-pr:%s#%d", p.Repository.FullName, p.Number),
+		Actor: ingest.WireActor{
+			Type: "human",
+			ID:   actorID,
+		},
+		Kind:    "pr",
+		Payload: payload,
+		Refs:    refs,
+	}, nil
+}

--- a/internal/webhooks/github/verify.go
+++ b/internal/webhooks/github/verify.go
@@ -1,0 +1,25 @@
+package github
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// verifySignature constant-time-compares GitHub's X-Hub-Signature-256
+// header against HMAC-SHA256(secret, body). The header is in the form
+// "sha256=<hex>". Empty header or any malformed input returns false.
+func verifySignature(secret, body []byte, header string) bool {
+	const prefix = "sha256="
+	if len(secret) == 0 || !strings.HasPrefix(header, prefix) {
+		return false
+	}
+	want, err := hex.DecodeString(header[len(prefix):])
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, secret)
+	mac.Write(body)
+	return hmac.Equal(want, mac.Sum(nil))
+}


### PR DESCRIPTION
## Summary

First slice of M2. Receive GitHub \`pull_request\` webhooks → HMAC verify → map into wire events → forward through the existing ingest pipeline so PRs appear in the Lens timeline.

**Out of scope**: linking PR ↔ commit events (M2-B), \`pull_request_review\` / \`push\` events (M2-D), GitHub Actions build plugin (M2-C).

## Slice details

- **ingest refactor**: \`Handler\`, \`WireEvent\`, \`WireActor\`, and \`Append(ctx, *WireEvent) error\` are now exported. Production caller (\`cmd/agent-lens\`) constructs one shared \`Handler\` and passes it to both the HTTP NDJSON path and the webhook receiver, so the per-session head-hash cache stays authoritative across producers.
- **HMAC verify**: \`crypto/hmac.Equal\` constant-time match against \`X-Hub-Signature-256\`. Empty secret / missing header / wrong scheme all reject.
- **pull_request mapper**: \`session_id\` = \`github-pr:<owner>/<repo>#<number>\` (stable across PR lifetime); head commit SHA recorded as \`refs[git:<sha>]\` for M2-B linking.
- **Routing**: \`/webhooks/github\` is mounted only when \`AGENT_LENS_GH_WEBHOOK_SECRET\` is set. Webhook is HMAC-authenticated; NOT subject to bearer-token auth (which only covers \`/v1\`).

## End-to-end demo

1. \`AGENT_LENS_GH_WEBHOOK_SECRET=<random> ./bin/agent-lens\`
2. GitHub repo → Settings → Webhooks → Add: \`Payload URL https://<host>/webhooks/github\`, secret matches, event = \`Pull requests\`.
3. Open / sync / close a PR.
4. UI: enter session id \`github-pr:<owner>/<repo>#<number>\` → see the PR timeline.

## Test plan

- [x] \`go test -race ./...\` — all packages green, including 8 new tests in \`internal/webhooks/github\`.
- [x] CI \`go test\` matrix on Go 1.23 + 1.26.
- [x] CI \`golangci-lint\` clean.
- [x] CI \`PG integration tests\` clean (refactor of ingest unchanged behavior).
- [x] CI \`web build\` unaffected.
- [x] CI \`codegen drift\` clean (no schema changes).

## Linking notes

The \`refs[git:<sha>]\` field on PR events doesn't auto-correlate yet — M2-B's linking worker is the consumer. Until then, PR events show in their own session and commit events show in theirs.

Tracks: M2-A. Refs: SPEC §10, §14.

🤖 Generated with [Claude Code](https://claude.com/claude-code)