### PR TITLE
feat(webhooks): deploy webhook (M3-A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ make web-build         # TS 类型检查 + Vite 打包
 - `AGENT_LENS_PG_DSN`（默认本地 compose 配置）
 - `AGENT_LENS_TOKEN`：bearer token；空则 `/v1` 不鉴权（dev 默认）。配置后 hook 与浏览器都需带 `Authorization: Bearer <token>`
 - `AGENT_LENS_PLAYGROUND`：设为 `true` 才挂载 `/v1/playground`（默认 off，避免生产暴露 introspection）
-- `AGENT_LENS_GH_WEBHOOK_SECRET`：GitHub webhook 共享密钥；空则 `/webhooks/github` 不挂载。设置后 server 用 HMAC-SHA256 校验 `X-Hub-Signature-256`
+- `AGENT_LENS_GH_WEBHOOK_SECRET`：GitHub webhook 共享密钥；空则 `/webhooks/github` 返 503。设置后 server 用 HMAC-SHA256 校验 `X-Hub-Signature-256`
+- `AGENT_LENS_DEPLOY_WEBHOOK_TOKEN`：deploy webhook 独立 bearer token（与 `AGENT_LENS_TOKEN` 分离）；空则 `/webhooks/deploy` 返 503
 
 **Hook (`agent-lens-hook`)**
 - `AGENT_LENS_URL`（默认 `http://localhost:8787`）
@@ -104,6 +105,37 @@ v1 仅校验 `prev_hash → hash` 链路完整性，**不**重新从内容推导
    - `push` → `kind=push`，session `github-push:<owner>/<repo>/<branch>`
    - `workflow_run` → `kind=build`，session `github-build:<owner>/<repo>/<run_id>`，三种 lifecycle（requested / in_progress / completed）汇入同一 run session
 4. 全部事件都把相关 commit SHA 写入 `refs[git:<sha>]`，linking worker 自动跟本地 commit hook 上报的 COMMIT 事件串联
+
+## 接入部署系统（M3-A）
+
+`/webhooks/deploy` 接收一种 generic JSON shape，K8s post-deploy job、Argo CD notification、Helm post-render hook、自定义 curl 都能用同一个端点。
+
+```bash
+curl -X POST https://<server>/webhooks/deploy \
+  -H "Authorization: Bearer $AGENT_LENS_DEPLOY_WEBHOOK_TOKEN" \
+  -H "Idempotency-Key: $(uuidgen)" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "environment": "production",
+    "git_sha": "deadbeefcafe1234567890abcdef0123456789ab",
+    "image_digest": "sha256:abcdef0123456789",
+    "image": "ghcr.io/acme/widget",
+    "status": "succeeded",
+    "deployed_by": "alice",
+    "platform": "k8s",
+    "cluster": "prod-us-east"
+  }'
+```
+
+事件落到 session `deploy:<environment>`（例：`deploy:production`），refs 自动写 `git:<git_sha>` 和 `image:<digest>`。linker 把 deploy 跟之前的 commit / PR / build 串起来。
+
+| 字段 | 必填 | 说明 |
+|---|---|---|
+| `environment` | ✅ | 决定 session_id（按环境分组所有部署历史） |
+| `git_sha` 或 `image_digest` | 至少一个 | 决定 refs，linker 串接的入口 |
+| `Idempotency-Key` header | 推荐 | 做 server 端 dedup；不传则每次都新事件 |
+
+Token 配置：在 server 端设 `AGENT_LENS_DEPLOY_WEBHOOK_TOKEN=<random>`（与 `AGENT_LENS_TOKEN` **分离**，便于给部署系统最小权限）。未设则 `/webhooks/deploy` 返 503。
 
 ## 在 CI 里上报 build 事件 + artifact hash
 

--- a/cmd/agent-lens/main.go
+++ b/cmd/agent-lens/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dongqiu/agent-lens/internal/linking"
 	"github.com/dongqiu/agent-lens/internal/query"
 	"github.com/dongqiu/agent-lens/internal/store"
+	deploywh "github.com/dongqiu/agent-lens/internal/webhooks/deploy"
 	githubwh "github.com/dongqiu/agent-lens/internal/webhooks/github"
 )
 
