### PR TITLE
feat(attest): deploy-evidence + verify-attestation CLI (M3-B-4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,51 @@ agent-lens-hook export slsa-build \
 
 self-hosted runner 用 `--builder-id` 覆盖默认的 GitHub-hosted URI。
 
+### 导出 deploy-evidence（deploy 边界）
+
+deploy 事件本身已经在 `/webhooks/deploy` 落地（M3-A）；M3-B-4 这条命令把它升级为可签名的 in-toto attestation：
+
+```bash
+agent-lens-hook export deploy-evidence \
+  --event <deploy-event-id> \
+  --build-attestation slsa.intoto.jsonl \
+  --code-attestation code-prov.intoto.jsonl \
+  --out deploy.intoto.jsonl
+```
+
+- subject = 容器镜像（取 `image` 字段当 name、`image_digest` 当 sha256）。
+- predicate.environment / cluster / namespace / status 等都直接来自 deploy webhook payload。
+- `--build-attestation` / `--code-attestation` 都是可选；命令会对文件做 sha256 然后写到 `predicate.upstream.{build,code}_attestation`，供 verifier 顺着 deploy → build → code 走完证据图。不传就是空字符串，相当于明示"上游证据缺失"。
+- `predicate.trace_root_event_id` 默认就是 deploy event 自身的 id；查 store 时直接当入口。
+
+事件 id 可以从 `/webhooks/deploy` 的响应 header / 服务端日志里捞，也可以用 GraphQL `events(sessionId:"deploy:<env>")` 查 session 时间线，参考 [`examples/`](./examples/) 里的脚本。
+
+## 校验 attestation
+
+```bash
+agent-lens-hook verify-attestation deploy.intoto.jsonl \
+  --pub ~/.agent-lens/keys/ed25519.pub \
+  --require-type agent-lens.dev/deploy-evidence/v1
+# OK · payloadType application/vnd.in-toto+json · predicateType agent-lens.dev/deploy-evidence/v1 · keyid <id>
+#   subject: ghcr.io/acme/widget (sha256:<digest>)
+```
+
+- exit 0：DSSE 签名通过，且（如果给了 `--require-type`）predicateType 一致。
+- exit 1：验证失败——签名错、predicateType 不匹配、envelope 解码失败。CI 网关里挂这个 exit code 就能阻断未签名的部署。
+- exit 2：用法 / 文件错（公钥读不到、文件不存在）。
+
+`--pub` 默认 `$HOME/.agent-lens/keys/ed25519.pub`，多人多机环境里直接 `cosign verify-blob` 也能消费（DSSE 是标准 envelope，cosign 走的是同一份 ed25519 公钥）：
+
+```bash
+cosign verify-blob \
+  --key ~/.agent-lens/keys/ed25519.pub \
+  --signature <(jq -r '.signatures[0].sig' deploy.intoto.jsonl) \
+  --payload <(jq -r '.payload' deploy.intoto.jsonl | base64 -d) \
+  /dev/null
+```
+
+> cosign 的 `verify-blob` 不直接吃 DSSE envelope，所以要拆出 payload 和 sig 再喂；agent-lens 的 `verify-attestation` 直接吃 envelope，更省事。两条路出的结论应当一致。
+
 ## 校验哈希链
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -162,17 +162,9 @@ agent-lens-hook verify-attestation deploy.intoto.jsonl \
 - exit 1：验证失败——签名错、predicateType 不匹配、envelope 解码失败。CI 网关里挂这个 exit code 就能阻断未签名的部署。
 - exit 2：用法 / 文件错（公钥读不到、文件不存在）。
 
-`--pub` 默认 `$HOME/.agent-lens/keys/ed25519.pub`，多人多机环境里直接 `cosign verify-blob` 也能消费（DSSE 是标准 envelope，cosign 走的是同一份 ed25519 公钥）：
+`--pub` 默认 `$HOME/.agent-lens/keys/ed25519.pub`。
 
-```bash
-cosign verify-blob \
-  --key ~/.agent-lens/keys/ed25519.pub \
-  --signature <(jq -r '.signatures[0].sig' deploy.intoto.jsonl) \
-  --payload <(jq -r '.payload' deploy.intoto.jsonl | base64 -d) \
-  /dev/null
-```
-
-> cosign 的 `verify-blob` 不直接吃 DSSE envelope，所以要拆出 payload 和 sig 再喂；agent-lens 的 `verify-attestation` 直接吃 envelope，更省事。两条路出的结论应当一致。
+DSSE envelope 是标准格式，cosign / sigstore-go 都能识别——agent-lens 用同一份 ed25519 公钥（PEM/PKIX）签 + 验。把 `.intoto.jsonl` 的 payload (base64) 解出来再喂给第三方工具即可；后续若启用 Sigstore 网络模式（Fulcio + Rekor），`verify-attestation` 会扩展 `--rekor-url` 等 flag，envelope 格式不变。
 
 ## 校验哈希链
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ agent-lens-hook export deploy-evidence \
 - `--build-attestation` / `--code-attestation` 都是可选；命令会对文件做 sha256 然后写到 `predicate.upstream.{build,code}_attestation`，供 verifier 顺着 deploy → build → code 走完证据图。不传就是空字符串，相当于明示"上游证据缺失"。
 - `predicate.trace_root_event_id` 默认就是 deploy event 自身的 id；查 store 时直接当入口。
 
-事件 id 可以从 `/webhooks/deploy` 的响应 header / 服务端日志里捞，也可以用 GraphQL `events(sessionId:"deploy:<env>")` 查 session 时间线，参考 [`examples/`](./examples/) 里的脚本。
+查事件 id 的两种方式：
+- POST `/webhooks/deploy` 时带 `Idempotency-Key: <ulid>`——这个 key 同时被服务器当成 event id 用，客户端预生成、自己留底。
+- 没设 `Idempotency-Key` 时只能事后用 GraphQL `events(sessionId: "deploy:<env>", limit: 10)` 查时间线（响应里的 `id` 字段）。
 
 ## 校验 attestation
 

--- a/cmd/agent-lens-hook/export.go
+++ b/cmd/agent-lens-hook/export.go
@@ -796,9 +796,9 @@ func buildDeployInputsFromEvent(ev *fetchEventResponse, storeURL string) attest.
 	if v, _ := p["git_sha"].(string); v != "" {
 		in.GitCommit = v
 	}
-	// finished_at preferred, fall back to started_at, fall back to
-	// the deploy event's wall-clock id-bearing time isn't available
-	// here without re-querying.
+	// finished_at preferred, started_at as fallback. The event's own ts
+	// would be a third fallback but it isn't on this GraphQL response;
+	// re-querying for it is more cost than the field is worth.
 	if v, _ := p["finished_at"].(string); v != "" {
 		in.DeployedAt = v
 	} else if v, _ := p["started_at"].(string); v != "" {

--- a/cmd/agent-lens-hook/export.go
+++ b/cmd/agent-lens-hook/export.go
@@ -25,7 +25,7 @@ Usage:
 Kinds:
   code-provenance   agent-lens.dev/code-provenance/v1 (commit boundary)
   slsa-build        slsa.dev/provenance/v1 (build boundary)
-  deploy-evidence   agent-lens.dev/deploy-evidence/v1 (deploy boundary; M3-B-4)
+  deploy-evidence   agent-lens.dev/deploy-evidence/v1 (deploy boundary)
 `
 
 func runExport(args []string) {
@@ -48,8 +48,10 @@ func runExport(args []string) {
 			os.Exit(1)
 		}
 	case "deploy-evidence":
-		fmt.Fprintln(os.Stderr, "TODO: deploy-evidence (M3-B-4)")
-		os.Exit(1)
+		if err := exportDeployEvidence(args[1:], os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "agent-lens-hook export deploy-evidence: %v\n", err)
+			os.Exit(1)
+		}
 	default:
 		fmt.Fprintf(os.Stderr, "unknown export kind: %s\n\n%s", args[0], exportUsage)
 		os.Exit(2)
@@ -562,4 +564,245 @@ func buildSLSAInputsFromEvents(events []provenanceEvent, repo string) (attest.SL
 		return in, fmt.Errorf("session has no composite-action build event with artifacts; SLSA build provenance needs ≥1 subject. Run the agent-lens/actions/build action in your workflow to record artifact hashes")
 	}
 	return in, nil
+}
+
+const deployEvidenceUsage = `agent-lens-hook export deploy-evidence — sign an
+agent-lens.dev/deploy-evidence/v1 attestation for a deploy event.
+
+Usage:
+  agent-lens-hook export deploy-evidence \
+    --event <deploy-event-id> \
+    [--build-attestation <file>] [--code-attestation <file>] \
+    [--key <path>] [--out <file>] [--url <url>] [--token <token>]
+
+  --event              deploy event id (required); fetched via GraphQL.
+                       Must be kind=DEPLOY.
+  --build-attestation  upstream build attestation file (.intoto.jsonl);
+                       its sha256 is recorded in predicate.upstream so
+                       a verifier can walk deploy → build.
+  --code-attestation   upstream code-provenance attestation file; its
+                       sha256 is recorded similarly.
+  --key                ed25519 private key path
+                       (default $HOME/.agent-lens/keys/ed25519)
+  --out                output file (default stdout)
+  --url                Agent Lens server URL
+                       (default $AGENT_LENS_URL or http://localhost:8787)
+  --token              bearer token (default $AGENT_LENS_TOKEN)
+  --timeout            HTTP timeout (default 30s)
+
+The attestation's subject is the container image (sha256 of its
+image_digest); the predicate carries environment / cluster / deploy
+metadata plus optional upstream attestation hashes for graph traversal.
+`
+
+func exportDeployEvidence(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("export deploy-evidence", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	var (
+		eventID    = fs.String("event", "", "deploy event id (required)")
+		buildAtt   = fs.String("build-attestation", "", "upstream build attestation file")
+		codeAtt    = fs.String("code-attestation", "", "upstream code-provenance attestation file")
+		keyPath    = fs.String("key", "", "ed25519 private key path")
+		outPath    = fs.String("out", "", "output file (default stdout)")
+		urlFlag    = fs.String("url", "", "server URL")
+		tokenFlag  = fs.String("token", "", "bearer token")
+		timeout    = fs.Duration("timeout", 30*time.Second, "HTTP timeout")
+	)
+	fs.Usage = func() { fmt.Fprint(os.Stderr, deployEvidenceUsage) }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *eventID == "" {
+		fs.Usage()
+		return fmt.Errorf("--event is required")
+	}
+
+	kp := *keyPath
+	if kp == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("home dir: %w", err)
+		}
+		kp = filepath.Join(home, ".agent-lens", "keys", "ed25519")
+	}
+	priv, err := attest.LoadPrivateKey(kp)
+	if err != nil {
+		return fmt.Errorf("load private key from %s: %w", kp, err)
+	}
+
+	url := chooseURL(*urlFlag)
+	token := chooseToken(*tokenFlag)
+	ev, err := fetchEvent(url, token, *eventID, *timeout)
+	if err != nil {
+		return fmt.Errorf("fetch event: %w", err)
+	}
+	if ev == nil {
+		return fmt.Errorf("event %q not found", *eventID)
+	}
+	if ev.Kind != "DEPLOY" {
+		return fmt.Errorf("event %q has kind %q, want DEPLOY", *eventID, ev.Kind)
+	}
+
+	in := buildDeployInputsFromEvent(ev, url)
+	if *buildAtt != "" {
+		d, err := attest.DigestFile(*buildAtt)
+		if err != nil {
+			return fmt.Errorf("hash --build-attestation: %w", err)
+		}
+		in.BuildAttestationDigest = d
+	}
+	if *codeAtt != "" {
+		d, err := attest.DigestFile(*codeAtt)
+		if err != nil {
+			return fmt.Errorf("hash --code-attestation: %w", err)
+		}
+		in.CodeAttestationDigest = d
+	}
+
+	stmt, err := attest.BuildDeployEvidenceStatement(in)
+	if err != nil {
+		return fmt.Errorf("build statement: %w", err)
+	}
+	stmtBytes, err := json.Marshal(stmt)
+	if err != nil {
+		return fmt.Errorf("marshal statement: %w", err)
+	}
+	env, err := attest.Sign(priv, attest.InTotoPayloadType, stmtBytes)
+	if err != nil {
+		return fmt.Errorf("sign: %w", err)
+	}
+	envBytes, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	envBytes = append(envBytes, '\n')
+
+	if *outPath != "" {
+		if err := os.WriteFile(*outPath, envBytes, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", *outPath, err)
+		}
+	} else if _, err := out.Write(envBytes); err != nil {
+		return err
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"deploy-evidence attestation written: env=%s, %d bytes, key id %s\n",
+		in.Environment, len(envBytes), priv.KeyID,
+	)
+	return nil
+}
+
+// fetchEventResponse mirrors the shape of `Query.event` in the schema.
+type fetchEventResponse struct {
+	ID        string         `json:"id"`
+	Kind      string         `json:"kind"`
+	SessionID string         `json:"sessionId"`
+	Actor     provenanceActor `json:"actor"`
+	Payload   map[string]any `json:"payload"`
+}
+
+const eventByIDQuery = `query EventByID($id: ID!) {
+  event(id: $id) {
+    id
+    kind
+    sessionId
+    actor { type id model }
+    payload
+  }
+}`
+
+// fetchEvent looks one event up by id; returns (nil, nil) when the
+// server responds with a null event (id not found).
+func fetchEvent(url, token, eventID string, timeout time.Duration) (*fetchEventResponse, error) {
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+	body, err := json.Marshal(map[string]any{
+		"query":     eventByIDQuery,
+		"variables": map[string]any{"id": eventID},
+	})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(http.MethodPost, url+"/v1/graphql", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := (&http.Client{Timeout: timeout}).Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		raw, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(raw))
+	}
+	var out struct {
+		Data struct {
+			Event *fetchEventResponse `json:"event"`
+		} `json:"data"`
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	dec := json.NewDecoder(resp.Body)
+	dec.UseNumber()
+	if err := dec.Decode(&out); err != nil {
+		return nil, err
+	}
+	if len(out.Errors) > 0 {
+		return nil, fmt.Errorf("graphql: %s", out.Errors[0].Message)
+	}
+	return out.Data.Event, nil
+}
+
+// buildDeployInputsFromEvent extracts the deploy fields from the
+// event payload. Image digest can come either bare or with prefix
+// (the deploy webhook accepts either).
+func buildDeployInputsFromEvent(ev *fetchEventResponse, storeURL string) attest.DeployEvidenceInputs {
+	in := attest.DeployEvidenceInputs{
+		StoreURL:         storeURL,
+		TraceRootEventID: ev.ID,
+	}
+	p := ev.Payload
+	if v, _ := p["environment"].(string); v != "" {
+		in.Environment = v
+	}
+	if v, _ := p["image"].(string); v != "" {
+		in.Image = v
+	}
+	if v, _ := p["image_digest"].(string); v != "" {
+		in.ImageDigest = v
+	}
+	if v, _ := p["platform"].(string); v != "" {
+		in.Platform = v
+	}
+	if v, _ := p["cluster"].(string); v != "" {
+		in.Cluster = v
+	}
+	if v, _ := p["namespace"].(string); v != "" {
+		in.Namespace = v
+	}
+	if v, _ := p["deployed_by"].(string); v != "" {
+		in.DeployedBy = v
+	}
+	if v, _ := p["status"].(string); v != "" {
+		in.Status = v
+	}
+	if v, _ := p["git_sha"].(string); v != "" {
+		in.GitCommit = v
+	}
+	// finished_at preferred, fall back to started_at, fall back to
+	// the deploy event's wall-clock id-bearing time isn't available
+	// here without re-querying.
+	if v, _ := p["finished_at"].(string); v != "" {
+		in.DeployedAt = v
+	} else if v, _ := p["started_at"].(string); v != "" {
+		in.DeployedAt = v
+	}
+	return in
 }

--- a/cmd/agent-lens-hook/export_test.go
+++ b/cmd/agent-lens-hook/export_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -602,6 +603,304 @@ func TestExportSLSABuildBuilderIDFlag(t *testing.T) {
 	_ = json.Unmarshal(stmt.Predicate, &pred)
 	if pred.RunDetails.Builder.ID != "https://acme.example.com/runner/self-hosted" {
 		t.Errorf("builder.id = %q, want override", pred.RunDetails.Builder.ID)
+	}
+}
+
+// postDeployEvent injects a kind=deploy event via NDJSON so we don't
+// need to wire the deploy webhook handler into every test. It returns
+// the server-assigned event id (read back via GraphQL) so the exporter
+// has something to look up.
+func postDeployEvent(t *testing.T, srvURL, sessionID string, payload map[string]any) string {
+	t.Helper()
+	rawPayload, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wire := map[string]any{
+		"session_id": sessionID,
+		"actor":      map[string]any{"type": "system", "id": "deploy-system"},
+		"kind":       "deploy",
+		"payload":    json.RawMessage(rawPayload),
+	}
+	wireBytes, err := json.Marshal(wire)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.Post(srvURL+"/v1/events", "application/x-ndjson", bytes.NewReader(wireBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	// Read the event id back via GraphQL — NDJSON's HTTP response body
+	// only carries counts, not assigned ids.
+	gqlBody, _ := json.Marshal(map[string]any{
+		"query": `query($s: String!) { events(sessionId: $s, limit: 10) { id } }`,
+		"variables": map[string]any{"s": sessionID},
+	})
+	resp2, err := http.Post(srvURL+"/v1/graphql", "application/json", bytes.NewReader(gqlBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	var out struct {
+		Data struct {
+			Events []struct {
+				ID string `json:"id"`
+			} `json:"events"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp2.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Data.Events) == 0 {
+		t.Fatalf("no events found for session %q", sessionID)
+	}
+	return out.Data.Events[0].ID
+}
+
+func TestExportDeployEvidenceEndToEnd(t *testing.T) {
+	st := store.NewMemory()
+	r := chi.NewRouter()
+	r.Route("/v1", func(sub chi.Router) {
+		ingest.RegisterRoutes(sub, st)
+		query.RegisterRoutes(sub, st)
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	eventID := postDeployEvent(t, srv.URL, "deploy:production", map[string]any{
+		"environment":  "production",
+		"image":        "ghcr.io/acme/widget",
+		"image_digest": "sha256:deadbeef0123456789",
+		"platform":     "k8s",
+		"cluster":      "prod-us-east",
+		"namespace":    "default",
+		"deployed_by":  "alice",
+		"status":       "succeeded",
+		"git_sha":      "feedface1234",
+		"started_at":   "2026-04-27T10:00:00Z",
+		"finished_at":  "2026-04-27T10:01:00Z",
+	})
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "ed25519")
+	priv, pub, _ := attest.GenerateKey()
+	_ = attest.SaveKeyPair(keyPath, priv)
+
+	// Pre-create dummy upstream attestation files so DigestFile has
+	// something to hash. Real callers point at .intoto.jsonl outputs
+	// from earlier export runs.
+	buildAtt := filepath.Join(dir, "build.intoto.jsonl")
+	codeAtt := filepath.Join(dir, "code.intoto.jsonl")
+	if err := os.WriteFile(buildAtt, []byte("BUILD-ATTESTATION-CONTENTS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(codeAtt, []byte("CODE-ATTESTATION-CONTENTS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	args := []string{
+		"--event", eventID,
+		"--build-attestation", buildAtt,
+		"--code-attestation", codeAtt,
+		"--key", keyPath,
+		"--url", srv.URL,
+	}
+	if err := exportDeployEvidence(args, &buf); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	var env attest.Envelope
+	if err := json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &env); err != nil {
+		t.Fatalf("parse envelope: %v", err)
+	}
+	payload, _, err := attest.Verify(pub, &env)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+
+	var stmt attest.Statement
+	_ = json.Unmarshal(payload, &stmt)
+	if stmt.PredicateType != attest.DeployEvidencePredicate {
+		t.Errorf("predicateType = %q", stmt.PredicateType)
+	}
+	if len(stmt.Subject) != 1 ||
+		stmt.Subject[0].Name != "ghcr.io/acme/widget" ||
+		stmt.Subject[0].Digest["sha256"] != "deadbeef0123456789" {
+		t.Errorf("subject = %+v", stmt.Subject)
+	}
+
+	var pred attest.DeployEvidence
+	_ = json.Unmarshal(stmt.Predicate, &pred)
+	if pred.Environment != "production" {
+		t.Errorf("environment = %q", pred.Environment)
+	}
+	if pred.Cluster != "prod-us-east" {
+		t.Errorf("cluster = %q", pred.Cluster)
+	}
+	if pred.Status != "succeeded" {
+		t.Errorf("status = %q", pred.Status)
+	}
+	if pred.DeployedAt != "2026-04-27T10:01:00Z" {
+		t.Errorf("deployed_at = %q, want finished_at", pred.DeployedAt)
+	}
+	if pred.Upstream.GitCommit != "feedface1234" {
+		t.Errorf("upstream.git_commit = %q", pred.Upstream.GitCommit)
+	}
+	if pred.Upstream.BuildAttestationDigest == "" {
+		t.Errorf("upstream.build_attestation should be a sha256")
+	}
+	wantBuildDigest, _ := attest.DigestFile(buildAtt)
+	if pred.Upstream.BuildAttestationDigest != wantBuildDigest {
+		t.Errorf("upstream.build_attestation = %q, want %q", pred.Upstream.BuildAttestationDigest, wantBuildDigest)
+	}
+	wantCodeDigest, _ := attest.DigestFile(codeAtt)
+	if pred.Upstream.CodeAttestationDigest != wantCodeDigest {
+		t.Errorf("upstream.code_attestation = %q, want %q", pred.Upstream.CodeAttestationDigest, wantCodeDigest)
+	}
+	if pred.TraceRootEventID != eventID {
+		t.Errorf("trace_root_event_id = %q, want %q", pred.TraceRootEventID, eventID)
+	}
+}
+
+func TestExportDeployEvidenceWithoutUpstreamAttestations(t *testing.T) {
+	// Upstream attestation flags are optional — the deploy is still
+	// signable, but predicate.upstream.{build,code} are empty so a
+	// verifier knows the chain is incomplete.
+	st := store.NewMemory()
+	r := chi.NewRouter()
+	r.Route("/v1", func(sub chi.Router) {
+		ingest.RegisterRoutes(sub, st)
+		query.RegisterRoutes(sub, st)
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	eventID := postDeployEvent(t, srv.URL, "deploy:staging", map[string]any{
+		"environment":  "staging",
+		"image_digest": "sha256:abc",
+	})
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "ed25519")
+	priv, pub, _ := attest.GenerateKey()
+	_ = attest.SaveKeyPair(keyPath, priv)
+
+	var buf bytes.Buffer
+	if err := exportDeployEvidence(
+		[]string{"--event", eventID, "--key", keyPath, "--url", srv.URL},
+		&buf,
+	); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	var env attest.Envelope
+	_ = json.Unmarshal(bytes.TrimSpace(buf.Bytes()), &env)
+	payload, _, _ := attest.Verify(pub, &env)
+	var stmt attest.Statement
+	_ = json.Unmarshal(payload, &stmt)
+	var pred attest.DeployEvidence
+	_ = json.Unmarshal(stmt.Predicate, &pred)
+	if pred.Upstream.BuildAttestationDigest != "" || pred.Upstream.CodeAttestationDigest != "" {
+		t.Errorf("upstream digests should be empty without flags: %+v", pred.Upstream)
+	}
+}
+
+func TestExportDeployEvidenceRejectsNonDeployEvent(t *testing.T) {
+	st := store.NewMemory()
+	r := chi.NewRouter()
+	r.Route("/v1", func(sub chi.Router) {
+		ingest.RegisterRoutes(sub, st)
+		query.RegisterRoutes(sub, st)
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	// Post a PROMPT event, then ask exportDeployEvidence to use its id —
+	// should fail because kind != DEPLOY.
+	body := `{"session_id":"s-not-deploy","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"hi"}}`
+	resp, err := http.Post(srv.URL+"/v1/events", "application/x-ndjson", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	gqlBody, _ := json.Marshal(map[string]any{
+		"query": `query { events(sessionId: "s-not-deploy", limit: 1) { id } }`,
+	})
+	resp2, err := http.Post(srv.URL+"/v1/graphql", "application/json", bytes.NewReader(gqlBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	var out struct {
+		Data struct {
+			Events []struct {
+				ID string `json:"id"`
+			} `json:"events"`
+		} `json:"data"`
+	}
+	_ = json.NewDecoder(resp2.Body).Decode(&out)
+	if len(out.Data.Events) == 0 {
+		t.Fatal("event missing")
+	}
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "ed25519")
+	priv, _, _ := attest.GenerateKey()
+	_ = attest.SaveKeyPair(keyPath, priv)
+
+	var buf bytes.Buffer
+	err = exportDeployEvidence(
+		[]string{"--event", out.Data.Events[0].ID, "--key", keyPath, "--url", srv.URL},
+		&buf,
+	)
+	if err == nil {
+		t.Fatal("expected error for non-DEPLOY event")
+	}
+	if !strings.Contains(err.Error(), "DEPLOY") {
+		t.Errorf("error should mention DEPLOY: %v", err)
+	}
+}
+
+func TestExportDeployEvidenceMissingEventErrors(t *testing.T) {
+	st := store.NewMemory()
+	r := chi.NewRouter()
+	r.Route("/v1", func(sub chi.Router) {
+		ingest.RegisterRoutes(sub, st)
+		query.RegisterRoutes(sub, st)
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "ed25519")
+	priv, _, _ := attest.GenerateKey()
+	_ = attest.SaveKeyPair(keyPath, priv)
+
+	var buf bytes.Buffer
+	err := exportDeployEvidence(
+		[]string{"--event", "01HNOSUCH", "--key", keyPath, "--url", srv.URL},
+		&buf,
+	)
+	if err == nil {
+		t.Fatal("expected error when event id is unknown")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("error should mention not found: %v", err)
+	}
+}
+
+func TestExportDeployEvidenceRequiresEventFlag(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "ed25519")
+	priv, _, _ := attest.GenerateKey()
+	_ = attest.SaveKeyPair(keyPath, priv)
+
+	var buf bytes.Buffer
+	if err := exportDeployEvidence([]string{"--key", keyPath}, &buf); err == nil {
+		t.Error("expected error when --event missing")
 	}
 }
 

--- a/cmd/agent-lens-hook/main.go
+++ b/cmd/agent-lens-hook/main.go
@@ -11,11 +11,12 @@ Usage:
   agent-lens-hook <subcommand> [flags]
 
 Subcommands:
-  claude            Capture a Claude Code hook payload from stdin and forward.
-  git-post-commit   Capture a git post-commit event and forward.
-  verify            Verify the local hash chain of a session.
-  keygen            Generate an ed25519 key pair for DSSE attestations.
-  export            Export an in-toto / SLSA attestation for a trace.
+  claude               Capture a Claude Code hook payload from stdin and forward.
+  git-post-commit      Capture a git post-commit event and forward.
+  verify               Verify the local hash chain of a session.
+  keygen               Generate an ed25519 key pair for DSSE attestations.
+  export               Export an in-toto / SLSA attestation for a trace.
+  verify-attestation   Verify a DSSE-wrapped in-toto attestation file.
 
 Environment:
   AGENT_LENS_URL    Ingest endpoint (default http://localhost:8787)
@@ -38,6 +39,8 @@ func main() {
 		runKeygen(os.Args[2:])
 	case "export":
 		runExport(os.Args[2:])
+	case "verify-attestation":
+		runVerifyAttestation(os.Args[2:])
 	case "-h", "--help", "help":
 		fmt.Print(usage)
 	default:
@@ -51,3 +54,4 @@ func main() {
 // runVerify is implemented in verify.go.
 // runKeygen is implemented in keygen.go.
 // runExport is implemented in export.go.
+// runVerifyAttestation is implemented in verify_attestation.go.

--- a/cmd/agent-lens-hook/verify_attestation.go
+++ b/cmd/agent-lens-hook/verify_attestation.go
@@ -137,12 +137,16 @@ func verifyAttestationCore(args []string, out io.Writer) error {
 		}
 	}
 
-	fmt.Fprintf(out,
+	if _, err := fmt.Fprintf(out,
 		"OK · payloadType %s · predicateType %s · keyid %s\n",
 		payloadType, stmt.PredicateType, pub.KeyID,
-	)
+	); err != nil {
+		return err
+	}
 	for _, s := range subjects {
-		fmt.Fprintf(out, "  subject: %s\n", s)
+		if _, err := fmt.Fprintf(out, "  subject: %s\n", s); err != nil {
+			return err
+		}
 	}
 	return nil
 }

--- a/cmd/agent-lens-hook/verify_attestation.go
+++ b/cmd/agent-lens-hook/verify_attestation.go
@@ -2,11 +2,14 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/dongqiu/agent-lens/internal/attest"
 )
@@ -32,9 +35,9 @@ mismatch, malformed envelope), 2 usage / file errors.
 func runVerifyAttestation(args []string) {
 	if err := verifyAttestationCore(args, os.Stdout); err != nil {
 		fmt.Fprintf(os.Stderr, "agent-lens-hook verify-attestation: %v\n", err)
-		// Distinguish usage / file errors (exit 2) from verification
-		// errors (exit 1). The core wraps verification failures with
-		// the sentinel string "verify:" so the caller can tell.
+		// Verification errors exit 1 (caller can gate on it); usage /
+		// file errors exit 2 so a CD pipeline doesn't confuse "we
+		// couldn't even check" with "we checked and it's bad".
 		if isVerifyFailure(err) {
 			os.Exit(1)
 		}
@@ -51,20 +54,8 @@ func (v *verifyFailure) Error() string { return v.err.Error() }
 func (v *verifyFailure) Unwrap() error { return v.err }
 
 func isVerifyFailure(err error) bool {
-	for ; err != nil; err = unwrap(err) {
-		if _, ok := err.(*verifyFailure); ok {
-			return true
-		}
-	}
-	return false
-}
-
-func unwrap(err error) error {
-	type unwrapper interface{ Unwrap() error }
-	if u, ok := err.(unwrapper); ok {
-		return u.Unwrap()
-	}
-	return nil
+	var vf *verifyFailure
+	return errors.As(err, &vf)
 }
 
 func verifyAttestationCore(args []string, out io.Writer) error {
@@ -124,16 +115,24 @@ func verifyAttestationCore(args []string, out io.Writer) error {
 
 	subjects := make([]string, 0, len(stmt.Subject))
 	for _, s := range stmt.Subject {
-		// Subject digest is a single map; pick whichever algo first.
-		var algo, hex string
-		for a, h := range s.Digest {
-			algo, hex = a, h
-			break
+		// in-toto Subject.Digest is `map[algo]hex`; sort algos so the
+		// output is stable across runs (Go map iteration is random).
+		// Sorted alphabetically because there's no canonical priority
+		// in the spec — sha256 happens to come before sha512.
+		algos := make([]string, 0, len(s.Digest))
+		for a := range s.Digest {
+			algos = append(algos, a)
 		}
+		sort.Strings(algos)
+		parts := make([]string, 0, len(algos))
+		for _, a := range algos {
+			parts = append(parts, fmt.Sprintf("%s:%s", a, s.Digest[a]))
+		}
+		joined := strings.Join(parts, ",")
 		if s.Name != "" {
-			subjects = append(subjects, fmt.Sprintf("%s (%s:%s)", s.Name, algo, hex))
+			subjects = append(subjects, fmt.Sprintf("%s (%s)", s.Name, joined))
 		} else {
-			subjects = append(subjects, fmt.Sprintf("%s:%s", algo, hex))
+			subjects = append(subjects, joined)
 		}
 	}
 

--- a/cmd/agent-lens-hook/verify_attestation.go
+++ b/cmd/agent-lens-hook/verify_attestation.go
@@ -1,0 +1,148 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/dongqiu/agent-lens/internal/attest"
+)
+
+const verifyAttestationUsage = `agent-lens-hook verify-attestation — verify a
+DSSE-wrapped in-toto attestation file produced by ` + "`agent-lens-hook export`" + `.
+
+Usage:
+  agent-lens-hook verify-attestation <file>
+    [--pub <key.pub>] [--require-type <predicate-type>]
+
+  <file>          .intoto.jsonl file containing a single DSSE envelope
+  --pub           ed25519 public key path
+                  (default $HOME/.agent-lens/keys/ed25519.pub)
+  --require-type  if set, fail unless the inner Statement's
+                  predicateType matches exactly (e.g.
+                  "agent-lens.dev/code-provenance/v1")
+
+Exit codes: 0 valid, 1 verification failed (bad signature, type
+mismatch, malformed envelope), 2 usage / file errors.
+`
+
+func runVerifyAttestation(args []string) {
+	if err := verifyAttestationCore(args, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "agent-lens-hook verify-attestation: %v\n", err)
+		// Distinguish usage / file errors (exit 2) from verification
+		// errors (exit 1). The core wraps verification failures with
+		// the sentinel string "verify:" so the caller can tell.
+		if isVerifyFailure(err) {
+			os.Exit(1)
+		}
+		os.Exit(2)
+	}
+}
+
+// verifyFailure is a sentinel wrapper used to mark verification (vs.
+// argument / file) errors so runVerifyAttestation can pick the right
+// exit code.
+type verifyFailure struct{ err error }
+
+func (v *verifyFailure) Error() string { return v.err.Error() }
+func (v *verifyFailure) Unwrap() error { return v.err }
+
+func isVerifyFailure(err error) bool {
+	for ; err != nil; err = unwrap(err) {
+		if _, ok := err.(*verifyFailure); ok {
+			return true
+		}
+	}
+	return false
+}
+
+func unwrap(err error) error {
+	type unwrapper interface{ Unwrap() error }
+	if u, ok := err.(unwrapper); ok {
+		return u.Unwrap()
+	}
+	return nil
+}
+
+func verifyAttestationCore(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("verify-attestation", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	var (
+		pubPath     = fs.String("pub", "", "ed25519 public key path")
+		requireType = fs.String("require-type", "", "fail unless predicateType matches")
+	)
+	fs.Usage = func() { fmt.Fprint(os.Stderr, verifyAttestationUsage) }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	files := fs.Args()
+	if len(files) != 1 {
+		fs.Usage()
+		return fmt.Errorf("exactly one attestation file is required (got %d)", len(files))
+	}
+	path := files[0]
+
+	pp := *pubPath
+	if pp == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("home dir: %w", err)
+		}
+		pp = filepath.Join(home, ".agent-lens", "keys", "ed25519.pub")
+	}
+	pub, err := attest.LoadPublicKey(pp)
+	if err != nil {
+		return fmt.Errorf("load public key from %s: %w", pp, err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var env attest.Envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return &verifyFailure{fmt.Errorf("decode envelope: %w", err)}
+	}
+
+	payload, payloadType, err := attest.Verify(pub, &env)
+	if err != nil {
+		return &verifyFailure{err}
+	}
+
+	var stmt attest.Statement
+	if err := json.Unmarshal(payload, &stmt); err != nil {
+		return &verifyFailure{fmt.Errorf("decode statement: %w", err)}
+	}
+
+	if *requireType != "" && stmt.PredicateType != *requireType {
+		return &verifyFailure{fmt.Errorf("predicateType = %q, --require-type = %q", stmt.PredicateType, *requireType)}
+	}
+
+	subjects := make([]string, 0, len(stmt.Subject))
+	for _, s := range stmt.Subject {
+		// Subject digest is a single map; pick whichever algo first.
+		var algo, hex string
+		for a, h := range s.Digest {
+			algo, hex = a, h
+			break
+		}
+		if s.Name != "" {
+			subjects = append(subjects, fmt.Sprintf("%s (%s:%s)", s.Name, algo, hex))
+		} else {
+			subjects = append(subjects, fmt.Sprintf("%s:%s", algo, hex))
+		}
+	}
+
+	fmt.Fprintf(out,
+		"OK · payloadType %s · predicateType %s · keyid %s\n",
+		payloadType, stmt.PredicateType, pub.KeyID,
+	)
+	for _, s := range subjects {
+		fmt.Fprintf(out, "  subject: %s\n", s)
+	}
+	return nil
+}

--- a/cmd/agent-lens-hook/verify_attestation_test.go
+++ b/cmd/agent-lens-hook/verify_attestation_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/dongqiu/agent-lens/internal/attest"
+)
+
+// writeSignedEnvelope signs a tiny in-toto Statement with priv, dumps
+// the DSSE envelope to a .intoto.jsonl file under dir, and returns the
+// path. Tests use this to set up the inputs verify-attestation expects.
+func writeSignedEnvelope(t *testing.T, dir string, priv *attest.PrivateKey, predicateType string) string {
+	t.Helper()
+	stmt := attest.Statement{
+		Type:          attest.InTotoStatementType,
+		PredicateType: predicateType,
+		Subject: []attest.Subject{
+			{Name: "test", Digest: map[string]string{"sha256": "abc123"}},
+		},
+		Predicate: json.RawMessage(`{"hello":"world"}`),
+	}
+	stmtBytes, err := json.Marshal(stmt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	env, err := attest.Sign(priv, attest.InTotoPayloadType, stmtBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envBytes, err := json.Marshal(env)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "att.intoto.jsonl")
+	if err := os.WriteFile(path, append(envBytes, '\n'), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// saveTestKey writes a fresh keypair under dir using SaveKeyPair and
+// returns (privKey, pubKeyPath). The public file is path+".pub".
+func saveTestKey(t *testing.T, dir, name string) (*attest.PrivateKey, string) {
+	t.Helper()
+	priv, _, err := attest.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	keyPath := filepath.Join(dir, name)
+	if err := attest.SaveKeyPair(keyPath, priv); err != nil {
+		t.Fatal(err)
+	}
+	return priv, keyPath + ".pub"
+}
+
+func TestVerifyAttestationHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	priv, pubPath := saveTestKey(t, dir, "ed25519")
+	envPath := writeSignedEnvelope(t, dir, priv, "agent-lens.dev/code-provenance/v1")
+
+	var out bytes.Buffer
+	if err := verifyAttestationCore([]string{"--pub", pubPath, envPath}, &out); err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	got := out.String()
+	if !strings.Contains(got, "OK ·") {
+		t.Errorf("output missing OK marker: %q", got)
+	}
+	if !strings.Contains(got, "code-provenance") {
+		t.Errorf("output missing predicateType: %q", got)
+	}
+	if !strings.Contains(got, "subject: test (sha256:abc123)") {
+		t.Errorf("output missing subject: %q", got)
+	}
+}
+
+func TestVerifyAttestationWrongKeyFails(t *testing.T) {
+	dir := t.TempDir()
+	priv, _, err := attest.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Save a *different* keypair — the one paired with this private
+	// key isn't who signed the envelope.
+	_, pubPath := saveTestKey(t, dir, "wrong")
+	envPath := writeSignedEnvelope(t, dir, priv, "agent-lens.dev/code-provenance/v1")
+
+	var out bytes.Buffer
+	err = verifyAttestationCore([]string{"--pub", pubPath, envPath}, &out)
+	if err == nil {
+		t.Fatal("expected verify failure with wrong key, got nil")
+	}
+	if !isVerifyFailure(err) {
+		t.Errorf("expected verifyFailure (exit 1), got plain error: %v", err)
+	}
+}
+
+func TestVerifyAttestationRequireTypeMatch(t *testing.T) {
+	dir := t.TempDir()
+	priv, pubPath := saveTestKey(t, dir, "ed25519")
+	envPath := writeSignedEnvelope(t, dir, priv, "agent-lens.dev/code-provenance/v1")
+
+	// Matching --require-type passes.
+	var out bytes.Buffer
+	if err := verifyAttestationCore(
+		[]string{"--pub", pubPath, "--require-type", "agent-lens.dev/code-provenance/v1", envPath},
+		&out,
+	); err != nil {
+		t.Fatalf("verify with matching require-type: %v", err)
+	}
+
+	// Mismatched --require-type fails as a verify error (exit 1).
+	var out2 bytes.Buffer
+	err := verifyAttestationCore(
+		[]string{"--pub", pubPath, "--require-type", "https://slsa.dev/provenance/v1", envPath},
+		&out2,
+	)
+	if err == nil {
+		t.Fatal("expected error on require-type mismatch")
+	}
+	if !isVerifyFailure(err) {
+		t.Errorf("expected verifyFailure on type mismatch, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "predicateType") {
+		t.Errorf("error should mention predicateType: %v", err)
+	}
+}
+
+func TestVerifyAttestationMalformedEnvelope(t *testing.T) {
+	dir := t.TempDir()
+	_, pubPath := saveTestKey(t, dir, "ed25519")
+
+	envPath := filepath.Join(dir, "bad.intoto.jsonl")
+	if err := os.WriteFile(envPath, []byte("not json at all"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out bytes.Buffer
+	err := verifyAttestationCore([]string{"--pub", pubPath, envPath}, &out)
+	if err == nil {
+		t.Fatal("expected error decoding malformed envelope")
+	}
+	if !isVerifyFailure(err) {
+		t.Errorf("expected verifyFailure for malformed json (exit 1), got: %v", err)
+	}
+}
+
+func TestVerifyAttestationMissingFile(t *testing.T) {
+	dir := t.TempDir()
+	_, pubPath := saveTestKey(t, dir, "ed25519")
+
+	var out bytes.Buffer
+	err := verifyAttestationCore([]string{"--pub", pubPath, "/no/such/attestation.jsonl"}, &out)
+	if err == nil {
+		t.Fatal("expected error on missing file")
+	}
+	// Missing file is a usage / file error (exit 2), not a verification
+	// failure (exit 1).
+	if isVerifyFailure(err) {
+		t.Errorf("missing file should not be a verifyFailure: %v", err)
+	}
+}
+
+func TestVerifyAttestationRequiresExactlyOneFile(t *testing.T) {
+	dir := t.TempDir()
+	_, pubPath := saveTestKey(t, dir, "ed25519")
+
+	var out bytes.Buffer
+	if err := verifyAttestationCore([]string{"--pub", pubPath}, &out); err == nil {
+		t.Error("expected error when no file provided")
+	}
+
+	var out2 bytes.Buffer
+	if err := verifyAttestationCore(
+		[]string{"--pub", pubPath, "/tmp/a", "/tmp/b"},
+		&out2,
+	); err == nil {
+		t.Error("expected error when two files provided")
+	}
+}

--- a/cmd/agent-lens-hook/verify_attestation_test.go
+++ b/cmd/agent-lens-hook/verify_attestation_test.go
@@ -75,7 +75,7 @@ func TestVerifyAttestationHappyPath(t *testing.T) {
 		t.Errorf("output missing predicateType: %q", got)
 	}
 	if !strings.Contains(got, "subject: test (sha256:abc123)") {
-		t.Errorf("output missing subject: %q", got)
+		t.Errorf("output missing subject (single algo): %q", got)
 	}
 }
 

--- a/internal/attest/deployevidence.go
+++ b/internal/attest/deployevidence.go
@@ -1,0 +1,134 @@
+package attest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+// DeployEvidencePredicate identifies the v1 deploy attestation produced
+// by Agent Lens. Subject of a deploy-evidence is the container image.
+const (
+	DeployEvidencePredicate = "agent-lens.dev/deploy-evidence/v1"
+	DeployEvidenceBuildType = "https://agent-lens.dev/deploy-evidence/v1"
+)
+
+// DeployEvidence is the v1 predicate body. It records the deploy
+// itself plus hashes of upstream attestations (build / code) so a
+// verifier can walk the attestation graph from deploy → build → code.
+type DeployEvidence struct {
+	BuildType        string         `json:"buildType"`
+	Environment      string         `json:"environment"`
+	Platform         string         `json:"platform,omitempty"`
+	Cluster          string         `json:"cluster,omitempty"`
+	Namespace        string         `json:"namespace,omitempty"`
+	DeployedBy       string         `json:"deployed_by,omitempty"`
+	DeployedAt       string         `json:"deployed_at,omitempty"`
+	Status           string         `json:"status,omitempty"`
+	Upstream         DeployUpstream `json:"upstream"`
+	StoreURL         string         `json:"store_url,omitempty"`
+	TraceRootEventID string         `json:"trace_root_event_id,omitempty"`
+}
+
+// DeployUpstream holds digest pointers back to the build and code
+// attestations that authorized this deploy. \`sha256:<hex>\` form. Empty
+// values mean the deployer didn't attach the corresponding upstream;
+// verifiers should treat that as reduced assurance, not silent ok.
+type DeployUpstream struct {
+	BuildAttestationDigest string `json:"build_attestation,omitempty"`
+	CodeAttestationDigest  string `json:"code_attestation,omitempty"`
+	GitCommit              string `json:"git_commit,omitempty"`
+}
+
+// DeployEvidenceInputs bundles values an exporter has assembled. Image
+// + ImageDigest determine the subject; everything else feeds the
+// predicate body.
+type DeployEvidenceInputs struct {
+	Image       string // e.g. ghcr.io/acme/widget
+	ImageDigest string // sha256:<hex> or bare hex
+	Environment string
+	Platform    string
+	Cluster     string
+	Namespace   string
+	DeployedBy  string
+	DeployedAt  string
+	Status      string
+	GitCommit   string
+
+	BuildAttestationDigest string // sha256:<hex>
+	CodeAttestationDigest  string
+
+	StoreURL         string
+	TraceRootEventID string
+}
+
+// BuildDeployEvidenceStatement builds an in-toto Statement for a
+// deploy. Subject is the container image (sha256 of its digest).
+func BuildDeployEvidenceStatement(in DeployEvidenceInputs) (*Statement, error) {
+	if in.Environment == "" {
+		return nil, errors.New("environment required")
+	}
+	digestHex := strings.TrimPrefix(in.ImageDigest, "sha256:")
+	if digestHex == "" {
+		return nil, errors.New("image_digest required (becomes the subject's sha256)")
+	}
+
+	name := in.Image
+	if name == "" {
+		// SLSA / in-toto subjects need a name even when only a digest
+		// is meaningful; "image" is a non-confusing placeholder.
+		name = "image"
+	}
+
+	pred := DeployEvidence{
+		BuildType:   DeployEvidenceBuildType,
+		Environment: in.Environment,
+		Platform:    in.Platform,
+		Cluster:     in.Cluster,
+		Namespace:   in.Namespace,
+		DeployedBy:  in.DeployedBy,
+		DeployedAt:  in.DeployedAt,
+		Status:      in.Status,
+		Upstream: DeployUpstream{
+			BuildAttestationDigest: in.BuildAttestationDigest,
+			CodeAttestationDigest:  in.CodeAttestationDigest,
+			GitCommit:              in.GitCommit,
+		},
+		StoreURL:         in.StoreURL,
+		TraceRootEventID: in.TraceRootEventID,
+	}
+	predBytes, err := json.Marshal(&pred)
+	if err != nil {
+		return nil, fmt.Errorf("marshal predicate: %w", err)
+	}
+
+	return &Statement{
+		Type: InTotoStatementType,
+		Subject: []Subject{
+			{Name: name, Digest: map[string]string{"sha256": digestHex}},
+		},
+		PredicateType: DeployEvidencePredicate,
+		Predicate:     predBytes,
+	}, nil
+}
+
+// DigestFile returns sha256:<hex> of the file at path. Used to record
+// upstream attestation hashes in DeployUpstream — a verifier hashes
+// the same .intoto.jsonl bytes and compares.
+func DigestFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	return "sha256:" + hex.EncodeToString(h.Sum(nil)), nil
+}

--- a/internal/attest/deployevidence.go
+++ b/internal/attest/deployevidence.go
@@ -13,16 +13,12 @@ import (
 
 // DeployEvidencePredicate identifies the v1 deploy attestation produced
 // by Agent Lens. Subject of a deploy-evidence is the container image.
-const (
-	DeployEvidencePredicate = "agent-lens.dev/deploy-evidence/v1"
-	DeployEvidenceBuildType = "https://agent-lens.dev/deploy-evidence/v1"
-)
+const DeployEvidencePredicate = "agent-lens.dev/deploy-evidence/v1"
 
 // DeployEvidence is the v1 predicate body. It records the deploy
 // itself plus hashes of upstream attestations (build / code) so a
 // verifier can walk the attestation graph from deploy → build → code.
 type DeployEvidence struct {
-	BuildType        string         `json:"buildType"`
 	Environment      string         `json:"environment"`
 	Platform         string         `json:"platform,omitempty"`
 	Cluster          string         `json:"cluster,omitempty"`
@@ -36,9 +32,10 @@ type DeployEvidence struct {
 }
 
 // DeployUpstream holds digest pointers back to the build and code
-// attestations that authorized this deploy. \`sha256:<hex>\` form. Empty
-// values mean the deployer didn't attach the corresponding upstream;
-// verifiers should treat that as reduced assurance, not silent ok.
+// attestations that authorized this deploy. Format is sha256:<hex>.
+// Empty values mean the deployer didn't attach the corresponding
+// upstream; verifiers should treat that as reduced assurance rather
+// than silent ok.
 type DeployUpstream struct {
 	BuildAttestationDigest string `json:"build_attestation,omitempty"`
 	CodeAttestationDigest  string `json:"code_attestation,omitempty"`
@@ -86,7 +83,6 @@ func BuildDeployEvidenceStatement(in DeployEvidenceInputs) (*Statement, error) {
 	}
 
 	pred := DeployEvidence{
-		BuildType:   DeployEvidenceBuildType,
 		Environment: in.Environment,
 		Platform:    in.Platform,
 		Cluster:     in.Cluster,

--- a/internal/attest/deployevidence_test.go
+++ b/internal/attest/deployevidence_test.go
@@ -1,0 +1,132 @@
+package attest
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildDeployEvidenceStatementHappyPath(t *testing.T) {
+	in := DeployEvidenceInputs{
+		Image:                  "ghcr.io/acme/widget",
+		ImageDigest:            "sha256:abcdef0123456789",
+		Environment:            "production",
+		Platform:               "k8s",
+		Cluster:                "prod-us-east",
+		Namespace:              "default",
+		DeployedBy:             "alice",
+		DeployedAt:             "2026-04-28T12:00:00Z",
+		Status:                 "succeeded",
+		GitCommit:              "deadbeefcafe",
+		BuildAttestationDigest: "sha256:00000000build",
+		CodeAttestationDigest:  "sha256:00000000code",
+		StoreURL:               "https://lens.example.com",
+		TraceRootEventID:       "01HDEPLOY",
+	}
+	stmt, err := BuildDeployEvidenceStatement(in)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if stmt.PredicateType != DeployEvidencePredicate {
+		t.Errorf("predicateType = %q", stmt.PredicateType)
+	}
+	if len(stmt.Subject) != 1 {
+		t.Fatalf("subject count = %d, want 1", len(stmt.Subject))
+	}
+	if stmt.Subject[0].Name != "ghcr.io/acme/widget" {
+		t.Errorf("subject.name = %q", stmt.Subject[0].Name)
+	}
+	if stmt.Subject[0].Digest["sha256"] != "abcdef0123456789" {
+		t.Errorf("subject.digest = %+v (sha256: prefix should be stripped)", stmt.Subject[0].Digest)
+	}
+
+	var pred DeployEvidence
+	if err := json.Unmarshal(stmt.Predicate, &pred); err != nil {
+		t.Fatalf("predicate decode: %v", err)
+	}
+	if pred.Environment != "production" {
+		t.Errorf("environment = %q", pred.Environment)
+	}
+	if pred.Upstream.BuildAttestationDigest != "sha256:00000000build" {
+		t.Errorf("upstream.build = %q", pred.Upstream.BuildAttestationDigest)
+	}
+	if pred.Upstream.CodeAttestationDigest != "sha256:00000000code" {
+		t.Errorf("upstream.code = %q", pred.Upstream.CodeAttestationDigest)
+	}
+	if pred.TraceRootEventID != "01HDEPLOY" {
+		t.Errorf("trace_root_event_id = %q", pred.TraceRootEventID)
+	}
+}
+
+func TestBuildDeployEvidenceStatementRejectsEmptyEnvOrDigest(t *testing.T) {
+	if _, err := BuildDeployEvidenceStatement(DeployEvidenceInputs{
+		ImageDigest: "sha256:abc",
+	}); err == nil {
+		t.Error("accepted empty environment")
+	}
+	if _, err := BuildDeployEvidenceStatement(DeployEvidenceInputs{
+		Environment: "production",
+	}); err == nil {
+		t.Error("accepted empty image_digest")
+	}
+}
+
+func TestBuildDeployEvidenceStatementAcceptsBareHexDigest(t *testing.T) {
+	stmt, err := BuildDeployEvidenceStatement(DeployEvidenceInputs{
+		Environment: "prod",
+		ImageDigest: "abcdef", // no sha256: prefix
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stmt.Subject[0].Digest["sha256"] != "abcdef" {
+		t.Errorf("digest = %+v, want bare hex preserved", stmt.Subject[0].Digest)
+	}
+}
+
+func TestBuildDeployEvidenceStatementMissingImageNameFallback(t *testing.T) {
+	stmt, _ := BuildDeployEvidenceStatement(DeployEvidenceInputs{
+		Environment: "prod",
+		ImageDigest: "sha256:abc",
+		// Image not set
+	})
+	if stmt.Subject[0].Name != "image" {
+		t.Errorf("subject.name = %q, want fallback %q", stmt.Subject[0].Name, "image")
+	}
+}
+
+func TestDigestFileMatchesKnownContent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "f.txt")
+	const content = "deploy-attestation contents"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	want := "sha256:" + hex.EncodeToString(sha256Sum([]byte(content)))
+	got, err := DigestFile(path)
+	if err != nil {
+		t.Fatalf("DigestFile: %v", err)
+	}
+	if got != want {
+		t.Errorf("digest = %q, want %q", got, want)
+	}
+	if !strings.HasPrefix(got, "sha256:") {
+		t.Errorf("digest missing prefix: %q", got)
+	}
+}
+
+func TestDigestFileMissing(t *testing.T) {
+	if _, err := DigestFile("/no/such/file/here"); err == nil {
+		t.Error("DigestFile accepted missing path")
+	}
+}
+
+func sha256Sum(b []byte) []byte {
+	sum := sha256.Sum256(b)
+	return sum[:]
+}


### PR DESCRIPTION
## Summary

- Adds `agent-lens.dev/deploy-evidence/v1` predicate (subject = container image; predicate carries env / cluster / status + optional sha256s of upstream build / code attestations) so verifiers can walk deploy → build → code.
- Adds `agent-lens-hook export deploy-evidence --event <id>` — fetches the DEPLOY event by id, builds the predicate from its payload, signs with local ed25519, emits a DSSE-wrapped `.intoto.jsonl`. `--build-attestation` / `--code-attestation` are optional file paths whose sha256 is recorded in `predicate.upstream`.
- Adds `agent-lens-hook verify-attestation <file>` — generic DSSE + (optional) predicateType verifier. Exit 1 = verification failure (signature / type / decode); exit 2 = usage / file errors. Drop into a CD pipeline as a gate.
- README extended with a deploy-evidence section + verify usage + a cosign interop note.

This is the fourth and last slice of M3-B. M3-B as a whole is now: code-provenance ✅ slsa-build ✅ deploy-evidence ✅ verify-attestation ✅. Sigstore (Fulcio + Rekor) network signing remains a future option behind the same `Sign` / `Verify` API.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — full suite passes
- [x] Unit tests for `BuildDeployEvidenceStatement` (happy path, missing env/digest rejection, bare hex digest, missing image fallback) and `DigestFile`
- [x] E2E tests for `exportDeployEvidence` (full upstream chain, no-upstream, non-DEPLOY rejection, unknown event, missing flag)
- [x] `verify-attestation` tests (happy, wrong key, --require-type match/mismatch, malformed envelope, missing file, arg count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)