### PR TITLE
feat(attest): code-provenance predicate + export CLI (M3-B-2)

### DIFF
--- a/cmd/agent-lens-hook/export.go
+++ b/cmd/agent-lens-hook/export.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dongqiu/agent-lens/internal/attest"
+)
+
+const exportUsage = `agent-lens-hook export — export an in-toto / SLSA attestation
+for a stage boundary.
+
+Usage:
+  agent-lens-hook export <kind> [flags]
+
+Kinds:
+  code-provenance   agent-lens.dev/code-provenance/v1 (commit boundary)
+  slsa-build        slsa.dev/provenance/v1 (build boundary; M3-B-3)
+  deploy-evidence   agent-lens.dev/deploy-evidence/v1 (deploy boundary; M3-B-4)
+`
+
+func runExport(args []string) {
+	if len(args) < 1 || args[0] == "-h" || args[0] == "--help" || args[0] == "help" {
+		fmt.Fprint(os.Stderr, exportUsage)
+		if len(args) < 1 {
+			os.Exit(2)
+		}
+		return
+	}
+	switch args[0] {
+	case "code-provenance":
+		if err := exportCodeProvenance(args[1:], os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "agent-lens-hook export code-provenance: %v\n", err)
+			os.Exit(1)
+		}
+	case "slsa-build":
+		fmt.Fprintln(os.Stderr, "TODO: slsa-build (M3-B-3)")
+		os.Exit(1)
+	case "deploy-evidence":
+		fmt.Fprintln(os.Stderr, "TODO: deploy-evidence (M3-B-4)")
+		os.Exit(1)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown export kind: %s\n\n%s", args[0], exportUsage)
+		os.Exit(2)
+	}
+}
+
+const codeProvenanceUsage = `agent-lens-hook export code-provenance — sign an
+in-toto Statement asserting which Claude Code session events
+contributed to a git commit.
+
+Usage:
+  agent-lens-hook export code-provenance \
+    --commit <sha> --session <claude-session-id> \
+    [--key <path>] [--out <file>] [--url <url>] [--token <token>]
+
+  --commit   git commit SHA-1 (required); becomes the in-toto subject
+             with digest type "gitCommit"
+  --session  Claude Code session id (required); enumerates the
+             prompt / thought / tool_call events that produced the
+             commit. v0 is manual; auto-correlation between commits
+             and Claude sessions is a follow-up
+  --key      ed25519 private key path
+             (default $HOME/.agent-lens/keys/ed25519)
+  --out      output file (default stdout)
+  --url      Agent Lens server URL
+             (default $AGENT_LENS_URL or http://localhost:8787)
+  --token    bearer token (default $AGENT_LENS_TOKEN)
+  --timeout  HTTP timeout for the GraphQL fetch (default 30s)
+
+Output is one JSON-encoded DSSE envelope, suitable for appending to
+a .intoto.jsonl file. The signed payload is an in-toto v1 Statement
+whose predicate carries digests + 200-char previews of the prompt /
+thinking / tool_call content — never the full text. Auditors who
+want the raw bytes follow predicate.store_url back to agent-lens.
+`
+
+func exportCodeProvenance(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("export code-provenance", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	var (
+		commit    = fs.String("commit", "", "git commit SHA (required)")
+		session   = fs.String("session", "", "Claude Code session id (required)")
+		keyPath   = fs.String("key", "", "ed25519 private key path")
+		outPath   = fs.String("out", "", "output file (default stdout)")
+		urlFlag   = fs.String("url", "", "server URL")
+		tokenFlag = fs.String("token", "", "bearer token")
+		timeout   = fs.Duration("timeout", 30*time.Second, "HTTP timeout")
+	)
+	fs.Usage = func() { fmt.Fprint(os.Stderr, codeProvenanceUsage) }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *commit == "" || *session == "" {
+		fs.Usage()
+		return fmt.Errorf("--commit and --session are both required")
+	}
+
+	kp := *keyPath
+	if kp == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("home dir: %w", err)
+		}
+		kp = filepath.Join(home, ".agent-lens", "keys", "ed25519")
+	}
+	priv, err := attest.LoadPrivateKey(kp)
+	if err != nil {
+		return fmt.Errorf("load private key from %s: %w", kp, err)
+	}
+
+	url := chooseURL(*urlFlag)
+	token := chooseToken(*tokenFlag)
+	events, err := fetchProvenanceEvents(url, token, *session, *timeout)
+	if err != nil {
+		return fmt.Errorf("fetch session events: %w", err)
+	}
+	if len(events) == 0 {
+		return fmt.Errorf("session %q has no events", *session)
+	}
+
+	pEvents := mapToProvenanceEvents(events)
+	if len(pEvents) == 0 {
+		return fmt.Errorf("session %q has no AI-side events (PROMPT/THOUGHT/TOOL_CALL/TOOL_RESULT/DECISION)", *session)
+	}
+
+	stmt, err := attest.BuildCodeProvenanceStatement(
+		*commit,
+		provenanceSessionFromEvents(*session, events),
+		pEvents,
+		url,
+		events[0].ID,
+	)
+	if err != nil {
+		return fmt.Errorf("build statement: %w", err)
+	}
+
+	stmtBytes, err := json.Marshal(stmt)
+	if err != nil {
+		return fmt.Errorf("marshal statement: %w", err)
+	}
+	env, err := attest.Sign(priv, attest.InTotoPayloadType, stmtBytes)
+	if err != nil {
+		return fmt.Errorf("sign: %w", err)
+	}
+	envBytes, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	envBytes = append(envBytes, '\n')
+
+	if *outPath != "" {
+		if err := os.WriteFile(*outPath, envBytes, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", *outPath, err)
+		}
+	} else if _, err := out.Write(envBytes); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"code-provenance attestation written: %d events, %d bytes, key id %s\n",
+		len(pEvents), len(envBytes), priv.KeyID,
+	)
+	return nil
+}
+
+// provenanceEvent is the shape we read off GraphQL. Unlike verify.go's
+// minimal verifyEvent, we need ts / actor / payload to build the
+// predicate.
+type provenanceEvent struct {
+	ID    string         `json:"id"`
+	TS    string         `json:"ts"`
+	Kind  string         `json:"kind"`
+	Actor provenanceActor `json:"actor"`
+	Payload map[string]any `json:"payload"`
+}
+
+type provenanceActor struct {
+	Type  string `json:"type"`
+	ID    string `json:"id"`
+	Model string `json:"model"`
+}
+
+const provenanceQuery = `query Provenance($sessionId: String!) {
+  events(sessionId: $sessionId, limit: 1000) {
+    id
+    ts
+    kind
+    actor { type id model }
+    payload
+  }
+}`
+
+func fetchProvenanceEvents(url, token, sessionID string, timeout time.Duration) ([]provenanceEvent, error) {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	body, err := json.Marshal(map[string]any{
+		"query": provenanceQuery,
+		"variables": map[string]any{
+			"sessionId": sessionID,
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, url+"/v1/graphql", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := (&http.Client{Timeout: timeout}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		raw, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(raw))
+	}
+	var out struct {
+		Data struct {
+			Events []provenanceEvent `json:"events"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, err
+	}
+	if len(out.Errors) > 0 {
+		return nil, fmt.Errorf("graphql: %s", out.Errors[0].Message)
+	}
+	return out.Data.Events, nil
+}
+
+// provenanceSessionFromEvents derives the session metadata. agent is
+// hardcoded to claude-code today (only producer); model is taken from
+// the first agent event that has it set.
+func provenanceSessionFromEvents(sessionID string, events []provenanceEvent) attest.ProvenanceSession {
+	s := attest.ProvenanceSession{ID: sessionID, Agent: "claude-code"}
+	for _, e := range events {
+		if e.Actor.Type == "AGENT" && e.Actor.Model != "" {
+			s.Model = e.Actor.Model
+			break
+		}
+	}
+	return s
+}
+
+// mapToProvenanceEvents filters and projects events to the predicate's
+// event row. Only AI-side kinds are included; downstream events (commit
+// itself, pr, build, deploy) are NOT in the predicate — those are
+// other attestations' subjects.
+func mapToProvenanceEvents(events []provenanceEvent) []attest.ProvenanceEvent {
+	out := make([]attest.ProvenanceEvent, 0, len(events))
+	for _, e := range events {
+		switch e.Kind {
+		case "PROMPT", "THOUGHT", "TOOL_CALL", "TOOL_RESULT", "DECISION":
+		default:
+			continue
+		}
+		pe := attest.ProvenanceEvent{ID: e.ID, TS: e.TS, Kind: e.Kind}
+		switch e.Kind {
+		case "PROMPT", "THOUGHT":
+			if text, _ := e.Payload["text"].(string); text != "" {
+				pe.ContentDigest, pe.ContentPreview = attest.SummarizeText(text)
+			}
+		case "TOOL_CALL", "TOOL_RESULT":
+			if name, _ := e.Payload["name"].(string); name != "" {
+				pe.ToolName = name
+			}
+			// Hash the entire payload (input + response) so a tampered
+			// tool log is detectable; preview omitted (often binary).
+			if e.Payload != nil {
+				if raw, err := json.Marshal(e.Payload); err == nil {
+					pe.ContentDigest, _ = attest.SummarizeText(string(raw))
+				}
+			}
+		case "DECISION":
+			if marker, _ := e.Payload["marker"].(string); marker != "" {
+				pe.Marker = marker
+			}
+			if text, _ := e.Payload["text"].(string); text != "" {
+				pe.ContentDigest, pe.ContentPreview = attest.SummarizeText(text)
+			}
+		}
+		out = append(out, pe)
+	}
+	return out
+}

--- a/cmd/agent-lens-hook/export.go
+++ b/cmd/agent-lens-hook/export.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/dongqiu/agent-lens/internal/attest"
@@ -67,12 +68,18 @@ Usage:
              prompt / thought / tool_call events that produced the
              commit. v0 is manual; auto-correlation between commits
              and Claude sessions is a follow-up
+  --repo     repo identifier for the in-toto subject name; emitted as
+             "git+<repo>". Default empty falls back to "git"
+             (uninformative; consider passing the repo URL)
   --key      ed25519 private key path
              (default $HOME/.agent-lens/keys/ed25519)
   --out      output file (default stdout)
   --url      Agent Lens server URL
              (default $AGENT_LENS_URL or http://localhost:8787)
   --token    bearer token (default $AGENT_LENS_TOKEN)
+  --limit    max events to fetch (default 5000); the command errors
+             rather than truncates if the cap is hit, since a partial
+             predicate would silently misrepresent the trace
   --timeout  HTTP timeout for the GraphQL fetch (default 30s)
 
 Output is one JSON-encoded DSSE envelope, suitable for appending to
@@ -88,10 +95,12 @@ func exportCodeProvenance(args []string, out io.Writer) error {
 	var (
 		commit    = fs.String("commit", "", "git commit SHA (required)")
 		session   = fs.String("session", "", "Claude Code session id (required)")
+		repoFlag  = fs.String("repo", "", "repo identifier for the in-toto subject name")
 		keyPath   = fs.String("key", "", "ed25519 private key path")
 		outPath   = fs.String("out", "", "output file (default stdout)")
 		urlFlag   = fs.String("url", "", "server URL")
 		tokenFlag = fs.String("token", "", "bearer token")
+		limit     = fs.Int("limit", 5000, "max events to fetch from the session")
 		timeout   = fs.Duration("timeout", 30*time.Second, "HTTP timeout")
 	)
 	fs.Usage = func() { fmt.Fprint(os.Stderr, codeProvenanceUsage) }
@@ -118,21 +127,42 @@ func exportCodeProvenance(args []string, out io.Writer) error {
 
 	url := chooseURL(*urlFlag)
 	token := chooseToken(*tokenFlag)
-	events, err := fetchProvenanceEvents(url, token, *session, *timeout)
+	events, err := fetchProvenanceEvents(url, token, *session, *limit, *timeout)
 	if err != nil {
 		return fmt.Errorf("fetch session events: %w", err)
 	}
 	if len(events) == 0 {
 		return fmt.Errorf("session %q has no events", *session)
 	}
+	if *limit > 0 && len(events) >= *limit {
+		// Hitting the cap means the session probably has more events
+		// than we fetched. A truncated predicate would silently
+		// misrepresent the trace, which defeats the audit goal —
+		// error out and let the operator raise --limit.
+		return fmt.Errorf("session %q hit the --limit cap (%d events); rerun with --limit larger to ensure a complete attestation", *session, *limit)
+	}
+
+	// Defense against future server contract drift: ListBySession
+	// returns events ordered by ts ASC, but client-side sort guards
+	// the metadata we derive (started_at = first event, ended_at =
+	// last) and the predicate's events array against any drift.
+	sort.SliceStable(events, func(i, j int) bool {
+		return events[i].TS < events[j].TS
+	})
 
 	pEvents := mapToProvenanceEvents(events)
 	if len(pEvents) == 0 {
 		return fmt.Errorf("session %q has no AI-side events (PROMPT/THOUGHT/TOOL_CALL/TOOL_RESULT/DECISION)", *session)
 	}
 
+	subjectName := "git"
+	if *repoFlag != "" {
+		subjectName = "git+" + *repoFlag
+	}
+
 	stmt, err := attest.BuildCodeProvenanceStatement(
 		*commit,
+		subjectName,
 		provenanceSessionFromEvents(*session, events),
 		pEvents,
 		url,
@@ -188,8 +218,8 @@ type provenanceActor struct {
 	Model string `json:"model"`
 }
 
-const provenanceQuery = `query Provenance($sessionId: String!) {
-  events(sessionId: $sessionId, limit: 1000) {
+const provenanceQuery = `query Provenance($sessionId: String!, $limit: Int) {
+  events(sessionId: $sessionId, limit: $limit) {
     id
     ts
     kind
@@ -198,7 +228,7 @@ const provenanceQuery = `query Provenance($sessionId: String!) {
   }
 }`
 
-func fetchProvenanceEvents(url, token, sessionID string, timeout time.Duration) ([]provenanceEvent, error) {
+func fetchProvenanceEvents(url, token, sessionID string, limit int, timeout time.Duration) ([]provenanceEvent, error) {
 	if timeout <= 0 {
 		timeout = 30 * time.Second
 	}
@@ -206,6 +236,7 @@ func fetchProvenanceEvents(url, token, sessionID string, timeout time.Duration) 
 		"query": provenanceQuery,
 		"variables": map[string]any{
 			"sessionId": sessionID,
+			"limit":     limit,
 		},
 	})
 	if err != nil {

--- a/cmd/agent-lens-hook/export_test.go
+++ b/cmd/agent-lens-hook/export_test.go
@@ -1,0 +1,229 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/dongqiu/agent-lens/internal/attest"
+	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dongqiu/agent-lens/internal/query"
+	"github.com/dongqiu/agent-lens/internal/store"
+)
+
+// TestExportCodeProvenanceEndToEnd posts realistic AI-side events
+// through ingest, runs the export CLI core against them, then parses,
+// verifies, and asserts the resulting DSSE envelope. Catches drift
+// between the ingest wire format, the GraphQL fetch path, the
+// predicate builder, and the signer.
+func TestExportCodeProvenanceEndToEnd(t *testing.T) {
+	st := store.NewMemory()
+	r := chi.NewRouter()
+	r.Route("/v1", func(sub chi.Router) {
+		ingest.RegisterRoutes(sub, st)
+		query.RegisterRoutes(sub, st)
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	ndjson := strings.Join([]string{
+		`{"session_id":"s-export","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"add a button to checkout"}}`,
+		`{"session_id":"s-export","actor":{"type":"agent","id":"claude-code","model":"claude-opus-4-7"},"kind":"thought","payload":{"text":"plan: open checkout.tsx, insert <Button>, wire onClick"}}`,
+		`{"session_id":"s-export","actor":{"type":"agent","id":"claude-code","model":"claude-opus-4-7"},"kind":"tool_call","payload":{"name":"Edit","input":{"file":"src/Checkout.tsx","old":"foo","new":"bar"}}}`,
+		`{"session_id":"s-export","actor":{"type":"agent","id":"claude-code","model":"claude-opus-4-7"},"kind":"tool_result","payload":{"name":"Edit","response":{"ok":true}}}`,
+		`{"session_id":"s-export","actor":{"type":"agent","id":"claude-code","model":"claude-opus-4-7"},"kind":"decision","payload":{"marker":"assistant_message","text":"Button added in src/Checkout.tsx."}}`,
+	}, "\n")
+	resp, err := http.Post(srv.URL+"/v1/events", "application/x-ndjson", strings.NewReader(ndjson))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	resp.Body.Close()
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "ed25519")
+	priv, pub, err := attest.GenerateKey()
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	if err := attest.SaveKeyPair(keyPath, priv); err != nil {
+		t.Fatalf("save key: %v", err)
+	}
+
+	var buf bytes.Buffer
+	args := []string{
+		"--commit", "deadbeefcafe1234567890abcdef0123456789ab",
+		"--session", "s-export",
+		"--key", keyPath,
+		"--url", srv.URL,
+		"--token", "",
+	}
+	if err := exportCodeProvenance(args, &buf); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	var env attest.Envelope
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &env); err != nil {
+		t.Fatalf("parse envelope: %v\nraw: %s", err, buf.String())
+	}
+	if env.PayloadType != attest.InTotoPayloadType {
+		t.Errorf("payloadType = %q, want %q", env.PayloadType, attest.InTotoPayloadType)
+	}
+
+	payload, gotType, err := attest.Verify(pub, &env)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if gotType != attest.InTotoPayloadType {
+		t.Errorf("verified payloadType = %q", gotType)
+	}
+
+	var stmt attest.Statement
+	if err := json.Unmarshal(payload, &stmt); err != nil {
+		t.Fatalf("parse statement: %v", err)
+	}
+	if stmt.Type != attest.InTotoStatementType {
+		t.Errorf("_type = %q", stmt.Type)
+	}
+	if stmt.PredicateType != attest.CodeProvenancePredicate {
+		t.Errorf("predicateType = %q", stmt.PredicateType)
+	}
+	if len(stmt.Subject) != 1 ||
+		stmt.Subject[0].Digest["gitCommit"] != "deadbeefcafe1234567890abcdef0123456789ab" {
+		t.Errorf("subject = %+v", stmt.Subject)
+	}
+
+	var pred attest.CodeProvenance
+	if err := json.Unmarshal(stmt.Predicate, &pred); err != nil {
+		t.Fatalf("parse predicate: %v", err)
+	}
+	if pred.Session.Model != "claude-opus-4-7" {
+		t.Errorf("session.model = %q", pred.Session.Model)
+	}
+	if len(pred.Events) != 5 {
+		t.Fatalf("events = %d, want 5 (prompt + thought + tool_call + tool_result + decision)", len(pred.Events))
+	}
+
+	// Spot-check that the first event has a digest+preview but NOT the
+	// raw text (privacy contract).
+	first := pred.Events[0]
+	if first.Kind != "PROMPT" {
+		t.Errorf("first event kind = %q, want PROMPT", first.Kind)
+	}
+	if !strings.HasPrefix(first.ContentDigest, "sha256:") {
+		t.Errorf("content_digest = %q", first.ContentDigest)
+	}
+	if first.ContentPreview != "add a button to checkout" {
+		t.Errorf("content_preview = %q", first.ContentPreview)
+	}
+	// The full prompt was 24 chars; preview equals full text. The point
+	// is the predicate has a digest the verifier can use to look up
+	// the matching event in the store and confirm content match.
+
+	// tool_call kept ToolName but not the full input text (only digest).
+	tc := pred.Events[2]
+	if tc.Kind != "TOOL_CALL" || tc.ToolName != "Edit" {
+		t.Errorf("tool_call event = %+v", tc)
+	}
+	if tc.ContentPreview != "" {
+		t.Errorf("tool_call preview should be empty (binary-ish), got %q", tc.ContentPreview)
+	}
+	if tc.ContentDigest == "" {
+		t.Errorf("tool_call content_digest should be set")
+	}
+
+	// Verify with the wrong public key fails.
+	_, otherPub, _ := attest.GenerateKey()
+	if _, _, err := attest.Verify(otherPub, &env); err == nil {
+		t.Error("verify with wrong key should fail")
+	}
+}
+
+func TestExportCodeProvenanceRequiresCommitAndSession(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "ed25519")
+	priv, _, _ := attest.GenerateKey()
+	_ = attest.SaveKeyPair(keyPath, priv)
+
+	cases := [][]string{
+		{"--commit", "abc"},                             // missing session
+		{"--session", "s1"},                             // missing commit
+		{"--commit", "", "--session", "s1", "--key", keyPath},
+		{"--commit", "abc", "--session", "", "--key", keyPath},
+	}
+	for i, args := range cases {
+		var buf bytes.Buffer
+		if err := exportCodeProvenance(args, &buf); err == nil {
+			t.Errorf("case %d: expected error, got nil (args=%v)", i, args)
+		}
+	}
+}
+
+func TestMapToProvenanceEventsFiltersAndExtracts(t *testing.T) {
+	events := []provenanceEvent{
+		{ID: "e1", Kind: "PROMPT", Payload: map[string]any{"text": "hello"}},
+		{ID: "e2", Kind: "THOUGHT", Payload: map[string]any{"text": "thinking..."}},
+		{ID: "e3", Kind: "TOOL_CALL", Payload: map[string]any{"name": "Edit", "input": map[string]any{"x": 1}}},
+		{ID: "e4", Kind: "COMMIT", Payload: map[string]any{"sha": "abc"}}, // should be filtered out
+		{ID: "e5", Kind: "DECISION", Payload: map[string]any{"marker": "turn_end"}},
+	}
+	got := mapToProvenanceEvents(events)
+	if len(got) != 4 {
+		t.Fatalf("got %d events, want 4 (commit filtered)", len(got))
+	}
+	ids := []string{got[0].ID, got[1].ID, got[2].ID, got[3].ID}
+	want := []string{"e1", "e2", "e3", "e5"}
+	for i, w := range want {
+		if ids[i] != w {
+			t.Errorf("event[%d].id = %q, want %q", i, ids[i], w)
+		}
+	}
+
+	// PROMPT event has digest + preview
+	if got[0].ContentPreview != "hello" || got[0].ContentDigest == "" {
+		t.Errorf("prompt event = %+v", got[0])
+	}
+	// TOOL_CALL has tool name + digest, no preview
+	if got[2].ToolName != "Edit" || got[2].ContentDigest == "" {
+		t.Errorf("tool_call event = %+v", got[2])
+	}
+	if got[2].ContentPreview != "" {
+		t.Errorf("tool_call preview should be empty, got %q", got[2].ContentPreview)
+	}
+	// DECISION has marker
+	if got[3].Marker != "turn_end" {
+		t.Errorf("decision marker = %q", got[3].Marker)
+	}
+}
+
+func TestProvenanceSessionFromEventsPicksFirstAgentModel(t *testing.T) {
+	events := []provenanceEvent{
+		{Actor: provenanceActor{Type: "HUMAN", ID: "alice"}},
+		{Actor: provenanceActor{Type: "AGENT", ID: "claude-code", Model: "claude-opus-4-7"}},
+		{Actor: provenanceActor{Type: "AGENT", ID: "claude-code", Model: "ignored"}},
+	}
+	s := provenanceSessionFromEvents("sx", events)
+	if s.ID != "sx" || s.Agent != "claude-code" {
+		t.Errorf("session = %+v", s)
+	}
+	if s.Model != "claude-opus-4-7" {
+		t.Errorf("model = %q, want claude-opus-4-7 (first agent event)", s.Model)
+	}
+
+	// No agent event → empty model, no panic.
+	s2 := provenanceSessionFromEvents("sx", []provenanceEvent{
+		{Actor: provenanceActor{Type: "HUMAN", ID: "alice"}},
+	})
+	if s2.Model != "" {
+		t.Errorf("expected empty model when no agent event, got %q", s2.Model)
+	}
+}
+
+// silence unused import warnings if context is dropped from any test
+var _ = context.Background

--- a/cmd/agent-lens-hook/export_test.go
+++ b/cmd/agent-lens-hook/export_test.go
@@ -227,3 +227,148 @@ func TestProvenanceSessionFromEventsPicksFirstAgentModel(t *testing.T) {
 
 // silence unused import warnings if context is dropped from any test
 var _ = context.Background
+
+func TestExportCodeProvenanceRepoAppearsInSubjectName(t *testing.T) {
+	st := store.NewMemory()
+	r := chi.NewRouter()
+	r.Route("/v1", func(sub chi.Router) {
+		ingest.RegisterRoutes(sub, st)
+		query.RegisterRoutes(sub, st)
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	body := `{"session_id":"s-repo","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"hi"}}`
+	resp, err := http.Post(srv.URL+"/v1/events", "application/x-ndjson", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "ed25519")
+	priv, pub, _ := attest.GenerateKey()
+	_ = attest.SaveKeyPair(keyPath, priv)
+
+	var buf bytes.Buffer
+	args := []string{
+		"--commit", "abc",
+		"--session", "s-repo",
+		"--repo", "https://github.com/acme/widget",
+		"--key", keyPath,
+		"--url", srv.URL,
+	}
+	if err := exportCodeProvenance(args, &buf); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	var env attest.Envelope
+	_ = json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &env)
+	payload, _, err := attest.Verify(pub, &env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var stmt attest.Statement
+	_ = json.Unmarshal(payload, &stmt)
+	if stmt.Subject[0].Name != "git+https://github.com/acme/widget" {
+		t.Errorf("subject name = %q, want %q", stmt.Subject[0].Name, "git+https://github.com/acme/widget")
+	}
+}
+
+func TestExportCodeProvenanceLimitCapErrors(t *testing.T) {
+	st := store.NewMemory()
+	r := chi.NewRouter()
+	r.Route("/v1", func(sub chi.Router) {
+		ingest.RegisterRoutes(sub, st)
+		query.RegisterRoutes(sub, st)
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	// Post 3 events; use --limit 2 to force the cap.
+	body := strings.Join([]string{
+		`{"session_id":"s-cap","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"a"}}`,
+		`{"session_id":"s-cap","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"b"}}`,
+		`{"session_id":"s-cap","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"c"}}`,
+	}, "\n")
+	resp, err := http.Post(srv.URL+"/v1/events", "application/x-ndjson", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "ed25519")
+	priv, _, _ := attest.GenerateKey()
+	_ = attest.SaveKeyPair(keyPath, priv)
+
+	var buf bytes.Buffer
+	args := []string{
+		"--commit", "abc",
+		"--session", "s-cap",
+		"--limit", "2",
+		"--key", keyPath,
+		"--url", srv.URL,
+	}
+	err = exportCodeProvenance(args, &buf)
+	if err == nil {
+		t.Fatal("expected error when --limit cap is hit, got nil")
+	}
+	if !strings.Contains(err.Error(), "limit") {
+		t.Errorf("error didn't mention limit: %v", err)
+	}
+}
+
+func TestExportCodeProvenanceClientSortsByTS(t *testing.T) {
+	// Defense-against-server-contract test: feed events whose TS are
+	// in store-insertion order but lexicographically increasing, then
+	// verify the predicate's metadata.started_at == earliest TS even
+	// after our client-side sort runs.
+	st := store.NewMemory()
+	r := chi.NewRouter()
+	r.Route("/v1", func(sub chi.Router) {
+		ingest.RegisterRoutes(sub, st)
+		query.RegisterRoutes(sub, st)
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	// Three events; first inserted has the latest ts. Server's
+	// ListBySession orders by ts ASC so we'd get them ts-sorted
+	// anyway, but the test pins client-side sort by inspecting the
+	// derived metadata.
+	body := strings.Join([]string{
+		`{"ts":"2026-04-27T10:00:30Z","session_id":"s-sort","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"third"}}`,
+		`{"ts":"2026-04-27T10:00:10Z","session_id":"s-sort","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"first"}}`,
+		`{"ts":"2026-04-27T10:00:20Z","session_id":"s-sort","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"second"}}`,
+	}, "\n")
+	resp, err := http.Post(srv.URL+"/v1/events", "application/x-ndjson", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "ed25519")
+	priv, pub, _ := attest.GenerateKey()
+	_ = attest.SaveKeyPair(keyPath, priv)
+
+	var buf bytes.Buffer
+	args := []string{"--commit", "abc", "--session", "s-sort", "--key", keyPath, "--url", srv.URL}
+	if err := exportCodeProvenance(args, &buf); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	var env attest.Envelope
+	_ = json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &env)
+	payload, _, _ := attest.Verify(pub, &env)
+	var stmt attest.Statement
+	_ = json.Unmarshal(payload, &stmt)
+	var pred attest.CodeProvenance
+	_ = json.Unmarshal(stmt.Predicate, &pred)
+
+	if pred.Metadata.StartedAt != "2026-04-27T10:00:10Z" {
+		t.Errorf("started_at = %q, want earliest 10:00:10", pred.Metadata.StartedAt)
+	}
+	if pred.Metadata.EndedAt != "2026-04-27T10:00:30Z" {
+		t.Errorf("ended_at = %q, want latest 10:00:30", pred.Metadata.EndedAt)
+	}
+}

--- a/cmd/agent-lens-hook/main.go
+++ b/cmd/agent-lens-hook/main.go
@@ -49,5 +49,5 @@ func main() {
 // runClaude is implemented in claude.go.
 // runGitPostCommit is implemented in git.go.
 // runVerify is implemented in verify.go.
-
-func runExport(_ []string) { fmt.Fprintln(os.Stderr, "TODO: export attestation"); os.Exit(1) }
+// runKeygen is implemented in keygen.go.
+// runExport is implemented in export.go.

--- a/internal/attest/codeprovenance.go
+++ b/internal/attest/codeprovenance.go
@@ -1,0 +1,149 @@
+package attest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// Identifiers used across all in-toto attestations we produce.
+const (
+	// InTotoStatementType is the v1 Statement type URI.
+	InTotoStatementType = "https://in-toto.io/Statement/v1"
+	// InTotoPayloadType is the DSSE payloadType for in-toto statements.
+	InTotoPayloadType = "application/vnd.in-toto+json"
+	// CodeProvenancePredicate is the predicateType for our v1
+	// code-provenance attestation.
+	CodeProvenancePredicate = "agent-lens.dev/code-provenance/v1"
+	// CodeProvenanceBuildType identifies the producer of the predicate.
+	CodeProvenanceBuildType = "https://agent-lens.dev/code-provenance/claude-code/v1"
+
+	// previewLen caps the per-event preview included in the predicate.
+	// Long enough to be useful for "what did the user prompt"; short
+	// enough that 100 events fit in a few KB of attestation. Full
+	// content stays in the agent-lens store; consumers cross-reference
+	// by ContentDigest + ID.
+	previewLen = 200
+)
+
+// Statement is the in-toto Statement envelope. The Predicate field is
+// json.RawMessage so we don't have to teach the encoder about every
+// predicate type.
+type Statement struct {
+	Type          string          `json:"_type"`
+	Subject       []Subject       `json:"subject"`
+	PredicateType string          `json:"predicateType"`
+	Predicate     json.RawMessage `json:"predicate"`
+}
+
+// Subject identifies what the attestation describes. For
+// code-provenance, it's the git commit; for SLSA build, the artifact
+// files; for deploy-evidence, the image digest.
+type Subject struct {
+	Name   string            `json:"name"`
+	Digest map[string]string `json:"digest"`
+}
+
+// CodeProvenance is the v1 predicate for agent-lens.dev/code-provenance.
+type CodeProvenance struct {
+	BuildType        string             `json:"buildType"`
+	Session          ProvenanceSession  `json:"session"`
+	Events           []ProvenanceEvent  `json:"events"`
+	Actor            map[string]string  `json:"actor,omitempty"`
+	Metadata         ProvenanceMetadata `json:"metadata"`
+	StoreURL         string             `json:"store_url,omitempty"`
+	TraceRootEventID string             `json:"trace_root_event_id,omitempty"`
+}
+
+type ProvenanceSession struct {
+	ID    string `json:"id"`
+	Agent string `json:"agent,omitempty"`
+	Model string `json:"model,omitempty"`
+}
+
+// ProvenanceEvent is one row of the AI-side activity that produced
+// the commit. We store digests + short previews — never the full
+// prompt / thinking text — so a signed attestation never carries
+// payload that may contain secrets.
+type ProvenanceEvent struct {
+	ID             string `json:"id"`
+	TS             string `json:"ts"`
+	Kind           string `json:"kind"`
+	ContentDigest  string `json:"content_digest,omitempty"`
+	ContentPreview string `json:"content_preview,omitempty"`
+	ToolName       string `json:"tool_name,omitempty"`
+	Marker         string `json:"marker,omitempty"`
+}
+
+type ProvenanceMetadata struct {
+	StartedAt string `json:"started_at,omitempty"`
+	EndedAt   string `json:"ended_at,omitempty"`
+}
+
+// BuildCodeProvenanceStatement assembles an in-toto Statement whose
+// subject is the git commit (digest type "gitCommit", standard in-toto
+// digest name for git commits) and whose predicate is the v1
+// code-provenance shape.
+//
+// The events slice should already be filtered to AI-side events
+// (PROMPT / THOUGHT / TOOL_CALL / TOOL_RESULT / DECISION) and sorted
+// by ts. Started/ended metadata is taken from the first/last event.
+func BuildCodeProvenanceStatement(
+	commit string,
+	session ProvenanceSession,
+	events []ProvenanceEvent,
+	storeURL, rootEventID string,
+) (*Statement, error) {
+	if commit == "" {
+		return nil, errors.New("commit sha required")
+	}
+	if len(events) == 0 {
+		return nil, errors.New("no events; nothing to attest")
+	}
+
+	pred := CodeProvenance{
+		BuildType: CodeProvenanceBuildType,
+		Session:   session,
+		Events:    events,
+		Metadata: ProvenanceMetadata{
+			StartedAt: events[0].TS,
+			EndedAt:   events[len(events)-1].TS,
+		},
+		StoreURL:         storeURL,
+		TraceRootEventID: rootEventID,
+	}
+	predBytes, err := json.Marshal(&pred)
+	if err != nil {
+		return nil, fmt.Errorf("marshal predicate: %w", err)
+	}
+
+	return &Statement{
+		Type: InTotoStatementType,
+		Subject: []Subject{
+			{
+				Name:   "git+local",
+				Digest: map[string]string{"gitCommit": commit},
+			},
+		},
+		PredicateType: CodeProvenancePredicate,
+		Predicate:     predBytes,
+	}, nil
+}
+
+// SummarizeText returns a sha256 digest (in "sha256:<hex>" form) and
+// a clipped preview. Preview clip uses bytes (not runes) so a
+// multi-byte character at the boundary gets cleanly cut at the
+// previous byte; that's a known minor trade-off for simplicity.
+// Empty input still returns the digest of empty bytes.
+func SummarizeText(s string) (digest, preview string) {
+	sum := sha256.Sum256([]byte(s))
+	digest = "sha256:" + hex.EncodeToString(sum[:])
+	if len(s) > previewLen {
+		preview = s[:previewLen] + "..."
+	} else {
+		preview = s
+	}
+	return digest, preview
+}

--- a/internal/attest/codeprovenance.go
+++ b/internal/attest/codeprovenance.go
@@ -87,11 +87,17 @@ type ProvenanceMetadata struct {
 // digest name for git commits) and whose predicate is the v1
 // code-provenance shape.
 //
+// subjectName identifies the repo for the auditor. Pass something
+// like "git+https://github.com/acme/widget" or any URI that names
+// the source. Empty string falls back to "git" — uninformative but
+// preserves backward compatibility with attestations made before this
+// argument existed.
+//
 // The events slice should already be filtered to AI-side events
 // (PROMPT / THOUGHT / TOOL_CALL / TOOL_RESULT / DECISION) and sorted
 // by ts. Started/ended metadata is taken from the first/last event.
 func BuildCodeProvenanceStatement(
-	commit string,
+	commit, subjectName string,
 	session ProvenanceSession,
 	events []ProvenanceEvent,
 	storeURL, rootEventID string,
@@ -101,6 +107,9 @@ func BuildCodeProvenanceStatement(
 	}
 	if len(events) == 0 {
 		return nil, errors.New("no events; nothing to attest")
+	}
+	if subjectName == "" {
+		subjectName = "git"
 	}
 
 	pred := CodeProvenance{
@@ -123,7 +132,7 @@ func BuildCodeProvenanceStatement(
 		Type: InTotoStatementType,
 		Subject: []Subject{
 			{
-				Name:   "git+local",
+				Name:   subjectName,
 				Digest: map[string]string{"gitCommit": commit},
 			},
 		},

--- a/internal/attest/codeprovenance_test.go
+++ b/internal/attest/codeprovenance_test.go
@@ -14,6 +14,7 @@ func TestBuildCodeProvenanceStatementHappyPath(t *testing.T) {
 	}
 	stmt, err := BuildCodeProvenanceStatement(
 		"deadbeefcafe",
+		"git+https://github.com/acme/widget",
 		ProvenanceSession{ID: "s1", Agent: "claude-code", Model: "claude-opus-4-7"},
 		events,
 		"https://lens.example.com",
@@ -34,6 +35,9 @@ func TestBuildCodeProvenanceStatementHappyPath(t *testing.T) {
 	}
 	if stmt.Subject[0].Digest["gitCommit"] != "deadbeefcafe" {
 		t.Errorf("subject digest = %+v", stmt.Subject[0].Digest)
+	}
+	if stmt.Subject[0].Name != "git+https://github.com/acme/widget" {
+		t.Errorf("subject name = %q, want repo URL", stmt.Subject[0].Name)
 	}
 
 	var pred CodeProvenance
@@ -61,11 +65,27 @@ func TestBuildCodeProvenanceStatementHappyPath(t *testing.T) {
 }
 
 func TestBuildCodeProvenanceStatementRejectsEmptyInput(t *testing.T) {
-	if _, err := BuildCodeProvenanceStatement("", ProvenanceSession{}, []ProvenanceEvent{{ID: "x"}}, "", ""); err == nil {
+	if _, err := BuildCodeProvenanceStatement("", "git", ProvenanceSession{}, []ProvenanceEvent{{ID: "x"}}, "", ""); err == nil {
 		t.Error("accepted empty commit")
 	}
-	if _, err := BuildCodeProvenanceStatement("abc", ProvenanceSession{}, nil, "", ""); err == nil {
+	if _, err := BuildCodeProvenanceStatement("abc", "git", ProvenanceSession{}, nil, "", ""); err == nil {
 		t.Error("accepted empty events")
+	}
+}
+
+func TestBuildCodeProvenanceStatementSubjectNameFallback(t *testing.T) {
+	stmt, err := BuildCodeProvenanceStatement(
+		"abc",
+		"", // empty subject name
+		ProvenanceSession{ID: "s1"},
+		[]ProvenanceEvent{{ID: "e1", TS: "t", Kind: "PROMPT"}},
+		"", "e1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stmt.Subject[0].Name != "git" {
+		t.Errorf("empty subjectName fallback = %q, want %q", stmt.Subject[0].Name, "git")
 	}
 }
 
@@ -114,6 +134,7 @@ func TestSummarizeTextEmpty(t *testing.T) {
 func TestStatementJSONRoundTrip(t *testing.T) {
 	stmt, err := BuildCodeProvenanceStatement(
 		"abc",
+		"git+example.com/r",
 		ProvenanceSession{ID: "s1", Agent: "claude-code"},
 		[]ProvenanceEvent{{ID: "e1", TS: "t", Kind: "PROMPT"}},
 		"", "e1",

--- a/internal/attest/codeprovenance_test.go
+++ b/internal/attest/codeprovenance_test.go
@@ -1,0 +1,146 @@
+package attest
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestBuildCodeProvenanceStatementHappyPath(t *testing.T) {
+	events := []ProvenanceEvent{
+		{ID: "e1", TS: "2026-04-27T10:00:00Z", Kind: "PROMPT", ContentDigest: "sha256:abc", ContentPreview: "do X"},
+		{ID: "e2", TS: "2026-04-27T10:00:05Z", Kind: "THOUGHT", ContentDigest: "sha256:def", ContentPreview: "plan"},
+		{ID: "e3", TS: "2026-04-27T10:00:10Z", Kind: "TOOL_CALL", ToolName: "Edit"},
+	}
+	stmt, err := BuildCodeProvenanceStatement(
+		"deadbeefcafe",
+		ProvenanceSession{ID: "s1", Agent: "claude-code", Model: "claude-opus-4-7"},
+		events,
+		"https://lens.example.com",
+		"e1",
+	)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+
+	if stmt.Type != InTotoStatementType {
+		t.Errorf("_type = %q", stmt.Type)
+	}
+	if stmt.PredicateType != CodeProvenancePredicate {
+		t.Errorf("predicateType = %q", stmt.PredicateType)
+	}
+	if len(stmt.Subject) != 1 {
+		t.Fatalf("subject count = %d, want 1", len(stmt.Subject))
+	}
+	if stmt.Subject[0].Digest["gitCommit"] != "deadbeefcafe" {
+		t.Errorf("subject digest = %+v", stmt.Subject[0].Digest)
+	}
+
+	var pred CodeProvenance
+	if err := json.Unmarshal(stmt.Predicate, &pred); err != nil {
+		t.Fatalf("predicate decode: %v", err)
+	}
+	if pred.BuildType != CodeProvenanceBuildType {
+		t.Errorf("buildType = %q", pred.BuildType)
+	}
+	if pred.Session.Model != "claude-opus-4-7" {
+		t.Errorf("session.model = %q", pred.Session.Model)
+	}
+	if len(pred.Events) != 3 {
+		t.Errorf("predicate.events len = %d, want 3", len(pred.Events))
+	}
+	if pred.Metadata.StartedAt != events[0].TS {
+		t.Errorf("metadata.started_at = %q, want %q", pred.Metadata.StartedAt, events[0].TS)
+	}
+	if pred.Metadata.EndedAt != events[2].TS {
+		t.Errorf("metadata.ended_at = %q, want %q", pred.Metadata.EndedAt, events[2].TS)
+	}
+	if pred.TraceRootEventID != "e1" {
+		t.Errorf("trace_root_event_id = %q", pred.TraceRootEventID)
+	}
+}
+
+func TestBuildCodeProvenanceStatementRejectsEmptyInput(t *testing.T) {
+	if _, err := BuildCodeProvenanceStatement("", ProvenanceSession{}, []ProvenanceEvent{{ID: "x"}}, "", ""); err == nil {
+		t.Error("accepted empty commit")
+	}
+	if _, err := BuildCodeProvenanceStatement("abc", ProvenanceSession{}, nil, "", ""); err == nil {
+		t.Error("accepted empty events")
+	}
+}
+
+func TestSummarizeTextDigestStable(t *testing.T) {
+	a, _ := SummarizeText("hello")
+	b, _ := SummarizeText("hello")
+	if a != b {
+		t.Errorf("non-deterministic digest: %s vs %s", a, b)
+	}
+	if !strings.HasPrefix(a, "sha256:") {
+		t.Errorf("digest missing prefix: %s", a)
+	}
+	if len(a) != len("sha256:")+64 {
+		t.Errorf("digest len = %d (want sha256: + 64 hex)", len(a))
+	}
+}
+
+func TestSummarizeTextPreviewClips(t *testing.T) {
+	short := strings.Repeat("a", previewLen)
+	_, preview := SummarizeText(short)
+	if preview != short {
+		t.Errorf("at-limit string was clipped: %q", preview)
+	}
+
+	tooLong := strings.Repeat("a", previewLen+50)
+	_, preview = SummarizeText(tooLong)
+	if !strings.HasSuffix(preview, "...") {
+		t.Errorf("over-limit string missing ellipsis: %q", preview)
+	}
+	// previewLen + len("...") = preview length
+	if len(preview) != previewLen+3 {
+		t.Errorf("clipped len = %d, want %d", len(preview), previewLen+3)
+	}
+}
+
+func TestSummarizeTextEmpty(t *testing.T) {
+	digest, preview := SummarizeText("")
+	if digest == "" {
+		t.Error("empty input still needs a digest (sha256 of empty bytes)")
+	}
+	if preview != "" {
+		t.Errorf("empty input preview = %q, want empty", preview)
+	}
+}
+
+func TestStatementJSONRoundTrip(t *testing.T) {
+	stmt, err := BuildCodeProvenanceStatement(
+		"abc",
+		ProvenanceSession{ID: "s1", Agent: "claude-code"},
+		[]ProvenanceEvent{{ID: "e1", TS: "t", Kind: "PROMPT"}},
+		"", "e1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, err := json.Marshal(stmt)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var parsed Statement
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if parsed.Type != stmt.Type || parsed.PredicateType != stmt.PredicateType {
+		t.Errorf("round-trip lost fields: %+v", parsed)
+	}
+
+	// Predicate is RawMessage; canonicalize via re-marshal for compare.
+	var ourPred, theirPred CodeProvenance
+	_ = json.Unmarshal(stmt.Predicate, &ourPred)
+	_ = json.Unmarshal(parsed.Predicate, &theirPred)
+	ours, _ := json.Marshal(ourPred)
+	theirs, _ := json.Marshal(theirPred)
+	if string(ours) != string(theirs) {
+		t.Errorf("predicate round-trip mismatch:\n  ours   = %s\n  theirs = %s", ours, theirs)
+	}
+}


### PR DESCRIPTION
## Summary

Second slice of M3-B. Lands the first concrete attestation Agent Lens can ship: an in-toto Statement whose **subject is a git commit** and whose predicate enumerates the AI-side events that produced it.

This is the project's core differentiating artifact — \"SLSA / in-toto link extended upstream into AI-assisted development\" finally has a concrete output to point at.

\`\`\`
agent-lens-hook export code-provenance \\
  --commit deadbeef... --session <claude-sid> \\
  [--key ~/.agent-lens/keys/ed25519] [--out file.intoto.jsonl]
\`\`\`

## Predicate shape

\`\`\`json
{
  \"_type\": \"https://in-toto.io/Statement/v1\",
  \"subject\": [{\"name\": \"git+local\", \"digest\": {\"gitCommit\": \"deadbeef...\"}}],
  \"predicateType\": \"agent-lens.dev/code-provenance/v1\",
  \"predicate\": {
    \"buildType\": \"https://agent-lens.dev/code-provenance/claude-code/v1\",
    \"session\": {\"id\": \"...\", \"agent\": \"claude-code\", \"model\": \"claude-opus-4-7\"},
    \"events\": [
      {\"id\": \"01H...\", \"ts\": \"...\", \"kind\": \"PROMPT\",
       \"content_digest\": \"sha256:...\", \"content_preview\": \"first 200 chars...\"},
      {\"id\": \"01H...\", \"ts\": \"...\", \"kind\": \"TOOL_CALL\",
       \"tool_name\": \"Edit\", \"content_digest\": \"sha256:...\"},
      ...
    ],
    \"metadata\": {\"started_at\": \"...\", \"ended_at\": \"...\"},
    \"store_url\": \"https://lens.example.com\",
    \"trace_root_event_id\": \"01H...\"
  }
}
\`\`\`

Wrapped in a DSSE envelope and signed with the ed25519 key produced by M3-B-1's \`keygen\`.

## Privacy contract

The predicate carries **digests + 200-char previews**, never full prompt / thinking / tool-call text. The contract:

- Auditor verifies attestation → confirms a real session emitted these events.
- For full content, follow \`predicate.store_url\` back to agent-lens, look up by event id, hash the stored content, compare against \`content_digest\`. If they match, the predicate's claims are intact.

This means signed attestations **never** carry secrets / proprietary content — important because attestations get attached to images, pushed to Rekor, etc.

## Trace assembly (v0 = manual)

The CLI takes \`--commit\` and \`--session\` separately. Auto-correlating \"which claude session produced this commit\" is tracked as follow-up; the eventual fix is the git-post-commit hook reading \`~/.agent-lens/sessions/current\` (written by claude SessionStart hook) and stuffing it into commit-event refs.

## Test plan

- [x] 6 unit tests in \`internal/attest/codeprovenance_test.go\`: builder happy path, empty-input rejection, Statement JSON round-trip, SummarizeText determinism / clip / over-clip / empty.
- [x] 4 tests in \`cmd/agent-lens-hook/export_test.go\` including a full end-to-end: real ingest+query in httptest, post 5 ndjson events through the writer, run the CLI core, parse + verify the DSSE envelope, decode the Statement+predicate, assert subject digest / events count / privacy contract (preview vs no full text), wrong-key verification fails.
- [x] \`go test -race ./...\` green across 14 packages.
- [x] Real binary smoke: \`agent-lens-hook export\` and \`agent-lens-hook export code-provenance\` print sensible help.

## Out of scope (next slices)

- **M3-B-3** \`slsa-build\` predicate from build events + composite-action artifact list.
- **M3-B-4** \`deploy-evidence\` predicate; cosign verify-attestation integration; upstream attestation hash chaining.
- **Auto trace assembly** (commit ↔ claude session) via SessionStart side-file.

Tracks: M3-B-2. Refs: SPEC §11, §14 M3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)