@@ -89,6 +90,22 @@ func main() {
 			http.Error(w, "webhook receiver disabled (AGENT_LENS_GH_WEBHOOK_SECRET unset)", http.StatusServiceUnavailable)
 		})
 		slog.Info("AGENT_LENS_GH_WEBHOOK_SECRET unset; /webhooks/github returns 503")
+	}
+
+	// /webhooks/deploy uses bearer-token auth (most deploy systems
+	// don't sign webhook bodies). Token is separate from /v1's
+	// AGENT_LENS_TOKEN so a deploy system gets write-only credentials.
+	if deployToken := os.Getenv("AGENT_LENS_DEPLOY_WEBHOOK_TOKEN"); deployToken != "" {
+		r.Group(func(authed chi.Router) {
+			authed.Use(auth.RequireToken(deployToken))
+			authed.Post("/webhooks/deploy", deploywh.NewHandler(ingestH).ServeHTTP)
+		})
+		slog.Info("deploy webhook enabled", "path", "/webhooks/deploy")
+	} else {
+		r.Post("/webhooks/deploy", func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "deploy webhook receiver disabled (AGENT_LENS_DEPLOY_WEBHOOK_TOKEN unset)", http.StatusServiceUnavailable)
+		})
+		slog.Info("AGENT_LENS_DEPLOY_WEBHOOK_TOKEN unset; /webhooks/deploy returns 503")
 	}
 
 	srv := &http.Server{

--- a/internal/webhooks/deploy/handler.go
+++ b/internal/webhooks/deploy/handler.go
@@ -1,0 +1,73 @@
+// Package deploy receives deploy notifications and forwards them as
+// kind=deploy events into the ingest pipeline.
+//
+// Auth: this package contains no auth logic; the route is gated by
+// internal/auth.RequireToken middleware in cmd/agent-lens (using a
+// dedicated AGENT_LENS_DEPLOY_WEBHOOK_TOKEN so a deploy system can be
+// granted write access without any /v1 read permissions).
+//
+// Idempotency: clients may set the `Idempotency-Key` header; the value
+// becomes the wire event id, so a redelivery hits store.ErrDuplicate
+// at the store layer and the handler responds 200 OK. Without the
+// header each delivery is a fresh ULID and dedup is the client's
+// responsibility.
+package deploy
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+
+	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dongqiu/agent-lens/internal/store"
+)
+
+// Handler is the http.Handler for POST /webhooks/deploy.
+type Handler struct {
+	ingest  *ingest.Handler
+	maxBody int64
+}
+
+func NewHandler(h *ingest.Handler) *Handler {
+	return &Handler{
+		ingest:  h,
+		maxBody: 1 << 20, // 1 MiB; deploy payloads are small
+	}
+}
+
+func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	defer func() { _ = r.Body.Close() }()
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, h.maxBody))
+	if err != nil {
+		http.Error(w, "read body", http.StatusBadRequest)
+		return
+	}
+
+	idempotencyKey := r.Header.Get("Idempotency-Key")
+
+	ev, err := mapDeploy(body, idempotencyKey)
+	if err != nil {
+		slog.Warn("deploy webhook map", "idempotency_key", idempotencyKey, "err", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	switch err := h.ingest.Append(r.Context(), ev); {
+	case err == nil:
+		slog.Info("deploy webhook accepted", "session", ev.SessionID, "idempotency_key", idempotencyKey)
+		w.WriteHeader(http.StatusAccepted)
+	case errors.Is(err, store.ErrDuplicate):
+		// Idempotency-Key matched a prior delivery; just ack.
+		slog.Info("deploy webhook duplicate", "session", ev.SessionID, "idempotency_key", idempotencyKey)
+		w.WriteHeader(http.StatusOK)
+	default:
+		slog.Error("deploy webhook append", "idempotency_key", idempotencyKey, "err", err)
+		http.Error(w, "store error", http.StatusInternalServerError)
+	}
+}

--- a/internal/webhooks/deploy/handler_test.go
+++ b/internal/webhooks/deploy/handler_test.go
@@ -1,0 +1,191 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dongqiu/agent-lens/internal/store"
+)
+
+const sampleDeploy = `{
+  "environment": "production",
+  "git_sha": "deadbeefcafe1234567890abcdef0123456789ab",
+  "image": "ghcr.io/acme/widget",
+  "image_digest": "sha256:abcdef0123456789",
+  "status": "succeeded",
+  "deployed_by": "alice",
+  "platform": "k8s",
+  "cluster": "prod-us-east",
+  "namespace": "default"
+}`
+
+func deliver(t *testing.T, h *Handler, body []byte, idempotencyKey string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/webhooks/deploy", bytes.NewReader(body))
+	if idempotencyKey != "" {
+		req.Header.Set("Idempotency-Key", idempotencyKey)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}
+
+func TestMapDeployHappyPath(t *testing.T) {
+	ev, err := mapDeploy([]byte(sampleDeploy), "deploy-1")
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if ev.Kind != "deploy" {
+		t.Errorf("kind = %q, want deploy", ev.Kind)
+	}
+	if ev.SessionID != "deploy:production" {
+		t.Errorf("session_id = %q (must be per-environment)", ev.SessionID)
+	}
+	if ev.ID != "deploy-1" {
+		t.Errorf("id = %q, want deploy-1", ev.ID)
+	}
+	if ev.Actor.Type != "system" || ev.Actor.ID != "alice" {
+		t.Errorf("actor = %+v", ev.Actor)
+	}
+	want := []string{"git:deadbeefcafe1234567890abcdef0123456789ab", "image:sha256:abcdef0123456789"}
+	if len(ev.Refs) != 2 {
+		t.Fatalf("refs = %+v, want 2", ev.Refs)
+	}
+	for i, r := range want {
+		if ev.Refs[i] != r {
+			t.Errorf("refs[%d] = %q, want %q", i, ev.Refs[i], r)
+		}
+	}
+}
+
+func TestMapDeployRejectsMalformed(t *testing.T) {
+	cases := map[string]string{
+		"not json":         `not json`,
+		"missing env":      `{"git_sha":"abc"}`,
+		"no sha or digest": `{"environment":"prod"}`,
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := mapDeploy([]byte(body), ""); err == nil {
+				t.Error("expected error, got nil")
+			}
+		})
+	}
+}
+
+func TestMapDeployFallsBackOnDeployedBy(t *testing.T) {
+	body := `{"environment":"production","git_sha":"abc","status":"succeeded"}`
+	ev, err := mapDeploy([]byte(body), "")
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if ev.Actor.ID != "deploy-system" {
+		t.Errorf("actor.id = %q, want fallback deploy-system", ev.Actor.ID)
+	}
+}
+
+func TestMapDeployImageDigestOnly(t *testing.T) {
+	body := `{"environment":"prod","image_digest":"sha256:1234"}`
+	ev, err := mapDeploy([]byte(body), "")
+	if err != nil {
+		t.Fatalf("map: %v", err)
+	}
+	if len(ev.Refs) != 1 || ev.Refs[0] != "image:sha256:1234" {
+		t.Errorf("refs = %+v", ev.Refs)
+	}
+}
+
+func TestHandlerHappyPath(t *testing.T) {
+	st := store.NewMemory()
+	h := NewHandler(ingest.NewHandler(st))
+
+	rec := deliver(t, h, []byte(sampleDeploy), "deploy-key-1")
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", rec.Code)
+	}
+	events, _ := st.ListBySession(context.Background(), "deploy:production", 0)
+	if len(events) != 1 {
+		t.Fatalf("got %d events, want 1", len(events))
+	}
+	if events[0].ID != "deploy-key-1" {
+		t.Errorf("event id = %q, want idempotency key", events[0].ID)
+	}
+}
+
+func TestHandlerDuplicateIdempotencyKey(t *testing.T) {
+	st := store.NewMemory()
+	h := NewHandler(ingest.NewHandler(st))
+
+	first := deliver(t, h, []byte(sampleDeploy), "deploy-key-dup")
+	if first.Code != http.StatusAccepted {
+		t.Fatalf("first delivery status = %d, want 202", first.Code)
+	}
+	second := deliver(t, h, []byte(sampleDeploy), "deploy-key-dup")
+	if second.Code != http.StatusOK {
+		t.Errorf("duplicate delivery status = %d, want 200", second.Code)
+	}
+	events, _ := st.ListBySession(context.Background(), "deploy:production", 0)
+	if len(events) != 1 {
+		t.Errorf("duplicate created extra events: %d", len(events))
+	}
+}
+
+func TestHandlerRejectsBadPayload(t *testing.T) {
+	st := store.NewMemory()
+	h := NewHandler(ingest.NewHandler(st))
+
+	rec := deliver(t, h, []byte(`{"environment":"prod"}`), "") // no sha/digest
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rec.Code)
+	}
+	events, _ := st.ListBySession(context.Background(), "deploy:prod", 0)
+	if len(events) != 0 {
+		t.Errorf("rejected delivery still appended %d events", len(events))
+	}
+}
+
+func TestHandlerRejectsGet(t *testing.T) {
+	h := NewHandler(ingest.NewHandler(store.NewMemory()))
+	req := httptest.NewRequest(http.MethodGet, "/webhooks/deploy", nil)
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Errorf("status = %d, want 405", rec.Code)
+	}
+}
+
+func TestHandlerLinksDeployToCommitViaSharedRef(t *testing.T) {
+	// End-to-end: a commit lands first; then a deploy with the same git_sha.
+	// EventsByRef must return both for the linker to connect them.
+	st := store.NewMemory()
+	ingestH := ingest.NewHandler(st)
+	h := NewHandler(ingestH)
+
+	commit := &ingest.WireEvent{
+		ID:        "01HCOMMITDEPLOY",
+		SessionID: "git-local",
+		Actor:     ingest.WireActor{Type: "human", ID: "alice"},
+		Kind:      "commit",
+		Refs:      []string{"git:deadbeefcafe1234567890abcdef0123456789ab"},
+	}
+	if err := ingestH.Append(context.Background(), commit); err != nil {
+		t.Fatalf("append commit: %v", err)
+	}
+
+	rec := deliver(t, h, []byte(sampleDeploy), "deploy-link-1")
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d", rec.Code)
+	}
+
+	peers, _ := st.EventsByRef(context.Background(), "git:deadbeefcafe1234567890abcdef0123456789ab")
+	if len(peers) != 2 {
+		t.Errorf("EventsByRef returned %d, want 2 (commit + deploy)", len(peers))
+	}
+	// Sanity: just ensure both fields decode rather than asserting specific JSON.
+	_ = json.RawMessage(peers[1].Payload)
+}

