### PR TITLE
feat(linking): cross-stage linking worker via shared refs (M2-B)

### DIFF
--- a/cmd/agent-lens/main.go
+++ b/cmd/agent-lens/main.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/dongqiu/agent-lens/internal/auth"
 	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dongqiu/agent-lens/internal/linking"
 	"github.com/dongqiu/agent-lens/internal/query"
 	"github.com/dongqiu/agent-lens/internal/store"
 	githubwh "github.com/dongqiu/agent-lens/internal/webhooks/github"
@@ -56,6 +57,14 @@ func main() {
 	// in-process producers (e.g. webhook receivers) so the head-hash
 	// cache stays authoritative.
 	ingestH := ingest.NewHandler(st)
+
+	// Linking worker observes successful appends and writes shared-ref
+	// links asynchronously so it never blocks ingest.
+	linker := linking.New(st, 1024)
+	ingestH.AfterAppend(func(_ context.Context, ev *ingest.WireEvent) {
+		linker.Notify(ev)
+	})
+	go linker.Run(ctx)
 
 	r.Route("/v1", func(sub chi.Router) {
 		sub.Use(auth.RequireToken(token))

--- a/cmd/agent-lens/main.go
+++ b/cmd/agent-lens/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -64,7 +65,12 @@ func main() {
 	ingestH.AfterAppend(func(_ context.Context, ev *ingest.WireEvent) {
 		linker.Notify(ev)
 	})
-	go linker.Run(ctx)
+	var linkerWG sync.WaitGroup
+	linkerWG.Add(1)
+	go func() {
+		defer linkerWG.Done()
+		linker.Run(ctx)
+	}()
 
 	r.Route("/v1", func(sub chi.Router) {
 		sub.Use(auth.RequireToken(token))
@@ -104,6 +110,10 @@ func main() {
 	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer shutdownCancel()
 	_ = srv.Shutdown(shutdownCtx)
+	// Linker.Run returns once ctx is cancelled; wait so any in-flight
+	// AppendLink finishes (or errors out cleanly) before we exit and
+	// the process tears down the DB connection pool.
+	linkerWG.Wait()
 }
 
 func envOr(k, def string) string {

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -74,8 +74,14 @@ func NewHandler(st store.Store) *Handler {
 
 // AfterAppend registers a hook called after every successful Append.
 // The hook runs outside the handler's lock so it can do its own I/O
-// without blocking other ingest paths. Set once during wiring; the
-// field is not protected for concurrent assignment.
+// without blocking other ingest paths.
+//
+// Concurrency contract: must be called during process startup, before
+// any goroutine that calls Append (HTTP server, webhook, etc.) is
+// started. The field is not protected for concurrent assignment;
+// happens-before is established only via the goroutine spawn that
+// later reads it. Multiple observers should be combined into a single
+// callback by the caller.
 func (h *Handler) AfterAppend(fn func(context.Context, *WireEvent)) {
 	h.after = fn
 }

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -57,14 +57,27 @@ var validKinds = map[string]struct{}{
 // into the store. Construct one per process and share it between every
 // ingest path (HTTP NDJSON, webhook, programmatic) so the cache stays
 // authoritative.
+//
+// AfterAppend, when set, is invoked outside the per-handler lock with
+// every successfully-stored event. It is the hook used by linkers,
+// metrics, and any other observer that should not be on the write path.
 type Handler struct {
 	st    store.Store
 	mu    sync.Mutex
 	heads map[string]string
+	after func(context.Context, *WireEvent)
 }
 
 func NewHandler(st store.Store) *Handler {
 	return &Handler{st: st, heads: map[string]string{}}
+}
+
+// AfterAppend registers a hook called after every successful Append.
+// The hook runs outside the handler's lock so it can do its own I/O
+// without blocking other ingest paths. Set once during wiring; the
+// field is not protected for concurrent assignment.
+func (h *Handler) AfterAppend(fn func(context.Context, *WireEvent)) {
+	h.after = fn
 }
 
 // WireEvent is the JSON shape accepted on the wire. It mirrors
@@ -123,8 +136,19 @@ func (h *Handler) IngestNDJSON(w http.ResponseWriter, r *http.Request) {
 // Append validates an event, computes its hash chain entry, persists
 // it, and advances the in-memory head cache. The lock spans only the
 // load-prev → compute → append → cache update sequence; canonical
-// marshaling happens before the lock since it does not depend on prev.
+// marshaling happens before the lock, and the AfterAppend hook (if
+// any) runs after the lock is released.
 func (h *Handler) Append(ctx context.Context, in *WireEvent) error {
+	if err := h.appendLocked(ctx, in); err != nil {
+		return err
+	}
+	if h.after != nil {
+		h.after(ctx, in)
+	}
+	return nil
+}
+
+func (h *Handler) appendLocked(ctx context.Context, in *WireEvent) error {
 	if err := validateWireEvent(in); err != nil {
 		return err
 	}

--- a/internal/linking/linker.go
+++ b/internal/linking/linker.go
@@ -1,0 +1,118 @@
+// Package linking computes causal/semantic links between events. v0
+// rule: any two events sharing a `git:<sha>` (or other) ref are linked
+// with relation "references". Linking happens off the ingest write path
+// — Notify is non-blocking; Run consumes a queue and writes to
+// store.Links.
+//
+// Recovery: if the queue overflows or the worker is restarted before
+// processing every queued job, links may be missing. A periodic
+// backfill scan is a follow-up; for v0 the queue is sized so overflow
+// is unusual.
+package linking
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+
+	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dongqiu/agent-lens/internal/store"
+)
+
+// DefaultRelation is the relation written for all v0 shared-ref links.
+// Refinement (commit→pr "produces", commit→build "builds", etc.)
+// belongs in M3.
+const DefaultRelation = "references"
+
+// Linker is started once by the main process. Notify is safe to call
+// from any goroutine; Run owns the worker loop and exits on context
+// cancellation. Construction does not start the worker — call Run.
+type Linker struct {
+	st    store.Store
+	queue chan job
+}
+
+type job struct {
+	eventID string
+	refs    []string
+}
+
+// New returns a Linker with the requested queue size. queueSize 0 means
+// "unbounded behavior is unsafe; use 1024".
+func New(st store.Store, queueSize int) *Linker {
+	if queueSize <= 0 {
+		queueSize = 1024
+	}
+	return &Linker{
+		st:    st,
+		queue: make(chan job, queueSize),
+	}
+}
+
+// Notify enqueues an event for linking. Returns immediately; if the
+// queue is full the event is dropped with a log line (the periodic
+// backfill, when added, is the recovery path).
+func (l *Linker) Notify(ev *ingest.WireEvent) {
+	if ev == nil || ev.ID == "" || len(ev.Refs) == 0 {
+		return
+	}
+	j := job{eventID: ev.ID, refs: append([]string(nil), ev.Refs...)}
+	select {
+	case l.queue <- j:
+	default:
+		slog.Warn("linker queue full; dropping event", "id", ev.ID, "queue_cap", cap(l.queue))
+	}
+}
+
+// Run blocks until ctx is cancelled. Returns when the worker stops.
+func (l *Linker) Run(ctx context.Context) {
+	slog.Info("linker started", "queue_cap", cap(l.queue))
+	for {
+		select {
+		case <-ctx.Done():
+			slog.Info("linker stopped")
+			return
+		case j := <-l.queue:
+			if err := l.process(ctx, j); err != nil {
+				slog.Warn("linker process", "id", j.eventID, "err", err)
+			}
+		}
+	}
+}
+
+// process is exported for tests via processOnce; production callers
+// always go through Run.
+func (l *Linker) process(ctx context.Context, j job) error {
+	for _, ref := range j.refs {
+		peers, err := l.st.EventsByRef(ctx, ref)
+		if err != nil {
+			return err
+		}
+		for _, peer := range peers {
+			if peer.ID == j.eventID {
+				continue
+			}
+			link := &store.Link{
+				FromEvent:  peer.ID,
+				ToEvent:    j.eventID,
+				Relation:   DefaultRelation,
+				Confidence: 1.0,
+				InferredBy: "shared_ref:" + ref,
+			}
+			if err := l.st.AppendLink(ctx, link); err != nil && !errors.Is(err, store.ErrDuplicate) {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// ProcessOnce is a test-only synchronous entry point that processes a
+// single notification inline. Use it in tests to avoid spinning up the
+// worker goroutine.
+func (l *Linker) ProcessOnce(ctx context.Context, ev *ingest.WireEvent) error {
+	if ev == nil || ev.ID == "" || len(ev.Refs) == 0 {
+		return nil
+	}
+	return l.process(ctx, job{eventID: ev.ID, refs: ev.Refs})
+}

--- a/internal/linking/linker.go
+++ b/internal/linking/linker.go
@@ -13,6 +13,7 @@ package linking
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 
 	"github.com/dongqiu/agent-lens/internal/ingest"
@@ -80,13 +81,20 @@ func (l *Linker) Run(ctx context.Context) {
 	}
 }
 
-// process is exported for tests via processOnce; production callers
-// always go through Run.
+// process is exported for tests via ProcessOnce; production callers
+// always go through Run. Errors on individual peers don't abort the
+// rest — a transient AppendLink failure on one peer should not strand
+// every other link the event would have produced. The first error is
+// returned (logged by the caller) so debugging still has a signal.
 func (l *Linker) process(ctx context.Context, j job) error {
+	var firstErr error
 	for _, ref := range j.refs {
 		peers, err := l.st.EventsByRef(ctx, ref)
 		if err != nil {
-			return err
+			if firstErr == nil {
+				firstErr = fmt.Errorf("EventsByRef(%q): %w", ref, err)
+			}
+			continue
 		}
 		for _, peer := range peers {
 			if peer.ID == j.eventID {
@@ -100,11 +108,14 @@ func (l *Linker) process(ctx context.Context, j job) error {
 				InferredBy: "shared_ref:" + ref,
 			}
 			if err := l.st.AppendLink(ctx, link); err != nil && !errors.Is(err, store.ErrDuplicate) {
-				return err
+				if firstErr == nil {
+					firstErr = fmt.Errorf("AppendLink(%s→%s): %w", peer.ID, j.eventID, err)
+				}
+				// keep going; other peers / refs may still succeed.
 			}
 		}
 	}
-	return nil
+	return firstErr
 }
 
 // ProcessOnce is a test-only synchronous entry point that processes a

--- a/internal/linking/linker_test.go
+++ b/internal/linking/linker_test.go
@@ -1,0 +1,190 @@
+package linking
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dongqiu/agent-lens/internal/store"
+)
+
+func appendEvent(t *testing.T, st store.Store, id string, refs []string) {
+	t.Helper()
+	if err := st.AppendEvent(context.Background(), &store.Event{
+		ID:        id,
+		TS:        time.Now().UTC(),
+		SessionID: "s-" + id,
+		ActorType: "human",
+		ActorID:   "alice",
+		Kind:      "prompt",
+		Hash:      "h-" + id,
+		Refs:      refs,
+	}); err != nil {
+		t.Fatalf("append %s: %v", id, err)
+	}
+}
+
+func TestProcessOnceLinksSharedRef(t *testing.T) {
+	st := store.NewMemory()
+	l := New(st, 0)
+	ctx := context.Background()
+
+	// e1 already in store with shared ref; e2 just arrived.
+	appendEvent(t, st, "e1", []string{"git:abc"})
+	appendEvent(t, st, "e2", []string{"git:abc", "git:def"})
+
+	if err := l.ProcessOnce(ctx, &ingest.WireEvent{ID: "e2", Refs: []string{"git:abc", "git:def"}}); err != nil {
+		t.Fatalf("ProcessOnce: %v", err)
+	}
+
+	links, _ := st.LinksForEvent(ctx, "e2")
+	if len(links) != 1 {
+		t.Fatalf("got %d links, want 1", len(links))
+	}
+	if links[0].FromEvent != "e1" || links[0].ToEvent != "e2" {
+		t.Errorf("link direction = %+v", links[0])
+	}
+	if links[0].Relation != DefaultRelation {
+		t.Errorf("relation = %q, want %q", links[0].Relation, DefaultRelation)
+	}
+}
+
+func TestProcessOnceMultiplePeers(t *testing.T) {
+	st := store.NewMemory()
+	l := New(st, 0)
+	ctx := context.Background()
+
+	appendEvent(t, st, "commit-a", []string{"git:abc"})
+	appendEvent(t, st, "pr-a", []string{"git:abc"})
+	appendEvent(t, st, "build-a", []string{"git:abc"})
+
+	if err := l.ProcessOnce(ctx, &ingest.WireEvent{ID: "build-a", Refs: []string{"git:abc"}}); err != nil {
+		t.Fatalf("ProcessOnce: %v", err)
+	}
+
+	links, _ := st.LinksForEvent(ctx, "build-a")
+	if len(links) != 2 {
+		t.Errorf("got %d links, want 2 (commit-a→build-a, pr-a→build-a)", len(links))
+	}
+}
+
+func TestProcessOnceIdempotent(t *testing.T) {
+	st := store.NewMemory()
+	l := New(st, 0)
+	ctx := context.Background()
+
+	appendEvent(t, st, "e1", []string{"git:abc"})
+	appendEvent(t, st, "e2", []string{"git:abc"})
+
+	for i := 0; i < 3; i++ {
+		if err := l.ProcessOnce(ctx, &ingest.WireEvent{ID: "e2", Refs: []string{"git:abc"}}); err != nil {
+			t.Fatalf("ProcessOnce iter %d: %v", i, err)
+		}
+	}
+	links, _ := st.LinksForEvent(ctx, "e2")
+	if len(links) != 1 {
+		t.Errorf("got %d links after 3 calls, want 1 (ErrDuplicate must be silenced)", len(links))
+	}
+}
+
+func TestProcessOnceSkipsSelfAndEmpty(t *testing.T) {
+	st := store.NewMemory()
+	l := New(st, 0)
+	ctx := context.Background()
+
+	appendEvent(t, st, "solo", []string{"git:onlyme"})
+
+	if err := l.ProcessOnce(ctx, &ingest.WireEvent{ID: "solo", Refs: []string{"git:onlyme"}}); err != nil {
+		t.Fatalf("ProcessOnce: %v", err)
+	}
+	links, _ := st.LinksForEvent(ctx, "solo")
+	if len(links) != 0 {
+		t.Errorf("self-link created: %+v", links)
+	}
+
+	// Empty refs / empty id are no-ops.
+	if err := l.ProcessOnce(ctx, &ingest.WireEvent{ID: "x", Refs: nil}); err != nil {
+		t.Errorf("empty refs returned err: %v", err)
+	}
+	if err := l.ProcessOnce(ctx, nil); err != nil {
+		t.Errorf("nil event returned err: %v", err)
+	}
+}
+
+func TestRunConsumesQueueAndShutsDown(t *testing.T) {
+	st := store.NewMemory()
+	l := New(st, 16)
+	ctx, cancel := context.WithCancel(context.Background())
+
+	appendEvent(t, st, "e1", []string{"git:run"})
+	appendEvent(t, st, "e2", []string{"git:run"})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() { defer wg.Done(); l.Run(ctx) }()
+
+	l.Notify(&ingest.WireEvent{ID: "e2", Refs: []string{"git:run"}})
+
+	// Poll briefly for the link to appear.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		links, _ := st.LinksForEvent(ctx, "e2")
+		if len(links) == 1 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	links, _ := st.LinksForEvent(ctx, "e2")
+	if len(links) != 1 {
+		t.Errorf("worker did not produce link within 500ms: got %d", len(links))
+	}
+
+	cancel()
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("worker did not shut down within 1s after cancel")
+	}
+}
+
+func TestNotifyDropsWhenQueueFull(t *testing.T) {
+	st := store.NewMemory()
+	l := New(st, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	_ = ctx
+
+	// Fill the queue without starting Run, then over-fill to trigger drop.
+	first := &ingest.WireEvent{ID: "first", Refs: []string{"git:full"}}
+	l.Notify(first)
+	// This Notify must NOT block; it's expected to drop.
+	dropped := make(chan struct{})
+	go func() {
+		l.Notify(&ingest.WireEvent{ID: "second", Refs: []string{"git:full"}})
+		close(dropped)
+	}()
+	select {
+	case <-dropped:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("Notify blocked when queue was full; should drop instead")
+	}
+}
+
+func TestProcessOncePropagatesStoreError(t *testing.T) {
+	l := New(failingStore{}, 0)
+	err := l.ProcessOnce(context.Background(), &ingest.WireEvent{ID: "x", Refs: []string{"git:any"}})
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
+type failingStore struct{ store.Store }
+
+func (failingStore) EventsByRef(_ context.Context, _ string) ([]*store.Event, error) {
+	return nil, errors.New("boom")
+}

--- a/internal/linking/linker_test.go
+++ b/internal/linking/linker_test.go
@@ -183,8 +183,48 @@ func TestProcessOncePropagatesStoreError(t *testing.T) {
 	}
 }
 
+// TestProcessOnceBestEffort verifies that one failing AppendLink does
+// NOT prevent other peers in the same job from being linked.
+func TestProcessOnceBestEffort(t *testing.T) {
+	st := &flakyAppendStore{Memory: store.NewMemory()}
+	ctx := context.Background()
+
+	// Three peers share the ref. The flaky store fails AppendLink for
+	// the first peer ("p1") and succeeds for the rest.
+	for _, id := range []string{"p1", "p2", "p3"} {
+		appendEvent(t, st.Memory, id, []string{"git:r"})
+	}
+	st.failFor = "p1"
+
+	l := New(st, 0)
+	err := l.ProcessOnce(ctx, &ingest.WireEvent{ID: "newcomer", Refs: []string{"git:r"}})
+	if err == nil {
+		t.Error("expected non-nil first error to be reported")
+	}
+
+	// Even with p1's link failing, p2 and p3 should still be linked.
+	links, _ := st.LinksForEvent(ctx, "newcomer")
+	if len(links) != 2 {
+		t.Errorf("got %d links, want 2 (p2 and p3 succeeded; p1 failed)", len(links))
+	}
+}
+
 type failingStore struct{ store.Store }
 
 func (failingStore) EventsByRef(_ context.Context, _ string) ([]*store.Event, error) {
 	return nil, errors.New("boom")
+}
+
+// flakyAppendStore wraps Memory and fails AppendLink whenever the link's
+// FromEvent equals failFor. EventsByRef and other methods pass through.
+type flakyAppendStore struct {
+	*store.Memory
+	failFor string
+}
+
+func (f *flakyAppendStore) AppendLink(ctx context.Context, l *store.Link) error {
+	if l.FromEvent == f.failFor {
+		return errors.New("flaky: synthetic AppendLink failure")
+	}
+	return f.Memory.AppendLink(ctx, l)
 }

--- a/internal/query/generated.go
+++ b/internal/query/generated.go
@@ -29,6 +29,7 @@ func NewExecutableSchema(cfg Config) graphql.ExecutableSchema {
 type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
 
 type ResolverRoot interface {
+	Event() EventResolver
 	Query() QueryResolver
 }
 
@@ -47,6 +48,7 @@ type ComplexityRoot struct {
 		Hash      func(childComplexity int) int
 		ID        func(childComplexity int) int
 		Kind      func(childComplexity int) int
+		Links     func(childComplexity int) int
 		Parents   func(childComplexity int) int
 		Payload   func(childComplexity int) int
 		PrevHash  func(childComplexity int) int
@@ -56,6 +58,14 @@ type ComplexityRoot struct {
 		TurnID    func(childComplexity int) int
 	}
 
+	Link struct {
+		Confidence func(childComplexity int) int
+		FromEvent  func(childComplexity int) int
+		InferredBy func(childComplexity int) int
+		Relation   func(childComplexity int) int
+		ToEvent    func(childComplexity int) int
+	}
+
 	Query struct {
 		Event       func(childComplexity int, id string) int
 		Events      func(childComplexity int, sessionID string, limit *int) int
@@ -63,6 +73,9 @@ type ComplexityRoot struct {
 	}
 }
 
+type EventResolver interface {
+	Links(ctx context.Context, obj *Event) ([]*Link, error)
+}
 type QueryResolver interface {
 	Event(ctx context.Context, id string) (*Event, error)
 	Events(ctx context.Context, sessionID string, limit *int) ([]*Event, error)
@@ -126,6 +139,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Event.Kind(childComplexity), true
+	case "Event.links":
+		if e.ComplexityRoot.Event.Links == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Event.Links(childComplexity), true
 	case "Event.parents":
 		if e.ComplexityRoot.Event.Parents == nil {
 			break
@@ -168,6 +187,37 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Event.TurnID(childComplexity), true
+
+	case "Link.confidence":
+		if e.ComplexityRoot.Link.Confidence == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Link.Confidence(childComplexity), true
+	case "Link.fromEvent":
+		if e.ComplexityRoot.Link.FromEvent == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Link.FromEvent(childComplexity), true
+	case "Link.inferredBy":
+		if e.ComplexityRoot.Link.InferredBy == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Link.InferredBy(childComplexity), true
+	case "Link.relation":
+		if e.ComplexityRoot.Link.Relation == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Link.Relation(childComplexity), true
+	case "Link.toEvent":
+		if e.ComplexityRoot.Link.ToEvent == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Link.ToEvent(childComplexity), true
 
 	case "Query.event":
 		if e.ComplexityRoot.Query.Event == nil {
@@ -326,8 +376,26 @@ func (ec *executionContext) childFields_Event(ctx context.Context, field graphql
 		return ec.fieldContext_Event_hash(ctx, field)
 	case "prevHash":
 		return ec.fieldContext_Event_prevHash(ctx, field)
+	case "links":
+		return ec.fieldContext_Event_links(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type Event", field.Name)
+}
+
+func (ec *executionContext) childFields_Link(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "fromEvent":
+		return ec.fieldContext_Link_fromEvent(ctx, field)
+	case "toEvent":
+		return ec.fieldContext_Link_toEvent(ctx, field)
+	case "relation":
+		return ec.fieldContext_Link_relation(ctx, field)
+	case "confidence":
+		return ec.fieldContext_Link_confidence(ctx, field)
+	case "inferredBy":
+		return ec.fieldContext_Link_inferredBy(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type Link", field.Name)
 }
 
 func (ec *executionContext) childFields___Directive(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -903,6 +971,153 @@ func (ec *executionContext) _Event_prevHash(ctx context.Context, field graphql.C
 }
 func (ec *executionContext) fieldContext_Event_prevHash(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("Event", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _Event_links(ctx context.Context, field graphql.CollectedField, obj *Event) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Event_links(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Event().Links(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*Link) graphql.Marshaler {
+			return ec.marshalNLink2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐLinkᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Event_links(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Event",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Link(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Link_fromEvent(ctx context.Context, field graphql.CollectedField, obj *Link) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Link_fromEvent(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.FromEvent, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNID2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Link_fromEvent(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Link", field, false, false, errors.New("field of type ID does not have child fields"))
+}
+
+func (ec *executionContext) _Link_toEvent(ctx context.Context, field graphql.CollectedField, obj *Link) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Link_toEvent(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ToEvent, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNID2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Link_toEvent(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Link", field, false, false, errors.New("field of type ID does not have child fields"))
+}
+
+func (ec *executionContext) _Link_relation(ctx context.Context, field graphql.CollectedField, obj *Link) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Link_relation(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Relation, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Link_relation(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Link", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _Link_confidence(ctx context.Context, field graphql.CollectedField, obj *Link) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Link_confidence(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Confidence, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v float64) graphql.Marshaler {
+			return ec.marshalNFloat2float64(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Link_confidence(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Link", field, false, false, errors.New("field of type Float does not have child fields"))
+}
+
+func (ec *executionContext) _Link_inferredBy(ctx context.Context, field graphql.CollectedField, obj *Link) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Link_inferredBy(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.InferredBy, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Link_inferredBy(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Link", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
 func (ec *executionContext) _Query_event(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
@@ -2240,49 +2455,144 @@ func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, ob
 		case "id":
 			out.Values[i] = ec._Event_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "ts":
 			out.Values[i] = ec._Event_ts(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "sessionId":
 			out.Values[i] = ec._Event_sessionId(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "turnId":
 			out.Values[i] = ec._Event_turnId(ctx, field, obj)
 		case "actor":
 			out.Values[i] = ec._Event_actor(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "kind":
 			out.Values[i] = ec._Event_kind(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "payload":
 			out.Values[i] = ec._Event_payload(ctx, field, obj)
 		case "parents":
 			out.Values[i] = ec._Event_parents(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "refs":
 			out.Values[i] = ec._Event_refs(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "hash":
 			out.Values[i] = ec._Event_hash(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "prevHash":
 			out.Values[i] = ec._Event_prevHash(ctx, field, obj)
+		case "links":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Event_links(ctx, field, obj)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var linkImplementors = []string{"Link"}
+
+func (ec *executionContext) _Link(ctx context.Context, sel ast.SelectionSet, obj *Link) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, linkImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Link")
+		case "fromEvent":
+			out.Values[i] = ec._Link_fromEvent(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "toEvent":
+			out.Values[i] = ec._Link_toEvent(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "relation":
+			out.Values[i] = ec._Link_relation(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "confidence":
+			out.Values[i] = ec._Link_confidence(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "inferredBy":
+			out.Values[i] = ec._Link_inferredBy(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -2826,6 +3136,22 @@ func (ec *executionContext) marshalNEventKind2githubᚗcomᚋdongqiuᚋagentᚑl
 	return v
 }
 
+func (ec *executionContext) unmarshalNFloat2float64(ctx context.Context, v any) (float64, error) {
+	res, err := graphql.UnmarshalFloatContext(ctx, v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNFloat2float64(ctx context.Context, sel ast.SelectionSet, v float64) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalFloatContext(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return graphql.WrapContextMarshaler(ctx, res)
+}
+
 func (ec *executionContext) unmarshalNID2string(ctx context.Context, v any) (string, error) {
 	res, err := graphql.UnmarshalID(v)
 	return res, graphql.ErrorOnPath(ctx, err)
@@ -2870,6 +3196,32 @@ func (ec *executionContext) marshalNID2ᚕstringᚄ(ctx context.Context, sel ast
 	}
 
 	return ret
+}
+
+func (ec *executionContext) marshalNLink2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐLinkᚄ(ctx context.Context, sel ast.SelectionSet, v []*Link) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNLink2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐLink(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNLink2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐLink(ctx context.Context, sel ast.SelectionSet, v *Link) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Link(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v any) (string, error) {

--- a/internal/query/gqlgen.yml
+++ b/internal/query/gqlgen.yml
@@ -20,3 +20,9 @@ models:
     model: github.com/99designs/gqlgen/graphql.Time
   JSON:
     model: github.com/99designs/gqlgen/graphql.Map
+  Event:
+    fields:
+      # Resolved lazily so a query that doesn't ask for links pays
+      # nothing, and we can DataLoader-batch later.
+      links:
+        resolver: true

--- a/internal/query/mapper.go
+++ b/internal/query/mapper.go
@@ -56,3 +56,16 @@ func nonNilStrings(s []string) []string {
 	}
 	return s
 }
+
+func toGQLLink(l *store.Link) *Link {
+	if l == nil {
+		return nil
+	}
+	return &Link{
+		FromEvent:  l.FromEvent,
+		ToEvent:    l.ToEvent,
+		Relation:   l.Relation,
+		Confidence: float64(l.Confidence),
+		InferredBy: l.InferredBy,
+	}
+}

--- a/internal/query/models_gen.go
+++ b/internal/query/models_gen.go
@@ -28,6 +28,16 @@ type Event struct {
 	Refs      []string       `json:"refs"`
 	Hash      string         `json:"hash"`
 	PrevHash  *string        `json:"prevHash,omitempty"`
+	// All links touching this event in either direction (from/to).
+	Links []*Link `json:"links"`
+}
+
+type Link struct {
+	FromEvent  string  `json:"fromEvent"`
+	ToEvent    string  `json:"toEvent"`
+	Relation   string  `json:"relation"`
+	Confidence float64 `json:"confidence"`
+	InferredBy string  `json:"inferredBy"`
 }
 
 type Query struct {

--- a/internal/query/router_test.go
+++ b/internal/query/router_test.go
@@ -128,3 +128,71 @@ func TestQuerySessionHeadEmpty(t *testing.T) {
 		t.Errorf("head for unknown session = %q, want empty", head)
 	}
 }
+
+// TestEventLinksResolver exercises the new Event.links resolver
+// (M2-B). Two events sharing a `git:<sha>` ref get linked via
+// AppendLink in the store; the GraphQL query for either event
+// returns the corresponding link.
+func TestEventLinksResolver(t *testing.T) {
+	st := store.NewMemory()
+	ctx := context.Background()
+	if err := st.AppendEvent(ctx, &store.Event{
+		ID: "e1", SessionID: "s1", ActorType: "human", ActorID: "alice",
+		Kind: "commit", Hash: "h1", Refs: []string{"git:abc"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AppendEvent(ctx, &store.Event{
+		ID: "e2", SessionID: "s2", ActorType: "human", ActorID: "alice",
+		Kind: "pr", Hash: "h2", Refs: []string{"git:abc"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AppendLink(ctx, &store.Link{
+		FromEvent: "e1", ToEvent: "e2", Relation: "references",
+		Confidence: 1.0, InferredBy: "shared_ref:git:abc",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(query.NewRouter(st))
+	defer srv.Close()
+
+	body := `{"query":"{ event(id: \"e2\") { id links { fromEvent toEvent relation inferredBy } } }"}`
+	resp, err := http.Post(srv.URL+"/graphql", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var got struct {
+		Data struct {
+			Event struct {
+				ID    string `json:"id"`
+				Links []struct {
+					FromEvent  string `json:"fromEvent"`
+					ToEvent    string `json:"toEvent"`
+					Relation   string `json:"relation"`
+					InferredBy string `json:"inferredBy"`
+				} `json:"links"`
+			} `json:"event"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", got.Errors)
+	}
+	if len(got.Data.Event.Links) != 1 {
+		t.Fatalf("got %d links, want 1", len(got.Data.Event.Links))
+	}
+	link := got.Data.Event.Links[0]
+	if link.FromEvent != "e1" || link.ToEvent != "e2" || link.Relation != "references" {
+		t.Errorf("link = %+v", link)
+	}
+	if link.InferredBy != "shared_ref:git:abc" {
+		t.Errorf("inferred_by = %q", link.InferredBy)
+	}
+}

--- a/internal/query/schema.graphql
+++ b/internal/query/schema.graphql
@@ -13,6 +13,16 @@ type Event {
   refs: [ID!]!
   hash: String!
   prevHash: String
+  """All links touching this event in either direction (from/to)."""
+  links: [Link!]!
+}
+
+type Link {
+  fromEvent: ID!
+  toEvent: ID!
+  relation: String!
+  confidence: Float!
+  inferredBy: String!
 }
 
 type Actor {

--- a/internal/query/schema.resolvers.go
+++ b/internal/query/schema.resolvers.go
@@ -12,6 +12,22 @@ import (
 	"github.com/dongqiu/agent-lens/internal/store"
 )
 
+// Links is the resolver for the links field.
+func (r *eventResolver) Links(ctx context.Context, obj *Event) ([]*Link, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	raw, err := r.Store.LinksForEvent(ctx, obj.ID)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*Link, 0, len(raw))
+	for _, l := range raw {
+		out = append(out, toGQLLink(l))
+	}
+	return out, nil
+}
+
 // Event is the resolver for the event field.
 func (r *queryResolver) Event(ctx context.Context, id string) (*Event, error) {
 	se, err := r.Store.GetEvent(ctx, id)
@@ -46,7 +62,11 @@ func (r *queryResolver) SessionHead(ctx context.Context, sessionID string) (stri
 	return r.Store.HeadHash(ctx, sessionID)
 }
 
+// Event returns EventResolver implementation.
+func (r *Resolver) Event() EventResolver { return &eventResolver{r} }
+
 // Query returns QueryResolver implementation.
 func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
+type eventResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -12,10 +12,14 @@ type Memory struct {
 	mu     sync.Mutex
 	events []*Event
 	byID   map[string]*Event
+	links  map[string]Link // key: from|to|relation
 }
 
 func NewMemory() *Memory {
-	return &Memory{byID: map[string]*Event{}}
+	return &Memory{
+		byID:  map[string]*Event{},
+		links: map[string]Link{},
+	}
 }
 
 func (m *Memory) Close() error { return nil }
@@ -83,4 +87,44 @@ func (m *Memory) HeadHash(_ context.Context, sessionID string) (string, error) {
 		}
 	}
 	return head, nil
+}
+
+func (m *Memory) EventsByRef(_ context.Context, ref string) ([]*Event, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []*Event
+	for _, e := range m.events {
+		for _, r := range e.Refs {
+			if r == ref {
+				cp := *e
+				out = append(out, &cp)
+				break
+			}
+		}
+	}
+	return out, nil
+}
+
+func (m *Memory) AppendLink(_ context.Context, l *Link) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := l.FromEvent + "|" + l.ToEvent + "|" + l.Relation
+	if _, exists := m.links[key]; exists {
+		return ErrDuplicate
+	}
+	m.links[key] = *l
+	return nil
+}
+
+func (m *Memory) LinksForEvent(_ context.Context, eventID string) ([]*Link, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []*Link
+	for _, l := range m.links {
+		if l.FromEvent == eventID || l.ToEvent == eventID {
+			cp := l
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
 }

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -109,6 +109,57 @@ func (p *Postgres) HeadHash(ctx context.Context, sessionID string) (string, erro
 	return h, err
 }
 
+func (p *Postgres) EventsByRef(ctx context.Context, ref string) ([]*Event, error) {
+	const q = `SELECT id, ts, session_id, turn_id, actor_type, actor_id, actor_model,
+		kind, payload, parents, refs, hash, prev_hash, sig
+		FROM events WHERE $1 = ANY(refs) ORDER BY ts ASC, id ASC`
+	rows, err := p.pool.Query(ctx, q, ref)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*Event
+	for rows.Next() {
+		e, err := scanEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+func (p *Postgres) AppendLink(ctx context.Context, l *Link) error {
+	const q = `INSERT INTO links (from_event, to_event, relation, confidence, inferred_by)
+		VALUES ($1, $2, $3, $4, $5)`
+	_, err := p.pool.Exec(ctx, q, l.FromEvent, l.ToEvent, l.Relation, l.Confidence, l.InferredBy)
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
+		return ErrDuplicate
+	}
+	return err
+}
+
+func (p *Postgres) LinksForEvent(ctx context.Context, eventID string) ([]*Link, error) {
+	const q = `SELECT from_event, to_event, relation, confidence, inferred_by
+		FROM links WHERE from_event = $1 OR to_event = $1
+		ORDER BY relation, from_event, to_event`
+	rows, err := p.pool.Query(ctx, q, eventID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*Link
+	for rows.Next() {
+		var l Link
+		if err := rows.Scan(&l.FromEvent, &l.ToEvent, &l.Relation, &l.Confidence, &l.InferredBy); err != nil {
+			return nil, err
+		}
+		out = append(out, &l)
+	}
+	return out, rows.Err()
+}
+
 type scanner interface {
 	Scan(dest ...any) error
 }

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -6,6 +6,9 @@ import (
 	"context"
 	"errors"
 	"os"
+	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -15,15 +18,31 @@ import (
 	"github.com/testcontainers/testcontainers-go/wait"
 )
 
-const migrationPath = "../../migrations/0001_init.up.sql"
+const migrationsDir = "../../migrations"
 
+// loadSchema concatenates every migrations/*.up.sql in lexical order so
+// the integration tests run against the same schema a fresh deployment
+// gets after `make migrate-up`.
 func loadSchema(t *testing.T) string {
 	t.Helper()
-	b, err := os.ReadFile(migrationPath)
+	files, err := filepath.Glob(filepath.Join(migrationsDir, "*.up.sql"))
 	if err != nil {
-		t.Fatalf("read migration: %v", err)
+		t.Fatalf("glob migrations: %v", err)
 	}
-	return string(b)
+	if len(files) == 0 {
+		t.Fatalf("no migrations found under %s", migrationsDir)
+	}
+	sort.Strings(files)
+	var b strings.Builder
+	for _, f := range files {
+		raw, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		b.Write(raw)
+		b.WriteString("\n")
+	}
+	return b.String()
 }
 
 func TestPostgresAppendAndList(t *testing.T) {
@@ -195,5 +214,72 @@ func openPostgresWithSchema(ctx context.Context, t *testing.T) (*Postgres, func(
 	return st, func() {
 		st.Close()
 		_ = pgC.Terminate(ctx)
+	}
+}
+
+// TestPostgresLinkRoundTrip exercises EventsByRef + AppendLink +
+// LinksForEvent end-to-end against the real GIN index added in 0002.
+func TestPostgresLinkRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	st, cleanup := openPostgresWithSchema(ctx, t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	e1 := &Event{
+		ID: "01HLINKA", TS: now, SessionID: "git-r", ActorType: "human",
+		ActorID: "alice", Kind: "commit", Hash: "h1",
+		Refs: []string{"git:abc123"},
+	}
+	e2 := &Event{
+		ID: "01HLINKB", TS: now.Add(time.Second), SessionID: "github-pr:o/r/1",
+		ActorType: "human", ActorID: "alice", Kind: "pr", Hash: "h2",
+		Refs: []string{"git:abc123"},
+	}
+	for _, e := range []*Event{e1, e2} {
+		if err := st.AppendEvent(ctx, e); err != nil {
+			t.Fatalf("append %s: %v", e.ID, err)
+		}
+	}
+
+	peers, err := st.EventsByRef(ctx, "git:abc123")
+	if err != nil {
+		t.Fatalf("EventsByRef: %v", err)
+	}
+	if len(peers) != 2 {
+		t.Errorf("got %d peers, want 2", len(peers))
+	}
+
+	link := &Link{
+		FromEvent: e1.ID, ToEvent: e2.ID, Relation: "references",
+		Confidence: 1.0, InferredBy: "shared_ref:git:abc123",
+	}
+	if err := st.AppendLink(ctx, link); err != nil {
+		t.Fatalf("AppendLink: %v", err)
+	}
+	if err := st.AppendLink(ctx, link); !errors.Is(err, ErrDuplicate) {
+		t.Errorf("duplicate link err = %v, want ErrDuplicate", err)
+	}
+
+	got, err := st.LinksForEvent(ctx, e1.ID)
+	if err != nil {
+		t.Fatalf("LinksForEvent(from): %v", err)
+	}
+	if len(got) != 1 || got[0].ToEvent != e2.ID {
+		t.Errorf("links for e1 = %+v, want one to e2", got)
+	}
+	got2, err := st.LinksForEvent(ctx, e2.ID)
+	if err != nil {
+		t.Fatalf("LinksForEvent(to): %v", err)
+	}
+	if len(got2) != 1 || got2[0].FromEvent != e1.ID {
+		t.Errorf("links for e2 = %+v, want one from e1", got2)
+	}
+
+	none, err := st.EventsByRef(ctx, "git:notfound")
+	if err != nil {
+		t.Fatalf("EventsByRef miss: %v", err)
+	}
+	if len(none) != 0 {
+		t.Errorf("EventsByRef miss returned %d events", len(none))
 	}
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -30,14 +30,36 @@ type Event struct {
 	Sig       []byte
 }
 
-// Store is the persistence interface used by ingest and query layers.
+// Link is a causal or semantic relation between two events. Links are
+// stored separately from the append-only event log so they can be
+// re-derived without rewriting history.
+type Link struct {
+	FromEvent  string
+	ToEvent    string
+	Relation   string
+	Confidence float32
+	InferredBy string
+}
+
+// Store is the persistence interface used by ingest, query, and linking
+// layers.
 //
 // ListBySession returns events for sessionID in append order. A limit of
 // zero or negative means "no limit"; both implementations honor this.
+//
+// EventsByRef returns events whose refs array contains ref, in append
+// order. Used by the linking worker to find peers for a given git/PR ref.
+//
+// AppendLink inserts a link; ErrDuplicate is returned if (from, to,
+// relation) already exists. LinksForEvent returns all links touching
+// eventID in either direction.
 type Store interface {
 	AppendEvent(ctx context.Context, e *Event) error
 	GetEvent(ctx context.Context, id string) (*Event, error)
 	ListBySession(ctx context.Context, sessionID string, limit int) ([]*Event, error)
 	HeadHash(ctx context.Context, sessionID string) (string, error)
+	EventsByRef(ctx context.Context, ref string) ([]*Event, error)
+	AppendLink(ctx context.Context, l *Link) error
+	LinksForEvent(ctx context.Context, eventID string) ([]*Link, error)
 	Close() error
 }

--- a/migrations/0002_refs_gin_idx.down.sql
+++ b/migrations/0002_refs_gin_idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS events_refs_gin_idx;

--- a/migrations/0002_refs_gin_idx.up.sql
+++ b/migrations/0002_refs_gin_idx.up.sql
@@ -1,0 +1,4 @@
+-- GIN index on the refs array makes EventsByRef (used by the linking
+-- worker to find peers via shared refs like "git:<sha>") a sub-ms
+-- lookup instead of a full table scan.
+CREATE INDEX IF NOT EXISTS events_refs_gin_idx ON events USING GIN (refs);

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -37,6 +37,7 @@ export const eventsQuery = `
       refs
       hash
       prevHash
+      links { fromEvent toEvent relation inferredBy }
     }
     sessionHead(sessionId: $sessionId)
   }

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -32,6 +32,20 @@ export function EventCard({ event }: { event: Event }) {
               {event.actor.type.toLowerCase()} · {event.actor.id}
               {event.actor.model ? ` · ${event.actor.model}` : ""}
             </span>
+            {event.links?.length > 0 && (
+              <span
+                className="inline-flex items-center gap-0.5 rounded bg-white px-1.5 py-0.5 text-[10px] font-medium text-zinc-700 ring-1 ring-zinc-300"
+                title={event.links
+                  .map((l) =>
+                    l.fromEvent === event.id
+                      ? `→ ${l.toEvent} (${l.relation})`
+                      : `← ${l.fromEvent} (${l.relation})`,
+                  )
+                  .join("\n")}
+              >
+                ↔ {event.links.length}
+              </span>
+            )}
           </div>
           {summary && (
             <div className="mt-1.5 text-sm text-zinc-800 break-words">

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -20,6 +20,14 @@ export type Actor = {
   model?: string | null;
 };
 
+export type Link = {
+  fromEvent: string;
+  toEvent: string;
+  relation: string;
+  confidence: number;
+  inferredBy: string;
+};
+
 export type Event = {
   id: string;
   ts: string;
@@ -32,6 +40,7 @@ export type Event = {
   refs: string[];
   hash: string;
   prevHash?: string | null;
+  links: Link[];
 };
 
 export type EventsResponse = {


### PR DESCRIPTION
## Summary

Second slice of M2. Off-write-path worker that writes \`Link\` rows for any two events sharing a \`git:<sha>\` (or other) ref. UI gains a per-card \"↔ N\" badge.

This is the piece that makes M2-A (PR webhook) actually useful: PR events with \`refs[git:<head_sha>]\` now connect to the COMMIT events the git hook produced for the same SHA, even though they're in different sessions.

**Out of scope**: link relation refinement (everything is \"references\" v0; commit→pr \"produces\" / commit→build \"builds\" / etc. wait for M3), causal graph view in UI (still timeline+badge only), backfill for queue overflow.

## Architecture

\`\`\`
ingest.Append succeeds
        │
        ▼
  AfterAppend(ev) ────────────►  Linker.Notify(ev)   [non-blocking]
                                       │
                                       ▼
                              channel (cap 1024)
                                       │
                                       ▼
                              Linker.Run goroutine
                                       │
                                       ▼
                  for each ref:
                    EventsByRef(ref)  ──►  store
                    for each peer ≠ self:
                      AppendLink(peer→self, "references")  [ErrDuplicate ok]
\`\`\`

Lock discipline: \`ingest.Handler.Append\` now splits into \`appendLocked\` (under lock) + \`AfterAppend\` invocation (outside lock). Observers run their own I/O without blocking the writer.

## Test plan

- [x] \`go test -race ./...\` — 11 packages green, including 7 new tests in \`internal/linking\` and 1 GraphQL vertical-slice test.
- [x] \`make test-integration\` — new \`TestPostgresLinkRoundTrip\` covers EventsByRef + AppendLink (with ErrDuplicate translation) + LinksForEvent against the GIN index.
- [x] \`pnpm build\` — clean.
- [ ] CI green (will be confirmed on this PR).

## End-to-end demo

1. Start the stack with the GitHub webhook configured (M2-A).
2. \`agent-lens-hook git-post-commit\` fires after a local commit; produces \`commit\` event with \`refs[git:<sha>]\`.
3. Push, open PR; GitHub fires \`pull_request opened\`; webhook handler produces \`pr\` event with \`refs[git:<head_sha>]\`.
4. Linker sees both share \`git:<sha>\`, writes a \`references\` link.
5. Lens UI shows \"↔ 1\" badge on both cards. Hover for details.

## Notes / known limitations

- **Queue overflow drops events.** v0 ships a 1024-deep buffered channel; if a backlog forms (e.g. burst of webhook deliveries), \`Notify\` drops with a warn log. The recovery path is a periodic backfill scan, deferred.
- **N+1 on \`event.links\`.** GraphQL resolver is lazy (only fires when the query asks for \`links\`), but each event triggers a \`LinksForEvent\` query. DataLoader-style batching is a future optimization.
- **Single relation type.** \"references\" for all v0 links. Differentiating commit→pr vs pr→build vs commit→deploy by event-kind pairs is M3 work.

Tracks: M2-B. Refs: SPEC §6 (\"Link\" capability), §14 M2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)