### PR TITLE
feat(verify): agent-lens-hook verify subcommand (M3-C-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ make web-build         # TS 类型检查 + Vite 打包
 
 Stop hook 会读 `transcript_path` 提取 `thinking` / `text` content blocks（仅当本轮启用 extended thinking 时有 thinking）。HTTP 失败时回落 `~/.agent-lens/sessions/<sid>.ndjson` 文件 sink。
 
+## 校验哈希链
+
+```bash
+agent-lens-hook verify --session <session-id>
+# OK · 6 events · head 7f53e1ebb9779555
+# 或：FAIL at index 3 (id=01HXX...): prev_hash="...", expected "..."
+```
+
+v1 仅校验 `prev_hash → hash` 链路完整性，**不**重新从内容推导每条事件的 hash——后者需要 server 端重序列化逻辑（计划在后续 PR 加 server-side `verifyChain` GraphQL field）。当前足以发现"丢一条事件"或"链条被截断"的篡改，但敌手如能直接写库可伪造一条自洽的链。
+
 ## 接入 GitHub（M2-A：PR 事件）
 
 1. 在 server 端设环境变量 `AGENT_LENS_GH_WEBHOOK_SECRET=<random>`，然后启动 / 重启 `agent-lens`

--- a/cmd/agent-lens-hook/main.go
+++ b/cmd/agent-lens-hook/main.go
@@ -45,6 +45,6 @@ func main() {
 
 // runClaude is implemented in claude.go.
 // runGitPostCommit is implemented in git.go.
+// runVerify is implemented in verify.go.
 
-func runVerify(_ []string) { fmt.Fprintln(os.Stderr, "TODO: verify hash chain"); os.Exit(1) }
 func runExport(_ []string) { fmt.Fprintln(os.Stderr, "TODO: export attestation"); os.Exit(1) }

--- a/cmd/agent-lens-hook/verify.go
+++ b/cmd/agent-lens-hook/verify.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+)
+
+const verifyUsage = `agent-lens-hook verify — walk a session's hash chain and verify
+that every event's prev_hash matches the previous event's hash.
+
+  agent-lens-hook verify --session <id> [--url <url>] [--token <token>]
+
+This v1 verifier checks chain *linkage* only: events are returned by
+the server in append order, and each event's prev_hash must equal its
+predecessor's hash. It does NOT yet re-derive each event's hash from
+its content; an attacker who can write to the store directly could
+produce a self-consistent chain of fabricated events. Content
+re-derivation is a follow-up (server-side, since the canonical-JSON
+encoding lives in the ingest package).
+
+Exit codes: 0 on success, 1 on chain break, 2 on usage / network /
+server errors.
+`
+
+func runVerify(args []string) {
+	fs := flag.NewFlagSet("verify", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	var (
+		sessionID = fs.String("session", "", "session id to verify (required)")
+		urlFlag   = fs.String("url", "", "Agent Lens server URL (defaults to AGENT_LENS_URL or http://localhost:8787)")
+		tokenFlag = fs.String("token", "", "bearer token (defaults to AGENT_LENS_TOKEN)")
+		limit     = fs.Int("limit", 0, "maximum events to fetch (0 = all)")
+		quiet     = fs.Bool("quiet", false, "only print FAIL or summary, not per-event progress")
+	)
+	fs.Usage = func() { fmt.Fprint(os.Stderr, verifyUsage) }
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+	if *sessionID == "" {
+		fs.Usage()
+		os.Exit(2)
+	}
+
+	url := chooseURL(*urlFlag)
+	token := chooseToken(*tokenFlag)
+
+	events, err := fetchSession(url, token, *sessionID, *limit)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "fetch: %v\n", err)
+		os.Exit(2)
+	}
+	if len(events) == 0 {
+		fmt.Printf("session %q: no events\n", *sessionID)
+		os.Exit(0)
+	}
+
+	if !*quiet {
+		fmt.Printf("session %q: walking %d events\n", *sessionID, len(events))
+	}
+
+	for i, e := range events {
+		var prev string
+		if i > 0 {
+			prev = events[i-1].Hash
+		}
+		gotPrev := ""
+		if e.PrevHash != nil {
+			gotPrev = *e.PrevHash
+		}
+		if gotPrev != prev {
+			fmt.Fprintf(os.Stderr, "FAIL at index %d (id=%s): prev_hash=%q, expected %q\n",
+				i, e.ID, gotPrev, prev)
+			os.Exit(1)
+		}
+		if !*quiet {
+			fmt.Printf("  [%d] %s · %s · %s\n", i, e.Kind, e.Hash[:12], e.ID)
+		}
+	}
+
+	head := events[len(events)-1].Hash
+	fmt.Printf("OK · %d events · head %s\n", len(events), head[:16])
+	os.Exit(0)
+}
+
+type verifyEvent struct {
+	ID       string  `json:"id"`
+	Kind     string  `json:"kind"`
+	Hash     string  `json:"hash"`
+	PrevHash *string `json:"prevHash"`
+}
+
+const verifyQuery = `query Verify($sessionId: String!, $limit: Int) {
+  events(sessionId: $sessionId, limit: $limit) {
+    id
+    kind
+    hash
+    prevHash
+  }
+}`
+
+func fetchSession(url, token, sessionID string, limit int) ([]verifyEvent, error) {
+	body, err := json.Marshal(map[string]any{
+		"query": verifyQuery,
+		"variables": map[string]any{
+			"sessionId": sessionID,
+			"limit":     limit,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, url+"/v1/graphql", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		raw, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(raw))
+	}
+	var out struct {
+		Data struct {
+			Events []verifyEvent `json:"events"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	if len(out.Errors) > 0 {
+		return nil, fmt.Errorf("graphql: %s", out.Errors[0].Message)
+	}
+	return out.Data.Events, nil
+}
+
+func chooseURL(flagVal string) string {
+	if flagVal != "" {
+		return flagVal
+	}
+	if v := os.Getenv("AGENT_LENS_URL"); v != "" {
+		return v
+	}
+	return "http://localhost:8787"
+}
+
+func chooseToken(flagVal string) string {
+	if flagVal != "" {
+		return flagVal
+	}
+	return os.Getenv("AGENT_LENS_TOKEN")
+}

--- a/cmd/agent-lens-hook/verify.go
+++ b/cmd/agent-lens-hook/verify.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"time"
 )
 
 const verifyUsage = `agent-lens-hook verify — walk a session's hash chain and verify
@@ -35,6 +36,7 @@ func runVerify(args []string) {
 		urlFlag   = fs.String("url", "", "Agent Lens server URL (defaults to AGENT_LENS_URL or http://localhost:8787)")
 		tokenFlag = fs.String("token", "", "bearer token (defaults to AGENT_LENS_TOKEN)")
 		limit     = fs.Int("limit", 0, "maximum events to fetch (0 = all)")
+		timeout   = fs.Duration("timeout", 30*time.Second, "HTTP request timeout")
 		quiet     = fs.Bool("quiet", false, "only print FAIL or summary, not per-event progress")
 	)
 	fs.Usage = func() { fmt.Fprint(os.Stderr, verifyUsage) }
@@ -49,7 +51,7 @@ func runVerify(args []string) {
 	url := chooseURL(*urlFlag)
 	token := chooseToken(*tokenFlag)
 
-	events, err := fetchSession(url, token, *sessionID, *limit)
+	events, err := fetchSession(url, token, *sessionID, *limit, *timeout)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "fetch: %v\n", err)
 		os.Exit(2)
@@ -103,7 +105,18 @@ const verifyQuery = `query Verify($sessionId: String!, $limit: Int) {
   }
 }`
 
-func fetchSession(url, token, sessionID string, limit int) ([]verifyEvent, error) {
+// fetchSession queries the server for sessionID's event chain. Server
+// is contracted to return events in append order (ListBySession's
+// `ORDER BY ts ASC, id ASC`); the chain walk in runVerify implicitly
+// validates that ordering — events out of order would surface as a
+// prev_hash mismatch — so a separate sort here would only mask
+// genuine integrity problems.
+func fetchSession(url, token, sessionID string, limit int, timeout time.Duration) ([]verifyEvent, error) {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	client := &http.Client{Timeout: timeout}
+
 	body, err := json.Marshal(map[string]any{
 		"query": verifyQuery,
 		"variables": map[string]any{
@@ -122,7 +135,7 @@ func fetchSession(url, token, sessionID string, limit int) ([]verifyEvent, error
 	if token != "" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/agent-lens-hook/verify_test.go
+++ b/cmd/agent-lens-hook/verify_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// fakeGQL is a tiny stand-in that decodes the verify query, looks the
+// requested sessionId up in a fixture map, and returns the events as
+// the GraphQL response shape that runVerify expects.
+type fakeGQL struct {
+	sessions map[string][]verifyEvent
+}
+
+func (f fakeGQL) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/v1/graphql" {
+		http.NotFound(w, r)
+		return
+	}
+	var req struct {
+		Variables struct {
+			SessionID string `json:"sessionId"`
+		} `json:"variables"`
+	}
+	_ = json.NewDecoder(r.Body).Decode(&req)
+	events, ok := f.sessions[req.Variables.SessionID]
+	if !ok {
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"events": []verifyEvent{}}})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"events": events}})
+}
+
+func ptr(s string) *string { return &s }
+
+func TestFetchSessionRoundTripsTheChain(t *testing.T) {
+	srv := httptest.NewServer(fakeGQL{
+		sessions: map[string][]verifyEvent{
+			"s1": {
+				{ID: "e1", Kind: "PROMPT", Hash: "h1", PrevHash: nil},
+				{ID: "e2", Kind: "THOUGHT", Hash: "h2", PrevHash: ptr("h1")},
+				{ID: "e3", Kind: "TOOL_CALL", Hash: "h3", PrevHash: ptr("h2")},
+			},
+		},
+	})
+	defer srv.Close()
+
+	got, err := fetchSession(srv.URL, "", "s1", 0)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("got %d events, want 3", len(got))
+	}
+	if got[2].Hash != "h3" || got[2].PrevHash == nil || *got[2].PrevHash != "h2" {
+		t.Errorf("event 3 = %+v", got[2])
+	}
+}
+
+func TestFetchSessionForwardsBearerToken(t *testing.T) {
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"events": []verifyEvent{}}})
+	}))
+	defer srv.Close()
+
+	if _, err := fetchSession(srv.URL, "secret", "s1", 0); err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if gotAuth != "Bearer secret" {
+		t.Errorf("Authorization header = %q, want Bearer secret", gotAuth)
+	}
+}
+
+func TestFetchSessionReportsServerErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	}))
+	defer srv.Close()
+
+	if _, err := fetchSession(srv.URL, "", "s1", 0); err == nil {
+		t.Error("expected error from 500, got nil")
+	}
+}
+
+func TestFetchSessionReportsGraphQLErrors(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"errors": []map[string]any{{"message": "session not found"}},
+		})
+	}))
+	defer srv.Close()
+
+	_, err := fetchSession(srv.URL, "", "s1", 0)
+	if err == nil {
+		t.Fatal("expected graphql error, got nil")
+	}
+	if got := err.Error(); got != "graphql: session not found" {
+		t.Errorf("err = %q", got)
+	}
+}
+
+func TestChooseURLAndToken(t *testing.T) {
+	t.Setenv("AGENT_LENS_URL", "http://from-env:9999")
+	t.Setenv("AGENT_LENS_TOKEN", "envtoken")
+
+	if got := chooseURL(""); got != "http://from-env:9999" {
+		t.Errorf("env URL = %q", got)
+	}
+	if got := chooseURL("http://flag:1234"); got != "http://flag:1234" {
+		t.Errorf("flag URL = %q", got)
+	}
+	if got := chooseToken(""); got != "envtoken" {
+		t.Errorf("env token = %q", got)
+	}
+	if got := chooseToken("flagtoken"); got != "flagtoken" {
+		t.Errorf("flag token = %q", got)
+	}
+
+	t.Setenv("AGENT_LENS_URL", "")
+	if got := chooseURL(""); got != "http://localhost:8787" {
+		t.Errorf("default URL = %q", got)
+	}
+}