--- a/internal/webhooks/deploy/handler_test.go
+++ b/internal/webhooks/deploy/handler_test.go
@@ -189,3 +189,44 @@ func TestHandlerLinksDeployToCommitViaSharedRef(t *testing.T) {
 	// Sanity: just ensure both fields decode rather than asserting specific JSON.
 	_ = json.RawMessage(peers[1].Payload)
 }
+
+func TestMapDeployRejectsLongEnvironment(t *testing.T) {
+	long := make([]byte, 65)
+	for i := range long {
+		long[i] = 'a'
+	}
+	body := []byte(`{"environment":"` + string(long) + `","git_sha":"abc"}`)
+	if _, err := mapDeploy(body, ""); err == nil {
+		t.Error("expected error for environment > 64 chars")
+	}
+
+	// At the limit (64) is OK.
+	ok := make([]byte, 64)
+	for i := range ok {
+		ok[i] = 'a'
+	}
+	body2 := []byte(`{"environment":"` + string(ok) + `","git_sha":"abc"}`)
+	if _, err := mapDeploy(body2, ""); err != nil {
+		t.Errorf("64-char env rejected: %v", err)
+	}
+}
+
+func TestMapDeployRejectsLongIdempotencyKey(t *testing.T) {
+	long := make([]byte, 129)
+	for i := range long {
+		long[i] = 'k'
+	}
+	body := []byte(`{"environment":"prod","git_sha":"abc"}`)
+	if _, err := mapDeploy(body, string(long)); err == nil {
+		t.Error("expected error for Idempotency-Key > 128 chars")
+	}
+
+	// At the limit (128) is OK.
+	ok := make([]byte, 128)
+	for i := range ok {
+		ok[i] = 'k'
+	}
+	if _, err := mapDeploy(body, string(ok)); err != nil {
+		t.Errorf("128-char key rejected: %v", err)
+	}
+}

