### PR TITLE
docs(spec): bump to v0.5 — capture token usage (pricing out of scope)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,9 @@
 # Agent Lens — 项目 SPEC
 
-> 版本：v0.4（2026-04-27）
+> 版本：v0.5（2026-04-28）
 > 状态：草案 / 规划阶段
+>
+> v0.5 变更：把每轮交互的 token 用量纳入证据链。撤回 v0.4 §10.1/§17 关于"hook 路径不抓 token / stop_reason"的限制（已被 transcript 验证证伪）。**价格 / 费用估算明确排除在 v1 范围之外**——多厂商计费结构差异大,token 数才是审计相关原语。详见 `docs/ADR/0002-token-usage-and-cost.md`。
 
 ## 1. 项目愿景
 
@@ -44,6 +46,7 @@ Agent Lens 是面向 Coding Agent 的**可观测、可追溯、可审计**系统
 - **Link**：事件之间的因果或语义关联。
 - **Trace / Evidence Chain**：以某目标（如一次 deploy）为根，反向展开的全部上游事件。
 - **Attestation**：对一段 trace 的签名声明，按 in-toto DSSE 信封格式输出。
+- **TokenUsage**：单条 assistant 消息的 token 计量（input / output / cache_read / cache_write 5m / cache_write 1h / web_search / web_fetch + model + service_tier）。供应商无关 schema，vendor 字段标注来源。**v1 只记录 token 数，不计算费用**——多厂商计费结构差异大且易变,留给下游消费者按需自行计算。详见 ADR 0002。
 
 ## 6. 核心能力
 
