### PR TITLE
feat(attest): DSSE + ed25519 signing infrastructure (M3-B-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,27 @@ make web-build         # TS 类型检查 + Vite 打包
 
 Stop hook 会读 `transcript_path` 提取 `thinking` / `text` content blocks（仅当本轮启用 extended thinking 时有 thinking）。HTTP 失败时回落 `~/.agent-lens/sessions/<sid>.ndjson` 文件 sink。
 
+## Attestation 签名密钥（M3-B-1）
+
+为后续导出 in-toto / SLSA attestation 准备本地 ed25519 密钥：
+
+```bash
+agent-lens-hook keygen
+# 默认写到 $HOME/.agent-lens/keys/ed25519 (私钥, 0600) + .pub (公钥, 0644)
+# PEM-encoded (PKCS#8 / PKIX)，cosign 和 openssl 都能读
+```
+
+`--out <path>` 可改路径。**拒绝覆盖已有文件**——轮换密钥写到新路径，避免在生产管道里悄悄抹掉私钥。
+
+`internal/attest` 包提供 `Sign` / `Verify` 走 DSSE envelope（`https://github.com/secure-systems-lab/dsse`），ed25519 走 stdlib。Sigstore（Fulcio + Rekor）网络签名作为后续可选项，与现有 API 同接口、按 flag 切换；M3-B-1 只做离线密钥这条腿。
+
+预算用法：
+- `agent-lens-hook export code-provenance` → in-toto Statement，predicateType `agent-lens.dev/code-provenance/v1`
+- `agent-lens-hook export slsa-build` → 标准 SLSA Build Track v1
+- `agent-lens-hook export deploy-evidence` → predicateType `agent-lens.dev/deploy-evidence/v1`
+
+每条命令产出一个 DSSE 信封 `.intoto.jsonl`，cosign 兼容。Predicate 里只放 thinking / prompt 的 sha256 + 200 字预览 + token 数；全文留 agent-lens 存储里——签了就难撤回，敏感内容上链得万分谨慎。
+
 ## 校验哈希链
 
 ```bash

--- a/cmd/agent-lens-hook/keygen.go
+++ b/cmd/agent-lens-hook/keygen.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/dongqiu/agent-lens/internal/attest"
+)
+
+const keygenUsage = `agent-lens-hook keygen — generate an ed25519 key pair for
+in-toto / DSSE attestations.
+
+  agent-lens-hook keygen [--out <path>]
+
+Writes <path> (private key, mode 0600) and <path>.pub (public key, mode
+0644). Default <path> is $HOME/.agent-lens/keys/ed25519. Both files are
+PEM-encoded (PKCS#8 / PKIX) so cosign and openssl can read them.
+
+Refuses to overwrite an existing file. Rotate by writing to a new path
+and updating callers; silent overwrite of a private key would be a
+footgun in a deploy pipeline.
+`
+
+func runKeygen(args []string) {
+	fs := flag.NewFlagSet("keygen", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	out := fs.String("out", "", "output path (default $HOME/.agent-lens/keys/ed25519)")
+	fs.Usage = func() { fmt.Fprint(os.Stderr, keygenUsage) }
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+
+	path := *out
+	if path == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "agent-lens-hook keygen: %v\n", err)
+			os.Exit(2)
+		}
+		path = filepath.Join(home, ".agent-lens", "keys", "ed25519")
+	}
+
+	priv, _, err := attest.GenerateKey()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "agent-lens-hook keygen: generate: %v\n", err)
+		os.Exit(1)
+	}
+	if err := attest.SaveKeyPair(path, priv); err != nil {
+		fmt.Fprintf(os.Stderr, "agent-lens-hook keygen: save: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("ed25519 key written\n  private: %s (mode 0600)\n  public:  %s.pub (mode 0644)\n  key id:  %s\n",
+		path, path, priv.KeyID)
+}

--- a/cmd/agent-lens-hook/main.go
+++ b/cmd/agent-lens-hook/main.go
@@ -14,6 +14,7 @@ Subcommands:
   claude            Capture a Claude Code hook payload from stdin and forward.
   git-post-commit   Capture a git post-commit event and forward.
   verify            Verify the local hash chain of a session.
+  keygen            Generate an ed25519 key pair for DSSE attestations.
   export            Export an in-toto / SLSA attestation for a trace.
 
 Environment:
@@ -33,6 +34,8 @@ func main() {
 		runGitPostCommit(os.Args[2:])
 	case "verify":
 		runVerify(os.Args[2:])
+	case "keygen":
+		runKeygen(os.Args[2:])
 	case "export":
 		runExport(os.Args[2:])
 	case "-h", "--help", "help":

--- a/internal/attest/dsse.go
+++ b/internal/attest/dsse.go
@@ -1,0 +1,115 @@
+// Package attest implements Dead Simple Signing Envelope (DSSE) sign/verify
+// over local ed25519 keys for in-toto attestations. v0 supports local key
+// files only; Sigstore (Fulcio / Rekor) network signing is a future option
+// that can plug into the same Sign / Verify API.
+//
+// DSSE wire format: https://github.com/secure-systems-lab/dsse
+package attest
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+// Envelope is the DSSE envelope serialized to/from JSON.
+type Envelope struct {
+	PayloadType string      `json:"payloadType"`
+	Payload     string      `json:"payload"` // base64
+	Signatures  []Signature `json:"signatures"`
+}
+
+// Signature carries one signer's bytes and an optional key id (sha256
+// prefix of the public key by convention).
+type Signature struct {
+	KeyID string `json:"keyid,omitempty"`
+	Sig   string `json:"sig"` // base64
+}
+
+// pae implements DSSE Pre-Authentication Encoding:
+//
+//	"DSSEv1" SP LEN(type) SP type SP LEN(payload) SP payload
+//
+// Hand-written rather than via a library so the spec is auditable in
+// one function and we don't add transitive deps for a 10-line algo.
+func pae(payloadType string, payload []byte) []byte {
+	var buf bytes.Buffer
+	buf.WriteString("DSSEv1 ")
+	buf.WriteString(strconv.Itoa(len(payloadType)))
+	buf.WriteByte(' ')
+	buf.WriteString(payloadType)
+	buf.WriteByte(' ')
+	buf.WriteString(strconv.Itoa(len(payload)))
+	buf.WriteByte(' ')
+	buf.Write(payload)
+	return buf.Bytes()
+}
+
+// Sign returns a DSSE envelope wrapping payload with one ed25519 signature.
+// payloadType identifies what the payload is (e.g.
+// "application/vnd.in-toto+json").
+func Sign(priv *PrivateKey, payloadType string, payload []byte) (*Envelope, error) {
+	if priv == nil {
+		return nil, errors.New("nil private key")
+	}
+	if payloadType == "" {
+		return nil, errors.New("empty payload type")
+	}
+	msg := pae(payloadType, payload)
+	sig := ed25519.Sign(priv.Key, msg)
+	return &Envelope{
+		PayloadType: payloadType,
+		Payload:     base64.StdEncoding.EncodeToString(payload),
+		Signatures: []Signature{
+			{KeyID: priv.KeyID, Sig: base64.StdEncoding.EncodeToString(sig)},
+		},
+	}, nil
+}
+
+// Verify checks the envelope's signatures against pub. On success it
+// returns the decoded payload bytes and the envelope's payloadType.
+//
+// Multiple signatures: any signature matching pub validates the
+// envelope. Mismatched key ids are skipped (not an error) so a multi-
+// signed envelope verifies under each individual key.
+func Verify(pub *PublicKey, env *Envelope) ([]byte, string, error) {
+	if pub == nil {
+		return nil, "", errors.New("nil public key")
+	}
+	if env == nil {
+		return nil, "", errors.New("nil envelope")
+	}
+	if len(env.Signatures) == 0 {
+		return nil, "", errors.New("envelope has no signatures")
+	}
+	payload, err := base64.StdEncoding.DecodeString(env.Payload)
+	if err != nil {
+		return nil, "", fmt.Errorf("decode payload: %w", err)
+	}
+	msg := pae(env.PayloadType, payload)
+	for _, s := range env.Signatures {
+		if pub.KeyID != "" && s.KeyID != "" && s.KeyID != pub.KeyID {
+			continue
+		}
+		sig, err := base64.StdEncoding.DecodeString(s.Sig)
+		if err != nil {
+			continue
+		}
+		if ed25519.Verify(pub.Key, msg, sig) {
+			return payload, env.PayloadType, nil
+		}
+	}
+	return nil, "", errors.New("no valid signature for the provided public key")
+}
+
+// keyIDFor returns sha256(pubBytes)[:8] hex-encoded — a deterministic
+// 16-char short identifier used in Signature.keyid and key file naming.
+func keyIDFor(pub ed25519.PublicKey) string {
+	sum := sha256.Sum256(pub)
+	return hex.EncodeToString(sum[:8])
+}

--- a/internal/attest/dsse.go
+++ b/internal/attest/dsse.go
@@ -53,12 +53,20 @@ func pae(payloadType string, payload []byte) []byte {
 // Sign returns a DSSE envelope wrapping payload with one ed25519 signature.
 // payloadType identifies what the payload is (e.g.
 // "application/vnd.in-toto+json").
+//
+// Empty payloads are rejected: an attestation over zero bytes is a
+// degenerate case that no legitimate caller wants, and accepting it
+// would let an attacker forge a "valid" envelope whose payload reads
+// as nothing.
 func Sign(priv *PrivateKey, payloadType string, payload []byte) (*Envelope, error) {
 	if priv == nil {
 		return nil, errors.New("nil private key")
 	}
 	if payloadType == "" {
 		return nil, errors.New("empty payload type")
+	}
+	if len(payload) == 0 {
+		return nil, errors.New("empty payload")
 	}
 	msg := pae(payloadType, payload)
 	sig := ed25519.Sign(priv.Key, msg)
@@ -77,6 +85,12 @@ func Sign(priv *PrivateKey, payloadType string, payload []byte) (*Envelope, erro
 // Multiple signatures: any signature matching pub validates the
 // envelope. Mismatched key ids are skipped (not an error) so a multi-
 // signed envelope verifies under each individual key.
+//
+// Errors distinguish "wrong key file" from "signature didn't match":
+//   - if no signature in the envelope shares pub's keyid, the error
+//     names the missing keyid (operator likely supplied the wrong .pub)
+//   - if a keyid matched but the signature bytes failed verification,
+//     the error says so (envelope is corrupt or tampered)
 func Verify(pub *PublicKey, env *Envelope) ([]byte, string, error) {
 	if pub == nil {
 		return nil, "", errors.New("nil public key")
@@ -91,11 +105,17 @@ func Verify(pub *PublicKey, env *Envelope) ([]byte, string, error) {
 	if err != nil {
 		return nil, "", fmt.Errorf("decode payload: %w", err)
 	}
+	if len(payload) == 0 {
+		return nil, "", errors.New("envelope payload is empty")
+	}
+
 	msg := pae(env.PayloadType, payload)
+	matchedKeyID := false
 	for _, s := range env.Signatures {
 		if pub.KeyID != "" && s.KeyID != "" && s.KeyID != pub.KeyID {
 			continue
 		}
+		matchedKeyID = true
 		sig, err := base64.StdEncoding.DecodeString(s.Sig)
 		if err != nil {
 			continue
@@ -104,7 +124,10 @@ func Verify(pub *PublicKey, env *Envelope) ([]byte, string, error) {
 			return payload, env.PayloadType, nil
 		}
 	}
-	return nil, "", errors.New("no valid signature for the provided public key")
+	if !matchedKeyID {
+		return nil, "", fmt.Errorf("no signature with keyid %q in envelope", pub.KeyID)
+	}
+	return nil, "", errors.New("signature(s) for matching keyid did not verify against the public key")
 }
 
 // keyIDFor returns sha256(pubBytes)[:8] hex-encoded — a deterministic

--- a/internal/attest/dsse_test.go
+++ b/internal/attest/dsse_test.go
@@ -1,0 +1,124 @@
+package attest
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSignVerifyRoundTrip(t *testing.T) {
+	priv, pub, err := GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := []byte(`{"hello":"world"}`)
+
+	env, err := Sign(priv, "application/vnd.in-toto+json", payload)
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	if len(env.Signatures) != 1 {
+		t.Fatalf("signatures = %d, want 1", len(env.Signatures))
+	}
+	if env.Signatures[0].KeyID != priv.KeyID {
+		t.Errorf("keyid = %q, want %q", env.Signatures[0].KeyID, priv.KeyID)
+	}
+
+	got, gotType, err := Verify(pub, env)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("payload mismatch: got %q want %q", got, payload)
+	}
+	if gotType != "application/vnd.in-toto+json" {
+		t.Errorf("payloadType = %q", gotType)
+	}
+}
+
+func TestVerifyRejectsTamperedPayload(t *testing.T) {
+	priv, pub, _ := GenerateKey()
+	env, _ := Sign(priv, "application/json", []byte(`{"a":1}`))
+
+	env.Payload = base64.StdEncoding.EncodeToString([]byte(`{"a":2}`))
+	if _, _, err := Verify(pub, env); err == nil {
+		t.Error("verify accepted tampered payload")
+	}
+}
+
+func TestVerifyRejectsTamperedType(t *testing.T) {
+	priv, pub, _ := GenerateKey()
+	env, _ := Sign(priv, "application/json", []byte(`{}`))
+
+	env.PayloadType = "application/x-evil"
+	if _, _, err := Verify(pub, env); err == nil {
+		t.Error("verify accepted tampered payloadType (PAE should bind it)")
+	}
+}
+
+func TestVerifyRejectsWrongKey(t *testing.T) {
+	priv, _, _ := GenerateKey()
+	_, otherPub, _ := GenerateKey()
+	env, _ := Sign(priv, "application/json", []byte(`{}`))
+	if _, _, err := Verify(otherPub, env); err == nil {
+		t.Error("verify accepted signature made by a different key")
+	}
+}
+
+func TestVerifyRejectsEmptyEnvelope(t *testing.T) {
+	_, pub, _ := GenerateKey()
+	cases := []*Envelope{
+		nil,
+		{},
+		{PayloadType: "x", Payload: "Zm9v"},
+	}
+	for i, env := range cases {
+		if _, _, err := Verify(pub, env); err == nil {
+			t.Errorf("case %d: verify accepted invalid envelope", i)
+		}
+	}
+}
+
+func TestSignRejectsNilOrEmpty(t *testing.T) {
+	priv, _, _ := GenerateKey()
+	if _, err := Sign(nil, "x", []byte(`{}`)); err == nil {
+		t.Error("Sign accepted nil priv")
+	}
+	if _, err := Sign(priv, "", []byte(`{}`)); err == nil {
+		t.Error("Sign accepted empty payloadType")
+	}
+}
+
+func TestEnvelopeJSONRoundTrip(t *testing.T) {
+	priv, pub, _ := GenerateKey()
+	env, _ := Sign(priv, "application/vnd.in-toto+json", []byte(`{"x":1}`))
+
+	raw, err := json.Marshal(env)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(raw), `"payloadType"`) {
+		t.Errorf("envelope JSON missing payloadType: %s", raw)
+	}
+
+	var parsed Envelope
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if _, _, err := Verify(pub, &parsed); err != nil {
+		t.Errorf("verify after json round-trip: %v", err)
+	}
+}
+
+func TestPAEDistinguishesType(t *testing.T) {
+	// The whole point of PAE: signing ("a", "bc") must differ from
+	// signing ("ab", "c"). Otherwise an attacker could swap type and
+	// payload bytes without breaking the signature.
+	a := pae("a", []byte("bc"))
+	b := pae("ab", []byte("c"))
+	if bytes.Equal(a, b) {
+		t.Errorf("PAE collision:\n  a = %q\n  b = %q", a, b)
+	}
+}

--- a/internal/attest/dsse_test.go
+++ b/internal/attest/dsse_test.go
@@ -2,11 +2,16 @@ package attest
 
 import (
 	"bytes"
+	"crypto/ed25519"
 	"encoding/base64"
 	"encoding/json"
 	"strings"
 	"testing"
 )
+
+func edSignForTest(priv *PrivateKey, msg []byte) []byte {
+	return ed25519.Sign(priv.Key, msg)
+}
 
 func TestSignVerifyRoundTrip(t *testing.T) {
 	priv, pub, err := GenerateKey()
@@ -120,5 +125,61 @@ func TestPAEDistinguishesType(t *testing.T) {
 	b := pae("ab", []byte("c"))
 	if bytes.Equal(a, b) {
 		t.Errorf("PAE collision:\n  a = %q\n  b = %q", a, b)
+	}
+}
+
+func TestVerifyDistinguishesKeyIDMismatchFromBadSignature(t *testing.T) {
+	priv, pub, _ := GenerateKey()
+
+	// Tampered payload, key matches → "did not verify"
+	env, _ := Sign(priv, "application/json", []byte(`{"a":1}`))
+	env.Payload = base64.StdEncoding.EncodeToString([]byte(`{"a":2}`))
+	_, _, err := Verify(pub, env)
+	if err == nil {
+		t.Fatal("expected error for tampered payload")
+	}
+	if !strings.Contains(err.Error(), "did not verify") {
+		t.Errorf("tampered-payload error = %q, want contains %q", err, "did not verify")
+	}
+
+	// Wrong key, keyid mismatch → "no signature with keyid"
+	_, otherPub, _ := GenerateKey()
+	env2, _ := Sign(priv, "application/json", []byte(`{"a":1}`))
+	_, _, err = Verify(otherPub, env2)
+	if err == nil {
+		t.Fatal("expected error for wrong key")
+	}
+	if !strings.Contains(err.Error(), "no signature with keyid") {
+		t.Errorf("wrong-key error = %q, want contains %q", err, "no signature with keyid")
+	}
+}
+
+func TestSignRejectsEmptyPayload(t *testing.T) {
+	priv, _, _ := GenerateKey()
+	if _, err := Sign(priv, "application/json", nil); err == nil {
+		t.Error("Sign accepted nil payload")
+	}
+	if _, err := Sign(priv, "application/json", []byte{}); err == nil {
+		t.Error("Sign accepted empty []byte payload")
+	}
+}
+
+func TestVerifyRejectsEmptyPayload(t *testing.T) {
+	// Bypass Sign by hand-crafting an envelope with an empty payload
+	// and a real signature over the empty PAE — proves Verify rejects
+	// the degenerate case at the envelope layer too, not just by
+	// coincidence of Sign refusing to produce one.
+	priv, pub, _ := GenerateKey()
+	emptyMsg := pae("application/json", []byte{})
+	sig := edSignForTest(priv, emptyMsg)
+	env := &Envelope{
+		PayloadType: "application/json",
+		Payload:     "",
+		Signatures: []Signature{
+			{KeyID: priv.KeyID, Sig: base64.StdEncoding.EncodeToString(sig)},
+		},
+	}
+	if _, _, err := Verify(pub, env); err == nil {
+		t.Error("Verify accepted envelope with empty payload")
 	}
 }

--- a/internal/attest/key.go
+++ b/internal/attest/key.go
@@ -1,0 +1,151 @@
+package attest
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// PrivateKey wraps an ed25519 private key with its short KeyID.
+type PrivateKey struct {
+	Key   ed25519.PrivateKey
+	KeyID string
+}
+
+// PublicKey wraps an ed25519 public key with its short KeyID.
+type PublicKey struct {
+	Key   ed25519.PublicKey
+	KeyID string
+}
+
+const (
+	pemTypePrivate = "PRIVATE KEY"
+	pemTypePublic  = "PUBLIC KEY"
+)
+
+// GenerateKey returns a fresh ed25519 key pair sharing the same
+// deterministic short KeyID.
+func GenerateKey() (*PrivateKey, *PublicKey, error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	id := keyIDFor(pub)
+	return &PrivateKey{Key: priv, KeyID: id}, &PublicKey{Key: pub, KeyID: id}, nil
+}
+
+// SaveKeyPair writes the private half of priv to path (mode 0600) and
+// the matching public half to path+".pub" (mode 0644). Both files are
+// PEM-encoded (PKCS#8 / PKIX) so cosign and openssl can read them.
+//
+// Refuses to overwrite either file. Rotate by writing to a new path;
+// silent overwrite of a private key would be a footgun in a deploy
+// pipeline.
+func SaveKeyPair(path string, priv *PrivateKey) error {
+	if priv == nil {
+		return errors.New("nil private key")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+
+	privPEM, err := encodePrivatePEM(priv.Key)
+	if err != nil {
+		return err
+	}
+	if err := writeNewFile(path, 0o600, privPEM); err != nil {
+		return err
+	}
+
+	pub := priv.Key.Public().(ed25519.PublicKey)
+	pubPEM, err := encodePublicPEM(pub)
+	if err != nil {
+		_ = os.Remove(path) // roll back the private file we just wrote
+		return err
+	}
+	if err := writeNewFile(path+".pub", 0o644, pubPEM); err != nil {
+		_ = os.Remove(path)
+		return err
+	}
+	return nil
+}
+
+// LoadPrivateKey reads a PEM-encoded ed25519 private key (PKCS#8) from
+// path. Returns an error if the file isn't a PEM block or the parsed
+// key isn't ed25519.
+func LoadPrivateKey(path string) (*PrivateKey, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		return nil, errors.New("not a PEM file")
+	}
+	parsed, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse private key: %w", err)
+	}
+	priv, ok := parsed.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("not an ed25519 key (got %T)", parsed)
+	}
+	pub := priv.Public().(ed25519.PublicKey)
+	return &PrivateKey{Key: priv, KeyID: keyIDFor(pub)}, nil
+}
+
+// LoadPublicKey reads a PEM-encoded ed25519 public key (PKIX) from path.
+func LoadPublicKey(path string) (*PublicKey, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	block, _ := pem.Decode(raw)
+	if block == nil {
+		return nil, errors.New("not a PEM file")
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse public key: %w", err)
+	}
+	pub, ok := parsed.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("not an ed25519 key (got %T)", parsed)
+	}
+	return &PublicKey{Key: pub, KeyID: keyIDFor(pub)}, nil
+}
+
+func encodePrivatePEM(priv ed25519.PrivateKey) ([]byte, error) {
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, fmt.Errorf("marshal private key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: pemTypePrivate, Bytes: der}), nil
+}
+
+func encodePublicPEM(pub ed25519.PublicKey) ([]byte, error) {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, fmt.Errorf("marshal public key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: pemTypePublic, Bytes: der}), nil
+}
+
+// writeNewFile creates path with mode and writes data. Refuses to
+// overwrite an existing file.
+func writeNewFile(path string, mode os.FileMode, data []byte) error {
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", path, err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return f.Close()
+}

--- a/internal/attest/key_test.go
+++ b/internal/attest/key_test.go
@@ -1,0 +1,128 @@
+package attest
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestSaveLoadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ed25519")
+
+	priv, pub, err := GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := SaveKeyPair(path, priv); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loadedPriv, err := LoadPrivateKey(path)
+	if err != nil {
+		t.Fatalf("load private: %v", err)
+	}
+	if !bytes.Equal(loadedPriv.Key, priv.Key) {
+		t.Error("loaded private key bytes differ from saved")
+	}
+	if loadedPriv.KeyID != priv.KeyID {
+		t.Errorf("loaded private KeyID = %q, want %q", loadedPriv.KeyID, priv.KeyID)
+	}
+
+	loadedPub, err := LoadPublicKey(path + ".pub")
+	if err != nil {
+		t.Fatalf("load public: %v", err)
+	}
+	if !bytes.Equal(loadedPub.Key, pub.Key) {
+		t.Error("loaded public key bytes differ from generated")
+	}
+}
+
+func TestSaveRefusesOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ed25519")
+	priv, _, _ := GenerateKey()
+	if err := SaveKeyPair(path, priv); err != nil {
+		t.Fatalf("first save: %v", err)
+	}
+	if err := SaveKeyPair(path, priv); err == nil {
+		t.Error("second save should refuse to overwrite existing private key")
+	}
+}
+
+func TestKeyIDIsDeterministicAndShort(t *testing.T) {
+	priv, pub, _ := GenerateKey()
+	if priv.KeyID != pub.KeyID {
+		t.Errorf("priv/pub KeyID mismatch: %q vs %q", priv.KeyID, pub.KeyID)
+	}
+	if len(priv.KeyID) != 16 {
+		t.Errorf("KeyID len = %d, want 16 (8 bytes hex)", len(priv.KeyID))
+	}
+	again := keyIDFor(pub.Key)
+	if again != pub.KeyID {
+		t.Errorf("keyIDFor not deterministic: %q vs %q", again, pub.KeyID)
+	}
+}
+
+func TestSavedFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("file mode bits don't match POSIX semantics on Windows")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ed25519")
+	priv, _, _ := GenerateKey()
+	if err := SaveKeyPair(path, priv); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("private key mode = %o, want 0600", info.Mode().Perm())
+	}
+	info, err = os.Stat(path + ".pub")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o644 {
+		t.Errorf("public key mode = %o, want 0644", info.Mode().Perm())
+	}
+}
+
+func TestLoadRejectsNonPEM(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "garbage")
+	if err := os.WriteFile(path, []byte("this is not a PEM file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadPrivateKey(path); err == nil {
+		t.Error("LoadPrivateKey accepted non-PEM input")
+	}
+	if _, err := LoadPublicKey(path); err == nil {
+		t.Error("LoadPublicKey accepted non-PEM input")
+	}
+}
+
+func TestPEMOutputIsCosignReadable(t *testing.T) {
+	// Sanity: the bytes we write are valid PEM with the expected
+	// header. cosign / openssl readability is implied by using
+	// PKCS#8 / PKIX standard encodings.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ed25519")
+	priv, _, _ := GenerateKey()
+	if err := SaveKeyPair(path, priv); err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(path)
+	if !bytes.HasPrefix(raw, []byte("-----BEGIN PRIVATE KEY-----")) {
+		t.Errorf("private PEM missing standard header:\n%s", raw)
+	}
+	raw, _ = os.ReadFile(path + ".pub")
+	if !bytes.HasPrefix(raw, []byte("-----BEGIN PUBLIC KEY-----")) {
+		t.Errorf("public PEM missing standard header:\n%s", raw)
+	}
+}


### PR DESCRIPTION
## Summary

First slice of M3-B. Lands the signing primitive that the next three slices build on:
- M3-B-2: \`agent-lens.dev/code-provenance/v1\` predicate
- M3-B-3: \`slsa.dev/provenance/v1\` (build) predicate
- M3-B-4: \`agent-lens.dev/deploy-evidence/v1\` predicate

This PR is **only** the base — no predicate generation, no \`export\` subcommand. Pure DSSE envelope + ed25519 keygen / save / load / sign / verify, plus the \`keygen\` CLI for operators to lay down a key file.

## Design choices (already discussed; pinning here)

- **Stdlib + hand-rolled DSSE** (~110 lines) over pulling in \`sigstore-go\`. For offline ed25519 the spec is auditable in one file with no transitive deps. \`sigstore-go\` becomes worth the bloat when we add the optional Sigstore network-signing path later — same Sign / Verify API, opt-in via flag.
- **PEM output** (PKCS#8 private + PKIX public) so cosign and openssl can read the keys. \`-----BEGIN PRIVATE KEY-----\` / \`-----BEGIN PUBLIC KEY-----\` standard headers verified by tests.
- **KeyID** = \`sha256(pub)[:8]\` hex (16 chars). Deterministic, short, embedded in \`Signature.keyid\` for multi-signer disambiguation.
- **\`SaveKeyPair\` refuses to overwrite.** Rotation = new path. Silent overwrite of a private key in a deploy pipeline would be a footgun.
- **Default key path** \`\$HOME/.agent-lens/keys/ed25519\` + \`.pub\`. Configurable via \`--out\`.

## What this PR delivers

\`\`\`
agent-lens-hook keygen [--out <path>]
\`\`\`

\`\`\`go
import \"github.com/dongqiu/agent-lens/internal/attest\"

priv, pub, _ := attest.GenerateKey()
env, _ := attest.Sign(priv, \"application/vnd.in-toto+json\", payload)
got, gotType, err := attest.Verify(pub, env)
\`\`\`

## Test plan

- [x] 15 tests across \`internal/attest\` covering: sign/verify round-trip, tampered payload rejected, tampered payloadType rejected (PAE binding test), wrong-key rejected, empty/nil envelope handling, Sign nil/empty rejection, JSON round-trip preserves verifiability, PAE no-collision invariant, save/load round-trip, refuse-overwrite, KeyID determinism, file mode 0600/0644 (skipped on Windows), non-PEM rejection, PEM-header standardness.
- [x] Real binary smoke: \`agent-lens-hook keygen\` writes keys with the right modes / PEM headers / 16-char key id.
- [x] \`go test -race ./...\` green across 13 packages.
- [ ] CI green on this PR.

## Out of scope (M3-B-2/3/4)

- Predicate generation for code-provenance / slsa-build / deploy-evidence
- \`export\` subcommand wiring
- Trace assembly from store events
- cosign verify-attestation tutorial
- Sigstore (Fulcio + Rekor) network signing — same API surface, opt-in later

Tracks: M3-B-1. Refs: SPEC §11, §14 M3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)