--- a/cmd/agent-lens-hook/verify_test.go
+++ b/cmd/agent-lens-hook/verify_test.go
@@ -4,7 +4,15 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dongqiu/agent-lens/internal/query"
+	"github.com/dongqiu/agent-lens/internal/store"
 )
 
 // fakeGQL is a tiny stand-in that decodes the verify query, looks the
@@ -47,7 +55,7 @@ func TestFetchSessionRoundTripsTheChain(t *testing.T) {
 	})
 	defer srv.Close()
 
-	got, err := fetchSession(srv.URL, "", "s1", 0)
+	got, err := fetchSession(srv.URL, "", "s1", 0, 0)
 	if err != nil {
 		t.Fatalf("fetch: %v", err)
 	}
@@ -67,7 +75,7 @@ func TestFetchSessionForwardsBearerToken(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := fetchSession(srv.URL, "secret", "s1", 0); err != nil {
+	if _, err := fetchSession(srv.URL, "secret", "s1", 0, 0); err != nil {
 		t.Fatalf("fetch: %v", err)
 	}
 	if gotAuth != "Bearer secret" {
@@ -82,7 +90,7 @@ func TestFetchSessionReportsServerErrors(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if _, err := fetchSession(srv.URL, "", "s1", 0); err == nil {
+	if _, err := fetchSession(srv.URL, "", "s1", 0, 0); err == nil {
 		t.Error("expected error from 500, got nil")
 	}
 }
@@ -95,7 +103,7 @@ func TestFetchSessionReportsGraphQLErrors(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, err := fetchSession(srv.URL, "", "s1", 0)
+	_, err := fetchSession(srv.URL, "", "s1", 0, 0)
 	if err == nil {
 		t.Fatal("expected graphql error, got nil")
 	}
@@ -124,5 +132,70 @@ func TestChooseURLAndToken(t *testing.T) {
 	t.Setenv("AGENT_LENS_URL", "")
 	if got := chooseURL(""); got != "http://localhost:8787" {
 		t.Errorf("default URL = %q", got)
+	}
+}
+
+func TestFetchSessionRespectsTimeout(t *testing.T) {
+	// Server that hangs forever on a request body read.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		time.Sleep(2 * time.Second)
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": map[string]any{"events": []verifyEvent{}}})
+	}))
+	defer srv.Close()
+
+	start := time.Now()
+	_, err := fetchSession(srv.URL, "", "s1", 0, 100*time.Millisecond)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("returned after %v, expected ~100ms timeout", elapsed)
+	}
+}
+
+// TestVerifyEndToEnd posts events through the real ingest pipeline,
+// then reads them back through the verify CLI's GraphQL fetch path.
+// Catches any future schema / mapper drift between writer and verifier.
+func TestVerifyEndToEnd(t *testing.T) {
+	st := store.NewMemory()
+	r := chi.NewRouter()
+	r.Route("/v1", func(sub chi.Router) {
+		ingest.RegisterRoutes(sub, st)
+		query.RegisterRoutes(sub, st)
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	body := strings.Join([]string{
+		`{"session_id":"s1","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"do X"}}`,
+		`{"session_id":"s1","actor":{"type":"agent","id":"claude"},"kind":"thought","payload":{"text":"reasoning"}}`,
+		`{"session_id":"s1","actor":{"type":"agent","id":"claude"},"kind":"tool_call","payload":{"name":"Edit"}}`,
+	}, "\n")
+	resp, err := http.Post(srv.URL+"/v1/events", "application/x-ndjson", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	resp.Body.Close()
+
+	events, err := fetchSession(srv.URL, "", "s1", 0, 5*time.Second)
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("got %d events, want 3", len(events))
+	}
+
+	if events[0].PrevHash != nil {
+		t.Errorf("events[0].prevHash = %v, want nil", *events[0].PrevHash)
+	}
+	for i := 1; i < len(events); i++ {
+		if events[i].PrevHash == nil {
+			t.Errorf("events[%d].prevHash is nil", i)
+			continue
+		}
+		if *events[i].PrevHash != events[i-1].Hash {
+			t.Errorf("chain broken at %d: prev=%q want %q", i, *events[i].PrevHash, events[i-1].Hash)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

First slice of M3. Implements the previously-stub \`verify\` subcommand. \`agent-lens-hook verify --session <id>\` walks a session's events via GraphQL and asserts every event's \`prev_hash\` equals its predecessor's \`hash\`.

Establishes the \"verify\" verb that M3 is built around. M3-A (deploy webhook) and M3-B (in-toto/SLSA attestation export) follow.

## Scope (deliberately small)

- ✅ Chain-linkage check: prev_hash → hash linkage.
- ❌ Content re-derivation. Each event's hash is computed from canonical-JSON of the WireEvent at ingest time; reproducing that requires the canonical-JSON encoding logic that lives inside the \`ingest\` package. Lands in M3-C-2 as a server-side \`verifyChain\` GraphQL field that runs the same code path the writer uses.

What v1 catches: deleted events, truncated chain, swapped order, accidentally re-ordered ingestion. What v1 misses: an attacker with direct DB write access who can fabricate a self-consistent chain.

## Interface

\`\`\`
agent-lens-hook verify --session <id> [--url <url>] [--token <token>] [--limit N] [--quiet]
\`\`\`

- Defaults: \`AGENT_LENS_URL\` env / \`http://localhost:8787\`; \`AGENT_LENS_TOKEN\` env.
- Output: per-event progress lines + final \`OK · N events · head <hash16>\` or \`FAIL at index N\`.
- Exit codes: 0 OK, 1 chain break, 2 usage/network/server error.

## Test plan

- [x] 5 unit tests covering the GraphQL fetch path: round-trip, bearer header forwarded, 5xx surface, graphql-errors-in-response surface, URL/token resolution precedence (flag > env > default).
- [x] Real binary built; \`agent-lens-hook verify --help\` prints the usage block.
- [x] \`go test -race ./...\` green.
- [ ] CI green on this PR.

## Follow-ups (open after merge)

- **M3-C-2**: server-side content re-derivation. Add \`Query.verifyChain(sessionId)\` resolver that re-runs the ingest canonical-JSON encoding and recomputes each hash, returning the first mismatch. CLI gains \`--strict\` flag that uses it.
- **M3-A** deploy webhook (next).
- **M3-B** in-toto / SLSA attestation (the centerpiece).

🤖 Generated with [Claude Code](https://claude.com/claude-code)