@@ -88,6 +91,26 @@ Link {
   inferred_by: rule_id | manual
 }
 ```
+
+`payload.usage` 子对象（仅出现在由 assistant 消息派生的 `decision` / `thought` 事件，可选）：
+
+```
+TokenUsage {
+  vendor:                  "anthropic" | "openai" | ...
+  model:                   string                    // 厂商原始 model id
+  service_tier?:           string                    // standard / priority / batch
+  input_tokens:            int
+  output_tokens:           int
+  cache_read_tokens?:      int
+  cache_write_5m_tokens?:  int
+  cache_write_1h_tokens?:  int
+  web_search_calls?:       int
+  web_fetch_calls?:        int
+  raw?:                    object                    // 原始 vendor usage 块，留作 forensic re-parse
+}
+```
+
+v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / session 级聚合在 query 层做。映射规则、跨厂商抽象、为何不做费用详见 ADR 0002。
 
 ## 8. 系统架构
 
@@ -149,13 +172,16 @@ Link {
 
 **Thinking 捕获条件**：仅当 Claude Code 在该轮启用了 extended thinking，transcript 中才会有 `thinking` block 可读。本路径不主动开启该选项，也不强制其存在。
 
+**Token 用量与 stop_reason 捕获**：transcript 中每条 assistant 消息的 `message.usage` 块（input / output / cache_read / cache_creation 含 5m+1h 分桶 / server_tool_use 含 web_search+web_fetch / service_tier）以及 `message.model`、`message.stop_reason` 均被 transcript 旁路在 Stop hook 中提取，归一化为 §7 `payload.usage` 的 `TokenUsage` shape，挂在该消息派生的 `decision` / `thought` 事件上。验证基础与映射规则见 ADR 0002。原 v0.4 版本曾把这些字段列为本路径不抓、推迟到 §10.4 代理深模式——经实测撤回。
+
 **已知局限**：
 - Claude Code transcript jsonl 不是公开稳定契约，解析按 fail-soft：未识别行跳过，不中断流。最低支持版本随发版迭代标注于 README。
-- 本路径不抓取 token 用量、stop_reason 等流式细节。需要这些指标时切换 §10.4 的代理深模式。
+- `<synthetic>` 模型标记的消息（Claude Code 自身注入的 stop-sequence 占位，usage 全 0）按已知形态跳过 usage 提取，不报错、不丢消息体。
+- 仍**没有**的能力：实时拦截 / token 流式即时反馈 / policy gate。要这些得走 §10.4。
 
 ### 10.4 代理深模式（M4+，未启用）
 
-为获取实时 thinking、token 用量、policy gate 能力，未来可让 Claude Code 走 `ANTHROPIC_BASE_URL` 指向本机 Agent Lens proxy，由 proxy 拦截请求/响应再转发上游。复杂度高于 §10.1，故 v1 不启用；激活条件由独立 ADR 拍板。
+为获取实时拦截能力（流式 thinking 与 token 即时反馈、policy gate），未来可让 Claude Code 走 `ANTHROPIC_BASE_URL` 指向本机 Agent Lens proxy，由 proxy 拦截请求/响应再转发上游。复杂度高于 §10.1，故 v1 不启用；激活条件由独立 ADR 拍板。注意：**token 总量统计**已通过 §10.1 transcript 旁路覆盖，不再是 §10.4 的独占价值。
 
 ### 10.2 OpenCode（次发）
 - OpenCode 是开源 Coding Agent，预期通过其插件机制或 fork patch 注入 capture 层。
@@ -229,6 +255,7 @@ Link {
 | R4 | 私有代码的存储成本与保留策略：只存 diff 还是全文件 snapshot？ |
 | R5 | 与现有 OpenTelemetry-GenAI / Langfuse 等观测系统的关系：互补还是重叠？ |
 | R6 | attestation 的密钥管理：自托管下用本地 KMS 还是 Sigstore（需外网）？ |
+| R7 | 跨厂商 TokenUsage 可比性：OpenCode / Cursor / 自研 Agent 的 usage schema 不一致——尤其 cache 语义(Anthropic 是 TTL 分桶 + 写入按倍率,OpenAI 是缓存输入打折)无法用同一字段名表达。SDK 层定义最小公约数 `TokenUsage`(input / output 通用,cache 字段按需扩展),vendor 字段保留出处,聚合时按 vendor 分组而非强行求和。详见 ADR 0002 D2。 |
 
 ---
 
@@ -321,6 +348,6 @@ agent-lens/
 - Redaction 规则按 §12 默认策略走，不因 dogfood 放宽——thinking 文本尤其敏感，redaction 必须在 hook 出口处完成，不依赖 server。
 - 在 Lens UI 上把"Agent Lens 自身"作为一个 project 单独建模，避免与未来其他被观测项目混淆。
 
-**已具备的捕获深度**（截至 v0.4）：§10.1 的 hook 直采 + transcript 旁路使得激活后能拿到 prompt / 工具调用 / 工具结果 / thinking（启用 extended thinking 时）/ assistant 文本回复 / turn 边界。token 用量与流式细节要等 §10.4 代理深模式上线。
+**已具备的捕获深度**（截至 v0.5）：§10.1 的 hook 直采 + transcript 旁路使得激活后能拿到 prompt / 工具调用 / 工具结果 / thinking（启用 extended thinking 时）/ assistant 文本回复 / turn 边界 / **每条 assistant 消息的 token 用量与 stop_reason**（含 cache 5m/1h 分桶、server_tool_use 计数、service_tier、model）。仍要等 §10.4 代理深模式才能拿到的能力：实时拦截、流式 token 即时反馈、policy gate。
 
 **反馈回路**：dogfood 暴露的可用性问题以 issue 入仓，作为 M4+ 优先级输入。

--- a/docs/ADR/0002-token-usage-and-cost.md
+++ b/docs/ADR/0002-token-usage-and-cost.md
@@ -1,0 +1,206 @@
+# ADR 0002: Token usage in the evidence chain
+
+- Status: Accepted
+- Date: 2026-04-28
+- Supersedes: —
+- Amends: SPEC §5, §7, §10.1, §15, §17
+
+## Context
+
+SPEC v0.4 §10.1 declared, as a known limitation, that the Claude Code hook +
+transcript path "does not capture token usage or stop_reason; switch to the
+proxy deep-mode (§10.4) when those are needed." §17 repeated the claim. That
+parked token accounting behind M4+ and made the proxy deep-mode the gating
+dependency for any usage dashboard.
+
+A new requirement: the auditable evidence chain must record token consumption
+per human↔Coding-Agent turn.
+
+Before accepting the cost of M4+ proxy work, we re-checked the transcript
+itself. The result invalidates the §10.1 / §17 limitation.
+
+## Validation
+
+We inspected two real Claude Code transcripts under
+`~/.claude/projects/-Users-dongqiu-Dev-code-agent-lens/` (both from this
+repo's own development — same user, same model `claude-opus-4-7`, similar
+workflow with extended thinking enabled):
+
+- Small session (`2e5479d3-...jsonl`): **19 / 19** assistant messages carry a
+  populated `message.usage`.
+- Large session (`330c2b60-...jsonl`): **1080 / 1080** real assistant messages
+  carry a populated `message.usage`. One additional `<synthetic>` message
+  appears with all-zero usage and `stop_reason=stop_sequence` — easy to
+  identify and skip.
+
+`message.usage` contains every dimension we need for usage accounting:
+
+| Field | Meaning |
+|---|---|
+| `input_tokens` | Non-cached input tokens |
+| `output_tokens` | Output tokens |
+| `cache_read_input_tokens` | Cache-hit reads |
+| `cache_creation_input_tokens` | Total tokens written to cache |
+| `cache_creation.ephemeral_5m_input_tokens` | 5-minute TTL portion |
+| `cache_creation.ephemeral_1h_input_tokens` | 1-hour TTL portion |
+| `service_tier` | `standard` / `priority` / `batch` |
+| `server_tool_use.web_search_requests` | Server-side web-search invocations |
+| `server_tool_use.web_fetch_requests` | Server-side web-fetch invocations |
+| `iterations` | Sub-message iterations when `stop_reason=tool_use` |
+
+Sibling fields `message.model` (e.g. `claude-opus-4-7`) and
+`message.stop_reason` (`end_turn` / `tool_use` / `stop_sequence` / null) are
+adjacent to `usage` and equally accessible. Both were also listed as "not
+captured" by §10.1; both are in fact present.
+
+Aggregate from the large session (1080 messages):
+
+- input: 1,660
+- output: 1,174,295
+- cache write: 3,346,839
+- **cache read: 416,961,148**
+
+Cache-read dominates by two orders of magnitude. Any usage dashboard that
+collapses cache reads into "input" would distort the picture by ~250×; the
+breakdown matters even when no money is involved.
+
+**Coverage caveat:** these two transcripts share user, model, and workflow
+shape. Cross-project, cross-model (haiku / sonnet / non-Anthropic), and
+no-cache-hit transcripts have not been exercised. The first M2-E
+implementation should re-confirm both the `usage` schema and the
+`<synthetic>` shape against transcripts from a different repo and at
+least one different model before the observations below are treated as
+universally true.
+
+## Why not cost
+
+We considered including a cost estimate (price table × usage). After review
+we deferred it indefinitely:
+
+- Vendor pricing differs in structure, not just numbers: Anthropic bills
+  cache writes with TTL-dependent multipliers; OpenAI bills cached input as
+  a flat discount; per-call billing for server-side tools (web_search /
+  web_fetch) has no analogue on most other vendors. A unified `$` figure
+  hides decisions an auditor would want to see.
+- Maintaining a multi-vendor price table is operational work (rate changes,
+  new tiers, regional differences) that distracts from Agent Lens's core
+  job — recording what happened.
+- Token counts are the audit-relevant primitive. Cost is a derived,
+  organisation-specific concern (billing accounts, negotiated rates, BYOK
+  vs API) that downstream tooling can compute against the raw counts when
+  it actually needs to.
+
+The capture path stays cost-ready: events store everything a future cost
+calculation would need (tokens by dimension, model, service_tier, vendor).
+Re-introducing cost is a query/UI/config layer addition, not a schema
+change.
+
+Reconsider this decision if downstream tooling consistently demands a
+unified cost view that the raw-token contract cannot satisfy — for
+example, if auditors need an `est_cost_usd` column they cannot compute
+themselves, or if multi-tenant deployments need centrally-governed price
+tables. The "out of scope" framing here is operational (avoid building a
+distracting price-table service in v1), not principled.
+
+## Decision
+
+### D1. Embed usage in existing event payloads, do not introduce a new EventKind.
+
+Each assistant-message-derived event (`DECISION` for the `text` block,
+`THOUGHT` for the `thinking` block) carries an optional `usage` sub-object in
+its payload. Turn-level and session-level totals are computed in the query
+layer, not stored as separate events.
+
+**Rejected alternative:** a dedicated `EVENT_KIND_USAGE`. Usage is metadata
+*about* a message, not a behaviour in its own right. A dedicated kind would
+require an extra `Link` back to the producing message and bloat the event
+stream by ~2× for no consumer benefit.
+
+### D2. Standardize a vendor-neutral `TokenUsage` shape. Vendor-specific schemas are normalised at ingest.
+
+```
+TokenUsage {
+  vendor:                  "anthropic" | "openai" | ...
+  model:                   string                       // raw vendor model id
+  service_tier?:           string
+  input_tokens:            int
+  output_tokens:           int
+  cache_read_tokens?:      int
+  cache_write_5m_tokens?:  int                          // anthropic-specific today
+  cache_write_1h_tokens?:  int                          // anthropic-specific today
+  web_search_calls?:       int
+  web_fetch_calls?:        int
+  raw?:                    object                       // verbatim vendor block, for forensic re-parse
+}
+```
+
+Claude Code mapping (from `message.usage`):
+
+- `input_tokens`            → `input_tokens`
+- `output_tokens`           → `output_tokens`
+- `cache_read_input_tokens` → `cache_read_tokens`
+- `cache_creation.ephemeral_5m_input_tokens` → `cache_write_5m_tokens`
+- `cache_creation.ephemeral_1h_input_tokens` → `cache_write_1h_tokens`
+- `server_tool_use.web_search_requests`      → `web_search_calls`
+- `server_tool_use.web_fetch_requests`       → `web_fetch_calls`
+- whole `usage` block                         → `raw` (so future re-derivation
+  is possible if we discover we under-captured a field)
+
+The optional fields are frankly Anthropic-shaped today. When OpenCode /
+Cursor / OpenAI vendors land, we extend the shape rather than coerce
+foreign concepts into these names — adding e.g. `cached_tokens` for
+OpenAI's flat-discount model, kept under the same `TokenUsage` umbrella.
+
+`raw` is intentionally redundant. It costs a few hundred bytes per event and
+buys us insurance against vendor schema drift and our own normalisation
+mistakes.
+
+### D3. Messages without usable usage are treated as metadata-only and logged at INFO.
+
+The `<synthetic>` model marker (Claude Code's own injected stop-sequence,
+observed once in the validation sample with an all-zero usage block) is the
+prompting case, but the rule generalises. If any of the following hold —
+`message.model == "<synthetic>"`, `message.usage` absent, or every numeric
+field in `usage` is zero — treat the message as metadata-only: emit any
+non-usage event content normally, skip the `TokenUsage` extraction, and
+**log at INFO with the offending shape so we can revisit if the assumption
+breaks**. Do not fail-error and do not drop the event.
+
+The `<synthetic>` shape is observed n=1 today; INFO-level logging is the
+explicit hedge against silently dropping richer data if a future Claude
+Code version starts populating `usage` for these messages.
+
+## Scope (this ADR)
+
+This ADR is documentation only. It updates SPEC and records decisions. The
+concrete implementation lands in a follow-up milestone (M2-E or M3 sub-item):
+
+- transcript usage extraction in `internal/transcript/`
+- `payload.usage` shape contract (no proto enum changes needed; payload is
+  `google.protobuf.Struct`)
+- GraphQL exposure: `Event.usage`, `Turn.totalUsage`, `Session.totalUsage`
+  resolvers
+- Lens UI: per-turn token breakdown, session-level totals
+
+No code changes ship with this ADR.
+
+## Consequences
+
+- §10.1 / §17 limitation language is wrong and is being removed in the same
+  changeset. Hook path is now declared as the source of truth for usage and
+  stop_reason; §10.4 proxy deep-mode is no longer the gating dependency for
+  usage features.
+- The v1 evidence chain gains a token-usage dimension without adding M4+
+  scope.
+- Cost / pricing is explicitly out of scope. Re-introducing it later is a
+  pure additive change (price-table config + query/UI layer); no event
+  schema migration would be required.
+- Cross-vendor support (OpenCode, Cursor, custom agents) is now schema-ready
+  via D2 but each new vendor still needs a mapping function. That work is
+  per-integration and tracked as part of §10.2 / §10.3.
+- Attestation-predicate inclusion of token totals is intentionally NOT
+  decided here. The data is captured in events and turn-level totals are
+  computable from the query layer; whoever next revises
+  `agent-lens.dev/code-provenance/v1` (shipped in M3-B-2) or its successors
+  picks what to embed and whether to extend v1 vs. bump to v2. That call
+  belongs to the attestation-revision PR, not this ADR.


### PR DESCRIPTION
## Summary

- Revoke v0.4 §10.1 / §17 limitation that the Claude Code hook + transcript path can't capture token usage or stop_reason. Validated against two real Claude Code transcripts under `~/.claude/projects/-Users-dongqiu-Dev-code-agent-lens/`: **19/19** and **1080/1080** assistant messages carry a populated `message.usage` with full breakdown (input / output / cache_read / cache_creation 5m+1h buckets / server_tool_use), plus adjacent `message.model` and `message.stop_reason`. Proxy deep-mode (§10.4) is no longer the gating dependency for usage features — its remaining unique value is realtime interception and policy-gate behavior.
- Add `docs/ADR/0002-token-usage-and-cost.md` with four decisions: **(D1)** embed usage in existing event payloads, no new `EventKind`; **(D2)** vendor-neutral `TokenUsage` shape with a `raw` fallback for forensic re-parse; **(D3)** skip `<synthetic>` null-usage messages without erroring; **(D4)** attestation predicates carry token totals, not pricing.
- **Pricing / cost estimation explicitly out of v1 scope.** Vendor billing structures differ in shape (Anthropic TTL multipliers vs OpenAI flat-discount cache vs per-call server-tool fees); maintaining a multi-vendor price table is operational distraction. Token counts are the audit-relevant primitive. Re-introducing cost later is a pure additive change (price-table config + query/UI layer) with no event schema migration.

## Scope

Documentation only. Edits to `SPEC.md` at §5 / §7 / §10.1 / §10.4 / §15 / §17 plus header version bump, plus the new ADR. No `proto/` / GraphQL / Go / migration changes — `payload` is already `google.protobuf.Struct`, so the `TokenUsage` shape is a payload contract, not a schema migration.

## Test plan

- [ ] SPEC.md renders cleanly on GitHub (tables, code blocks, em dashes)
- [ ] ADR 0002 cross-references in SPEC (`详见 ADR 0002` / `详见 ADR 0002 D2`) match the section labels actually present in the ADR
- [ ] No leftover "费用" / "价格" / "cost" / "\$" mentions in SPEC outside the explicit out-of-scope language at the header / §5 / §7
- [ ] No leftover claim that token usage requires §10.4 proxy deep-mode
- [ ] §15 risk-table numbering is consistent (R1–R7, no gaps from removed R8/R9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)