--- a/internal/webhooks/deploy/mapper.go
+++ b/internal/webhooks/deploy/mapper.go
@@ -1,0 +1,71 @@
+package deploy
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/dongqiu/agent-lens/internal/ingest"
+)
+
+// payload is the shape /webhooks/deploy accepts. Most fields are
+// optional; the deploy can come from K8s, Argo CD, a Helm post-render
+// hook, or a hand-rolled curl in someone's Makefile, so the schema is
+// deliberately loose. The full body is preserved verbatim in the wire
+// event's payload field for downstream introspection.
+type payload struct {
+	Environment string    `json:"environment"`
+	GitSHA      string    `json:"git_sha"`
+	ImageDigest string    `json:"image_digest"`
+	Image       string    `json:"image"`
+	Status      string    `json:"status"`
+	StartedAt   time.Time `json:"started_at"`
+	FinishedAt  time.Time `json:"finished_at"`
+	DeployedBy  string    `json:"deployed_by"`
+	Platform    string    `json:"platform"`
+	Cluster     string    `json:"cluster"`
+	Namespace   string    `json:"namespace"`
+}
+
+// mapDeploy parses the body, derives session_id / actor / refs, and
+// returns a wire event ready for ingest. eventID is the optional
+// Idempotency-Key header value; empty falls back to a server-assigned
+// ULID and the call won't be deduplicated.
+func mapDeploy(raw json.RawMessage, eventID string) (*ingest.WireEvent, error) {
+	var p payload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return nil, fmt.Errorf("decode deploy: %w", err)
+	}
+	if p.Environment == "" {
+		return nil, fmt.Errorf("deploy missing required field: environment")
+	}
+	if p.GitSHA == "" && p.ImageDigest == "" {
+		return nil, fmt.Errorf("deploy must include at least one of git_sha or image_digest")
+	}
+
+	actorID := p.DeployedBy
+	if actorID == "" {
+		actorID = "deploy-system"
+	}
+
+	var refs []string
+	if p.GitSHA != "" {
+		refs = append(refs, "git:"+p.GitSHA)
+	}
+	if p.ImageDigest != "" {
+		refs = append(refs, "image:"+p.ImageDigest)
+	}
+
+	return &ingest.WireEvent{
+		ID:        eventID,
+		TS:        time.Now().UTC(),
+		SessionID: fmt.Sprintf("deploy:%s", p.Environment),
+		Actor: ingest.WireActor{
+			Type: "system",
+			ID:   actorID,
+		},
+		Kind:    "deploy",
+		Payload: raw,
+		Refs:    refs,
+	}, nil
+}

--- a/internal/webhooks/deploy/mapper.go
+++ b/internal/webhooks/deploy/mapper.go
@@ -27,6 +27,16 @@ type payload struct {
 	Namespace   string    `json:"namespace"`
 }
 
+// maxEnvironmentLen caps the environment string so an absurdly long
+// payload can't blow up the session_id (used in URLs, logs, the UI
+// dropdown). Realistic env names are <32 chars; 64 is generous.
+const maxEnvironmentLen = 64
+
+// maxIdempotencyKeyLen caps the Idempotency-Key header so an attacker
+// can't smuggle a multi-MB key into the events.id column. ULIDs are
+// 26 chars, UUIDs are 36; 128 is comfortable headroom.
+const maxIdempotencyKeyLen = 128
+
 // mapDeploy parses the body, derives session_id / actor / refs, and
 // returns a wire event ready for ingest. eventID is the optional
 // Idempotency-Key header value; empty falls back to a server-assigned
@@ -38,6 +48,12 @@ func mapDeploy(raw json.RawMessage, eventID string) (*ingest.WireEvent, error) {
 	}
 	if p.Environment == "" {
 		return nil, fmt.Errorf("deploy missing required field: environment")
+	}
+	if len(p.Environment) > maxEnvironmentLen {
+		return nil, fmt.Errorf("deploy environment too long (got %d, max %d)", len(p.Environment), maxEnvironmentLen)
+	}
+	if len(eventID) > maxIdempotencyKeyLen {
+		return nil, fmt.Errorf("Idempotency-Key too long (got %d, max %d)", len(eventID), maxIdempotencyKeyLen)
 	}
 	if p.GitSHA == "" && p.ImageDigest == "" {
 		return nil, fmt.Errorf("deploy must include at least one of git_sha or image_digest")

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -110,6 +110,17 @@ function summarize(event: Event): string {
       if (commits > 0) parts.push(`${commits} commit${commits === 1 ? "" : "s"}`);
       return parts.join(" · ");
     }
+    case "DEPLOY": {
+      const env = asString(p.environment);
+      const status = asString(p.status);
+      const platform = asString(p.platform);
+      const sha = asString(p.git_sha).slice(0, 7);
+      const parts = [env].filter(Boolean);
+      if (status) parts.push(status);
+      if (sha) parts.push(sha);
+      if (platform) parts.push(platform);
+      return parts.join(" · ");
+    }
     case "BUILD": {
       // Two payload shapes: workflow_run webhook (nested workflow_run
       // object) vs. composite-action (flat fields with source flag).


### PR DESCRIPTION
## Summary

First slice of M3 work to land. With PR, push, build (M2-A/B/C/D), and now deploy events on the same chain, the trace from \"Claude prompt\" through to \"prod deploy\" is end-to-end. SPEC §14 M3 first-line requirement.

## Wire format

Generic JSON shape — no per-system parsers, no Argo or K8s-specific code paths. Adapters for those systems live in user-controlled glue (curl in a post-deploy job, ApplicationSync notification template, etc.).

\`\`\`json
{
  \"environment\": \"production\",
  \"git_sha\": \"deadbeef...\",
  \"image_digest\": \"sha256:abcdef...\",
  \"image\": \"ghcr.io/acme/widget\",
  \"status\": \"succeeded\",
  \"deployed_by\": \"alice\",
  \"platform\": \"k8s\",
  \"cluster\": \"prod-us-east\",
  \"namespace\": \"default\"
}
\`\`\`

| Field | Required | Effect |
|---|---|---|
| \`environment\` | ✅ | session_id is \`deploy:<environment>\` |
| \`git_sha\` or \`image_digest\` | ≥1 | refs entry (\`git:<sha>\` and/or \`image:<digest>\`) for linking |
| `Idempotency-Key` header | recommended | server uses it as wire event id; redelivery → 200 dedup |

## Auth

\`/webhooks/deploy\` is gated by \`AGENT_LENS_DEPLOY_WEBHOOK_TOKEN\` (separate from \`AGENT_LENS_TOKEN\`) so a deploy system gets a write-only credential with no /v1 read access. Endpoint always mounted; returns 503 with an actionable message when the token is unset, matching the github webhook pattern.

## End-to-end

1. Claude Code session writes commits → local hook emits \`commit\` events.
2. PR opens → GitHub webhook emits \`pr\` (M2-A).
3. CI runs → GitHub webhook emits \`build\` lifecycle (M2-C-1) AND composite Action emits \`build\` with artifact hashes (M2-C-2).
4. Deploy fires → this PR's webhook emits \`deploy\` event into \`deploy:production\`.
5. Linker writes \`references\` links across all five sessions via shared \`git:<sha>\` refs.

## Test plan

- [x] 9 tests in \`internal/webhooks/deploy\`: happy path, malformed/missing-field rejection, deployed_by fallback, image-digest-only refs, dispatch, idempotency dedup, bad payload 400, GET 405, end-to-end shared-ref linking via store.EventsByRef.
- [x] \`go test -race ./...\` green.
- [x] \`pnpm build\` green.
- [ ] CI green on this PR.

## UI

EventCard summary for DEPLOY: \`<env> · <status> · <sha7> · <platform>\` (e.g. \`production · succeeded · deadbee · k8s\`).

## Out of scope

- **Argo / K8s system-specific parsers**: deferred until generic shape proves insufficient. Most users will write a 5-line curl glue.
- **HMAC signing**: bearer token only for v0. Argo doesn't sign, K8s post-deploy jobs don't either; HMAC would be deferred until a system that does it ships.
- **Image-digest peer linking**: \`refs[image:<digest>]\` is recorded but no other event currently emits image refs (composite Action does artifact paths). Filing as follow-up if it becomes useful.

Tracks: M3-A. Refs: SPEC §14 M3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)