### PR TITLE
feat(audit): audit report export + verifier (M3-D)

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,40 @@ agent-lens-hook export deploy-evidence \
 - POST `/webhooks/deploy` 时带 `Idempotency-Key: <ulid>`——这个 key 同时被服务器当成 event id 用，客户端预生成、自己留底。
 - 没设 `Idempotency-Key` 时只能事后用 GraphQL `events(sessionId: "deploy:<env>", limit: 10)` 查时间线（响应里的 `id` 字段）。
 
-## 校验 attestation
+### 导出 audit-report（整条证据链打包）
+
+把一个 root event id 起点的整条证据链打成单文件 JSON，包含所有相关 session 的 events、哈希链、可选嵌入的 attestations，以及 manifest sha256，自鉴防篡改。
+
+```bash
+agent-lens-hook export audit-report \
+  --root <event-id> \
+  --attestation deploy.intoto.jsonl \
+  --attestation slsa.intoto.jsonl \
+  --attestation code.intoto.jsonl \
+  --out audit-report.json
+```
+
+- `--root` 取一个 deploy / commit / pr / build event id；BFS 沿 `event.links` 把所有可达 session 拉进来（默认上限 50 session，靠 `--max-sessions` 调）。
+- `--attestation` 可重复，把 `.intoto.jsonl` 文件原样嵌入；记录 sha256，verifier 可以脱机比对。
+- 输出 JSON 顶层有 `manifest.{sessions_sha256, attestations_sha256}`，重命名 / 改字段 / 加事件 / 改 attestation 都会被 verifier 当场抓出来。
+
+## 校验 audit-report
+
+```bash
+agent-lens-hook verify-audit-report audit-report.json \
+  --pub ~/.agent-lens/keys/ed25519.pub
+# OK · version agent-lens.dev/audit-report/v1 · 3 sessions · 17 events · attestations: 3 verified, 0 skipped
+```
+
+校验流程：
+1. **Manifest re-hash**——Sessions / Attestations 字节重做 sha256，跟报告里的 manifest 比对。
+2. **逐 session 链式校验**——每个 event 的 `prev_hash` 必须等于前一个 event 的 `hash`；`head_hash` 必须等于最后一个 event 的 `hash`。
+3. **嵌入 attestation 重 hash**——envelope 字节重算 sha256 跟记录值比对。
+4. **DSSE 验签**（可选）——给了 `--pub` 就逐条校验签名；省略 `--pub` 默认走 `~/.agent-lens/keys/ed25519.pub`，文件不存在则跳过 DSSE（manifest+chain 两步仍然走完）；显式 `--pub=` 强制跳过。
+
+退出码：0 干净，1 发现 issue（链断 / hash 不匹配 / DSSE 验签失败），2 用法或文件错。这套语义跟 `verify-attestation` 一致，CD pipeline 直接 gate 在 exit 1 上。
+
+## 校验单个 attestation
 
 ```bash
 agent-lens-hook verify-attestation deploy.intoto.jsonl \

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ agent-lens-hook export audit-report \
   --out audit-report.json
 ```
 
-- `--root` 取一个 deploy / commit / pr / build event id；BFS 沿 `event.links` 把所有可达 session 拉进来（默认上限 50 session，靠 `--max-sessions` 调）。
+- `--root` 取一个 deploy / commit / pr / build event id；BFS 沿 `event.links` 把所有可达 session 拉进来（默认上限 50 session，靠 `--max-sessions` 调）。事件 id 的来源跟 deploy webhook 一节一致：客户端预生成的 `Idempotency-Key`（双用作 event id），或事后 `events(sessionId, limit)` 查 GraphQL 取第一个/最近一个事件。
 - `--attestation` 可重复，把 `.intoto.jsonl` 文件原样嵌入；记录 sha256，verifier 可以脱机比对。
 - 输出 JSON 顶层有 `manifest.{sessions_sha256, attestations_sha256}`，重命名 / 改字段 / 加事件 / 改 attestation 都会被 verifier 当场抓出来。
 

--- a/cmd/agent-lens-hook/audit_report.go
+++ b/cmd/agent-lens-hook/audit_report.go
@@ -207,18 +207,24 @@ func verifyAuditReportCore(args []string, out io.Writer) error {
 	}
 
 	if len(res.Issues) > 0 {
-		fmt.Fprintf(out, "FAIL · %d issues\n", len(res.Issues))
+		if _, err := fmt.Fprintf(out, "FAIL · %d issues\n", len(res.Issues)); err != nil {
+			return err
+		}
 		for _, iss := range res.Issues {
-			fmt.Fprintf(out, "  - %s\n", iss)
+			if _, err := fmt.Fprintf(out, "  - %s\n", iss); err != nil {
+				return err
+			}
 		}
 		return &auditReportIssue{msg: fmt.Sprintf("%d issue(s) found", len(res.Issues))}
 	}
 
-	fmt.Fprintf(out,
+	if _, err := fmt.Fprintf(out,
 		"OK · version %s · %d sessions · %d events · attestations: %d verified, %d skipped\n",
 		r.Version, res.SessionsCount, res.EventsCount,
 		res.AttestationsVerified, res.AttestationsSkipped,
-	)
+	); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/cmd/agent-lens-hook/audit_report.go
+++ b/cmd/agent-lens-hook/audit_report.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dongqiu/agent-lens/internal/attest"
+	"github.com/dongqiu/agent-lens/internal/audit"
+)
+
+const auditReportUsage = `agent-lens-hook export audit-report — bundle the
+evidence chain rooted at one event id into a single tamper-evident
+JSON file.
+
+Usage:
+  agent-lens-hook export audit-report \
+    --root <event-id> \
+    [--attestation <file>...] \
+    [--out <file>] [--max-sessions N] \
+    [--url <url>] [--token <token>]
+
+  --root           required; trace graph entry point. Typically a
+                   deploy / commit / pr event id.
+  --attestation    repeatable; embeds a .intoto.jsonl envelope
+                   verbatim. The bundle records sha256 of the file
+                   and the report's manifest hashes them together so
+                   the bundle is tamper-evident.
+  --max-sessions   BFS cap (default 50). Errors out — does NOT
+                   silently truncate — so a partial report can't be
+                   mistaken for a complete one.
+  --out            output path; default stdout.
+  --url            Agent Lens URL (default $AGENT_LENS_URL or
+                   http://localhost:8787)
+  --token          bearer token (default $AGENT_LENS_TOKEN)
+  --timeout        per-GraphQL-call timeout (default 30s)
+
+The bundle is JSON, suitable for archiving / mailing / pasting into
+a compliance tracker. Use ` + "`agent-lens-hook verify-audit-report`" + ` to
+re-check it offline.
+`
+
+func runExportAuditReport(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("export audit-report", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	var (
+		rootID     = fs.String("root", "", "root event id (required)")
+		outPath    = fs.String("out", "", "output file (default stdout)")
+		urlFlag    = fs.String("url", "", "server URL")
+		tokenFlag  = fs.String("token", "", "bearer token")
+		maxSession = fs.Int("max-sessions", 50, "BFS cap")
+		timeout    = fs.Duration("timeout", 30*time.Second, "HTTP timeout")
+	)
+	var atts repeatedString
+	fs.Var(&atts, "attestation", "attestation file path (repeatable)")
+	fs.Usage = func() { fmt.Fprint(os.Stderr, auditReportUsage) }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *rootID == "" {
+		fs.Usage()
+		return fmt.Errorf("--root is required")
+	}
+
+	url := chooseURL(*urlFlag)
+	token := chooseToken(*tokenFlag)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	r, err := audit.Build(ctx, audit.BuildOptions{
+		URL:          url,
+		Token:        token,
+		RootEventID:  *rootID,
+		Attestations: atts,
+		MaxSessions:  *maxSession,
+		Timeout:      *timeout,
+		Generator:    "agent-lens-hook",
+	})
+	if err != nil {
+		return err
+	}
+
+	body, err := json.MarshalIndent(r, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal report: %w", err)
+	}
+	body = append(body, '\n')
+
+	if *outPath != "" {
+		if err := os.WriteFile(*outPath, body, 0o644); err != nil {
+			return fmt.Errorf("write %s: %w", *outPath, err)
+		}
+	} else if _, err := out.Write(body); err != nil {
+		return err
+	}
+
+	totalEvents := 0
+	for _, s := range r.Sessions {
+		totalEvents += len(s.Events)
+	}
+	fmt.Fprintf(os.Stderr,
+		"audit-report written: %d sessions, %d events, %d attestations, %d bytes\n",
+		len(r.Sessions), totalEvents, len(r.Attestations), len(body),
+	)
+	return nil
+}
+
+const verifyAuditReportUsage = `agent-lens-hook verify-audit-report — re-check
+a bundle's manifest, per-session hash chains, and (optionally) the
+DSSE signatures of any embedded attestations.
+
+Usage:
+  agent-lens-hook verify-audit-report <file> [--pub <key.pub>]
+
+  <file>   audit report JSON (produced by ` + "`agent-lens-hook export audit-report`" + `)
+  --pub    ed25519 public key for DSSE verification (default
+           $HOME/.agent-lens/keys/ed25519.pub). Omit by passing an
+           empty value (--pub=) to skip signature verification — the
+           manifest + chain checks still run.
+
+Exit codes: 0 clean, 1 issues found (manifest mismatch, broken chain,
+DSSE failure), 2 usage / file errors.
+`
+
+func runVerifyAuditReport(args []string) {
+	if err := verifyAuditReportCore(args, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "agent-lens-hook verify-audit-report: %v\n", err)
+		if isAuditReportIssue(err) {
+			os.Exit(1)
+		}
+		os.Exit(2)
+	}
+}
+
+// auditReportIssue marks errors that represent a verification failure
+// (exit 1) vs. usage / file errors (exit 2). Same separation pattern
+// as verify-attestation.
+type auditReportIssue struct{ msg string }
+
+func (e *auditReportIssue) Error() string { return e.msg }
+
+func isAuditReportIssue(err error) bool {
+	_, ok := err.(*auditReportIssue)
+	return ok
+}
+
+func verifyAuditReportCore(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("verify-audit-report", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	pubFlag := fs.String("pub", "", "ed25519 public key path (empty to skip DSSE)")
+	fs.Usage = func() { fmt.Fprint(os.Stderr, verifyAuditReportUsage) }
+	// `--pub` semantics: omitted → default home-dir key, silently skip
+	// DSSE if it's not on disk; explicit `--pub <path>` → must load;
+	// explicit `--pub=` → skip DSSE on purpose. We use fs.Visit to
+	// distinguish "set but empty" from "not set", which Go's flag
+	// package doesn't expose otherwise.
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	files := fs.Args()
+	if len(files) != 1 {
+		fs.Usage()
+		return fmt.Errorf("exactly one report file is required (got %d)", len(files))
+	}
+	path := files[0]
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	var r audit.Report
+	if err := json.Unmarshal(raw, &r); err != nil {
+		return fmt.Errorf("decode report: %w", err)
+	}
+
+	var pubKey *attest.PublicKey
+	if pubFlagWasSet(fs) {
+		if *pubFlag == "" {
+			pubKey = nil // explicit --pub= means skip DSSE
+		} else {
+			pk, err := attest.LoadPublicKey(*pubFlag)
+			if err != nil {
+				return fmt.Errorf("load public key from %s: %w", *pubFlag, err)
+			}
+			pubKey = pk
+		}
+	} else {
+		// Default path: try $HOME/.agent-lens/keys/ed25519.pub; if it
+		// isn't there, silently skip DSSE so the verifier is still
+		// useful on a host without the signing key.
+		if home, herr := os.UserHomeDir(); herr == nil {
+			if pk, err := attest.LoadPublicKey(filepath.Join(home, ".agent-lens", "keys", "ed25519.pub")); err == nil {
+				pubKey = pk
+			}
+		}
+	}
+
+	res, err := audit.Verify(&r, audit.VerifyOptions{PubKey: pubKey})
+	if err != nil {
+		return err
+	}
+
+	if len(res.Issues) > 0 {
+		fmt.Fprintf(out, "FAIL · %d issues\n", len(res.Issues))
+		for _, iss := range res.Issues {
+			fmt.Fprintf(out, "  - %s\n", iss)
+		}
+		return &auditReportIssue{msg: fmt.Sprintf("%d issue(s) found", len(res.Issues))}
+	}
+
+	fmt.Fprintf(out,
+		"OK · version %s · %d sessions · %d events · attestations: %d verified, %d skipped\n",
+		r.Version, res.SessionsCount, res.EventsCount,
+		res.AttestationsVerified, res.AttestationsSkipped,
+	)
+	return nil
+}
+
+// pubFlagWasSet returns true if --pub was passed on the command line
+// (even with an empty value). Required because Go's flag package
+// doesn't distinguish "not passed" from "passed empty".
+func pubFlagWasSet(fs *flag.FlagSet) bool {
+	set := false
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name == "pub" {
+			set = true
+		}
+	})
+	return set
+}
+
+// repeatedString collects multiple --flag values into a slice. Used
+// by --attestation.
+type repeatedString []string
+
+func (r *repeatedString) String() string     { return strings.Join(*r, ",") }
+func (r *repeatedString) Set(v string) error { *r = append(*r, v); return nil }

--- a/cmd/agent-lens-hook/audit_report.go
+++ b/cmd/agent-lens-hook/audit_report.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -145,9 +146,11 @@ type auditReportIssue struct{ msg string }
 
 func (e *auditReportIssue) Error() string { return e.msg }
 
+// isAuditReportIssue uses errors.As so a wrapping `fmt.Errorf("...: %w", ...)`
+// in a future caller still surfaces the right exit code.
 func isAuditReportIssue(err error) bool {
-	_, ok := err.(*auditReportIssue)
-	return ok
+	var ari *auditReportIssue
+	return errors.As(err, &ari)
 }
 
 func verifyAuditReportCore(args []string, out io.Writer) error {
@@ -175,7 +178,7 @@ func verifyAuditReportCore(args []string, out io.Writer) error {
 		return fmt.Errorf("read %s: %w", path, err)
 	}
 	var r audit.Report
-	if err := json.Unmarshal(raw, &r); err != nil {
+	if err := audit.DecodeReport(raw, &r); err != nil {
 		return fmt.Errorf("decode report: %w", err)
 	}
 

--- a/cmd/agent-lens-hook/audit_report_test.go
+++ b/cmd/agent-lens-hook/audit_report_test.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/dongqiu/agent-lens/internal/attest"
+	"github.com/dongqiu/agent-lens/internal/audit"
+	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dongqiu/agent-lens/internal/linking"
+	"github.com/dongqiu/agent-lens/internal/query"
+	"github.com/dongqiu/agent-lens/internal/store"
+)
+
+// startHookTestServer mirrors internal/audit.startTestServer but lives
+// here so the CLI tests don't depend on a test helper from another
+// package. Returns the URL.
+func startHookTestServer(t *testing.T) string {
+	t.Helper()
+	st := store.NewMemory()
+	ingestH := ingest.NewHandler(st)
+	linker := linking.New(st, 1024)
+	ingestH.AfterAppend(func(_ context.Context, ev *ingest.WireEvent) {
+		linker.Notify(ev)
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		linker.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	r := chi.NewRouter()
+	r.Route("/v1", func(sub chi.Router) {
+		sub.Post("/events", ingestH.IngestNDJSON)
+		query.RegisterRoutes(sub, st)
+	})
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+func TestExportAuditReportRoundTrip(t *testing.T) {
+	url := startHookTestServer(t)
+
+	// Single-session trace, two events.
+	body := strings.Join([]string{
+		`{"session_id":"s-roundtrip","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"hi"}}`,
+		`{"session_id":"s-roundtrip","actor":{"type":"agent","id":"claude-code"},"kind":"thought","payload":{"text":"thinking"}}`,
+	}, "\n")
+	resp, err := http.Post(url+"/v1/events", "application/x-ndjson", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	// Get root id via GraphQL.
+	gql, _ := json.Marshal(map[string]any{
+		"query": `query { events(sessionId: "s-roundtrip", limit: 1) { id } }`,
+	})
+	resp2, err := http.Post(url+"/v1/graphql", "application/json", bytes.NewReader(gql))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	var idOut struct {
+		Data struct {
+			Events []struct {
+				ID string `json:"id"`
+			} `json:"events"`
+		} `json:"data"`
+	}
+	_ = json.NewDecoder(resp2.Body).Decode(&idOut)
+	if len(idOut.Data.Events) == 0 {
+		t.Fatal("missing event id")
+	}
+	rootID := idOut.Data.Events[0].ID
+
+	// Build a real DSSE attestation to embed.
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "ed25519")
+	priv, pub, _ := attest.GenerateKey()
+	_ = attest.SaveKeyPair(keyPath, priv)
+	stmt := attest.Statement{
+		Type:          attest.InTotoStatementType,
+		Subject:       []attest.Subject{{Name: "x", Digest: map[string]string{"sha256": "abc"}}},
+		PredicateType: "agent-lens.dev/code-provenance/v1",
+		Predicate:     json.RawMessage(`{}`),
+	}
+	stmtBytes, _ := json.Marshal(stmt)
+	env, _ := attest.Sign(priv, attest.InTotoPayloadType, stmtBytes)
+	envBytes, _ := json.Marshal(env)
+	attPath := filepath.Join(dir, "code.intoto.jsonl")
+	if err := os.WriteFile(attPath, envBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the export CLI.
+	reportPath := filepath.Join(dir, "report.json")
+	var buf bytes.Buffer
+	args := []string{
+		"--root", rootID,
+		"--attestation", attPath,
+		"--out", reportPath,
+		"--url", url,
+	}
+	if err := runExportAuditReport(args, &buf); err != nil {
+		t.Fatalf("export: %v", err)
+	}
+
+	raw, err := os.ReadFile(reportPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var r audit.Report
+	if err := json.Unmarshal(raw, &r); err != nil {
+		t.Fatalf("parse report: %v", err)
+	}
+	if r.RootEventID != rootID {
+		t.Errorf("root_event_id = %q", r.RootEventID)
+	}
+	if len(r.Sessions) != 1 || len(r.Sessions[0].Events) != 2 {
+		t.Errorf("unexpected sessions: %+v", r.Sessions)
+	}
+	if len(r.Attestations) != 1 {
+		t.Fatalf("expected 1 attestation embedded, got %d", len(r.Attestations))
+	}
+
+	// Verify the report via the verify CLI, with the matching key.
+	pubPath := keyPath + ".pub"
+	_ = pub
+	var vout bytes.Buffer
+	if err := verifyAuditReportCore([]string{"--pub", pubPath, reportPath}, &vout); err != nil {
+		t.Fatalf("verify: %v\n%s", err, vout.String())
+	}
+	got := vout.String()
+	if !strings.Contains(got, "OK ·") {
+		t.Errorf("expected OK summary, got: %q", got)
+	}
+	if !strings.Contains(got, "1 verified") {
+		t.Errorf("expected `1 verified` count: %q", got)
+	}
+}
+
+func TestVerifyAuditReportDetectsTamper(t *testing.T) {
+	url := startHookTestServer(t)
+	body := `{"session_id":"s-tamper","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"hi"}}`
+	resp, _ := http.Post(url+"/v1/events", "application/x-ndjson", strings.NewReader(body))
+	resp.Body.Close()
+	gql, _ := json.Marshal(map[string]any{
+		"query": `query { events(sessionId: "s-tamper", limit: 1) { id } }`,
+	})
+	resp2, err := http.Post(url+"/v1/graphql", "application/json", bytes.NewReader(gql))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp2.Body.Close()
+	var idOut struct {
+		Data struct {
+			Events []struct {
+				ID string `json:"id"`
+			} `json:"events"`
+		} `json:"data"`
+	}
+	_ = json.NewDecoder(resp2.Body).Decode(&idOut)
+	rootID := idOut.Data.Events[0].ID
+
+	dir := t.TempDir()
+	reportPath := filepath.Join(dir, "report.json")
+	var out bytes.Buffer
+	if err := runExportAuditReport(
+		[]string{"--root", rootID, "--out", reportPath, "--url", url},
+		&out,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tamper: overwrite an event field but DON'T re-compute manifest.
+	raw, _ := os.ReadFile(reportPath)
+	var r audit.Report
+	_ = json.Unmarshal(raw, &r)
+	r.Sessions[0].Events[0].Kind = "TAMPERED"
+	tamperedBytes, _ := json.MarshalIndent(&r, "", "  ")
+	if err := os.WriteFile(reportPath, tamperedBytes, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify with explicit --pub= (skip DSSE), so we isolate the manifest
+	// failure.
+	var vout bytes.Buffer
+	err = verifyAuditReportCore([]string{"--pub", "", reportPath}, &vout)
+	if err == nil {
+		t.Fatal("expected verify to fail on tampered report")
+	}
+	if !isAuditReportIssue(err) {
+		t.Errorf("expected auditReportIssue (exit 1), got: %v", err)
+	}
+	if !strings.Contains(vout.String(), "sessions_sha256") {
+		t.Errorf("expected sessions_sha256 issue in output: %q", vout.String())
+	}
+}
+
+func TestExportAuditReportRequiresRoot(t *testing.T) {
+	var buf bytes.Buffer
+	if err := runExportAuditReport([]string{}, &buf); err == nil {
+		t.Error("expected error when --root missing")
+	}
+}
+
+func TestVerifyAuditReportArgCount(t *testing.T) {
+	dir := t.TempDir()
+	r := audit.Report{Version: audit.Version}
+	body, _ := json.MarshalIndent(&r, "", "  ")
+	path := filepath.Join(dir, "r.json")
+	_ = os.WriteFile(path, body, 0o644)
+
+	var out bytes.Buffer
+	// no file
+	if err := verifyAuditReportCore([]string{"--pub", ""}, &out); err == nil {
+		t.Error("expected error with no file")
+	}
+	// two files
+	var out2 bytes.Buffer
+	if err := verifyAuditReportCore([]string{"--pub", "", path, path}, &out2); err == nil {
+		t.Error("expected error with two files")
+	}
+}
+
+func TestVerifyAuditReportMissingFile(t *testing.T) {
+	var out bytes.Buffer
+	err := verifyAuditReportCore([]string{"--pub", "", "/no/such/report.json"}, &out)
+	if err == nil {
+		t.Fatal("expected error on missing file")
+	}
+	if isAuditReportIssue(err) {
+		t.Errorf("missing file should not be auditReportIssue (should be exit 2): %v", err)
+	}
+}

--- a/cmd/agent-lens-hook/export.go
+++ b/cmd/agent-lens-hook/export.go
@@ -26,6 +26,7 @@ Kinds:
   code-provenance   agent-lens.dev/code-provenance/v1 (commit boundary)
   slsa-build        slsa.dev/provenance/v1 (build boundary)
   deploy-evidence   agent-lens.dev/deploy-evidence/v1 (deploy boundary)
+  audit-report      agent-lens.dev/audit-report/v1 (whole-trace bundle)
 `
 
 func runExport(args []string) {
@@ -50,6 +51,11 @@ func runExport(args []string) {
 	case "deploy-evidence":
 		if err := exportDeployEvidence(args[1:], os.Stdout); err != nil {
 			fmt.Fprintf(os.Stderr, "agent-lens-hook export deploy-evidence: %v\n", err)
+			os.Exit(1)
+		}
+	case "audit-report":
+		if err := runExportAuditReport(args[1:], os.Stdout); err != nil {
+			fmt.Fprintf(os.Stderr, "agent-lens-hook export audit-report: %v\n", err)
 			os.Exit(1)
 		}
 	default:

--- a/cmd/agent-lens-hook/main.go
+++ b/cmd/agent-lens-hook/main.go
@@ -11,12 +11,13 @@ Usage:
   agent-lens-hook <subcommand> [flags]
 
 Subcommands:
-  claude               Capture a Claude Code hook payload from stdin and forward.
-  git-post-commit      Capture a git post-commit event and forward.
-  verify               Verify the local hash chain of a session.
-  keygen               Generate an ed25519 key pair for DSSE attestations.
-  export               Export an in-toto / SLSA attestation for a trace.
-  verify-attestation   Verify a DSSE-wrapped in-toto attestation file.
+  claude                 Capture a Claude Code hook payload from stdin and forward.
+  git-post-commit        Capture a git post-commit event and forward.
+  verify                 Verify the local hash chain of a session.
+  keygen                 Generate an ed25519 key pair for DSSE attestations.
+  export                 Export an in-toto / SLSA attestation, or an audit report.
+  verify-attestation     Verify a DSSE-wrapped in-toto attestation file.
+  verify-audit-report    Verify an audit-report bundle.
 
 Environment:
   AGENT_LENS_URL    Ingest endpoint (default http://localhost:8787)
@@ -41,6 +42,8 @@ func main() {
 		runExport(os.Args[2:])
 	case "verify-attestation":
 		runVerifyAttestation(os.Args[2:])
+	case "verify-audit-report":
+		runVerifyAuditReport(os.Args[2:])
 	case "-h", "--help", "help":
 		fmt.Print(usage)
 	default:
@@ -55,3 +58,4 @@ func main() {
 // runKeygen is implemented in keygen.go.
 // runExport is implemented in export.go.
 // runVerifyAttestation is implemented in verify_attestation.go.
+// runVerifyAuditReport is implemented in audit_report.go.

--- a/internal/audit/builder.go
+++ b/internal/audit/builder.go
@@ -94,6 +94,16 @@ func Build(ctx context.Context, opts BuildOptions) (*Report, error) {
 		if err != nil {
 			return nil, fmt.Errorf("fetch session head %q: %w", sessionID, err)
 		}
+		// Truncation guard: if the GraphQL limit cap silently capped a
+		// long session, head won't match the last event we got. Same
+		// check covers a server contract drift where events come back
+		// out of ts ASC order. Either way, the report would be a lie
+		// — fail loudly.
+		if len(events) > 0 && head != "" && events[len(events)-1].Hash != head {
+			return nil, fmt.Errorf(
+				"session %q: server head_hash %s != last event hash %s — events truncated by GraphQL limit, or returned out of order",
+				sessionID, head, events[len(events)-1].Hash)
+		}
 		sessions = append(sessions, Session{
 			SessionID: sessionID,
 			HeadHash:  head,

--- a/internal/audit/builder.go
+++ b/internal/audit/builder.go
@@ -1,0 +1,331 @@
+package audit
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// BuildOptions configures Build. URL / RootEventID are required.
+type BuildOptions struct {
+	URL          string
+	Token        string
+	RootEventID  string
+	Attestations []string // file paths to embed verbatim
+	MaxSessions  int      // hard cap on BFS expansion (default 50)
+	Timeout      time.Duration
+	Generator    string // recorded in Report.Generator
+	GeneratedAt  string // optional override; defaults to time.Now().UTC().Format(RFC3339)
+}
+
+const (
+	defaultMaxSessions = 50
+	defaultTimeout     = 30 * time.Second
+)
+
+// Build walks the link graph from RootEventID via GraphQL, collects
+// every reachable event (grouped by session), embeds each attestation
+// file verbatim, and computes the sha256 manifest. Returns a Report
+// suitable for json.MarshalIndent + os.WriteFile.
+//
+// Error semantics: missing root event is a hard error; an exceeded
+// MaxSessions cap is a hard error (the report would be incomplete);
+// per-attestation read errors are hard errors. Network errors fail
+// fast — partial reports would silently misrepresent the trace.
+func Build(ctx context.Context, opts BuildOptions) (*Report, error) {
+	if opts.URL == "" {
+		return nil, errors.New("URL required")
+	}
+	if opts.RootEventID == "" {
+		return nil, errors.New("RootEventID required")
+	}
+	if opts.MaxSessions <= 0 {
+		opts.MaxSessions = defaultMaxSessions
+	}
+	if opts.Timeout <= 0 {
+		opts.Timeout = defaultTimeout
+	}
+	generatedAt := opts.GeneratedAt
+	if generatedAt == "" {
+		generatedAt = time.Now().UTC().Format(time.RFC3339)
+	}
+
+	root, err := fetchEventByID(ctx, opts, opts.RootEventID)
+	if err != nil {
+		return nil, fmt.Errorf("fetch root event: %w", err)
+	}
+	if root == nil {
+		return nil, fmt.Errorf("root event %q not found", opts.RootEventID)
+	}
+
+	// BFS over sessions. We index every event we've fetched by id so
+	// peer-id lookups (from links) only trigger an extra HTTP roundtrip
+	// when the peer is in a session we haven't visited yet.
+	visited := map[string]bool{}
+	knownEventIDs := map[string]bool{}
+	queue := []string{root.SessionID}
+	visited[root.SessionID] = true
+	var sessions []Session
+
+	for len(queue) > 0 {
+		if len(sessions) >= opts.MaxSessions {
+			return nil, fmt.Errorf(
+				"max-sessions cap (%d) hit while traversing link graph; raise --max-sessions or trim the trace",
+				opts.MaxSessions)
+		}
+		sessionID := queue[0]
+		queue = queue[1:]
+
+		events, err := fetchSessionEvents(ctx, opts, sessionID)
+		if err != nil {
+			return nil, fmt.Errorf("fetch session %q: %w", sessionID, err)
+		}
+		head, err := fetchSessionHead(ctx, opts, sessionID)
+		if err != nil {
+			return nil, fmt.Errorf("fetch session head %q: %w", sessionID, err)
+		}
+		sessions = append(sessions, Session{
+			SessionID: sessionID,
+			HeadHash:  head,
+			Events:    events,
+		})
+		for _, e := range events {
+			knownEventIDs[e.ID] = true
+		}
+
+		// Walk links → discover peer events → discover new sessions.
+		// peerSet dedupes within this session's events.
+		peerSet := map[string]bool{}
+		for _, e := range events {
+			for _, l := range e.Links {
+				peer := peerEventID(l, e.ID)
+				if peer != "" && !knownEventIDs[peer] {
+					peerSet[peer] = true
+				}
+			}
+		}
+		for peerID := range peerSet {
+			peer, err := fetchEventByID(ctx, opts, peerID)
+			if err != nil {
+				return nil, fmt.Errorf("fetch peer event %q: %w", peerID, err)
+			}
+			if peer == nil {
+				// Dangling link target — log and skip rather than fail
+				// the whole report. A link to a deleted/never-stored
+				// event isn't fatal; it's just a gap the verifier sees.
+				continue
+			}
+			if !visited[peer.SessionID] {
+				visited[peer.SessionID] = true
+				queue = append(queue, peer.SessionID)
+			}
+		}
+	}
+
+	atts, err := loadAttestations(opts.Attestations)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &Report{
+		Version:      Version,
+		GeneratedAt:  generatedAt,
+		Generator:    opts.Generator,
+		StoreURL:     opts.URL,
+		RootEventID:  opts.RootEventID,
+		Sessions:     sessions,
+		Attestations: atts,
+	}
+	manifest, err := computeManifest(r)
+	if err != nil {
+		return nil, fmt.Errorf("compute manifest: %w", err)
+	}
+	r.Manifest = manifest
+	return r, nil
+}
+
+// peerEventID picks the side of a link that isn't `eventID`. Returns
+// "" if eventID matches neither side (shouldn't happen since the
+// server filters links by the event we asked for, but defensive).
+func peerEventID(l Link, eventID string) string {
+	switch {
+	case l.FromEvent == eventID:
+		return l.ToEvent
+	case l.ToEvent == eventID:
+		return l.FromEvent
+	}
+	return ""
+}
+
+// loadAttestations reads each file verbatim, base64-encodes for JSON
+// transport, and records the sha256 of the original bytes. The
+// envelope bytes are stored as-is so a verifier hashes the same input
+// cosign / sigstore would.
+func loadAttestations(paths []string) ([]Attestation, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	out := make([]Attestation, 0, len(paths))
+	for _, p := range paths {
+		raw, err := os.ReadFile(p)
+		if err != nil {
+			return nil, fmt.Errorf("read attestation %s: %w", p, err)
+		}
+		sum := sha256.Sum256(raw)
+		out = append(out, Attestation{
+			Filename:    filepath.Base(p),
+			Sha256:      "sha256:" + hex.EncodeToString(sum[:]),
+			EnvelopeB64: base64.StdEncoding.EncodeToString(raw),
+		})
+	}
+	return out, nil
+}
+
+// computeManifest serializes the bulky sections to canonical JSON
+// (encoding/json sorts map keys alphabetically since Go 1.12; struct
+// field order is source-stable) and hashes them. Verifiers re-do the
+// same marshal+hash and compare.
+func computeManifest(r *Report) (Manifest, error) {
+	sessionsBytes, err := json.Marshal(r.Sessions)
+	if err != nil {
+		return Manifest{}, err
+	}
+	attsBytes, err := json.Marshal(r.Attestations)
+	if err != nil {
+		return Manifest{}, err
+	}
+	sessionsSum := sha256.Sum256(sessionsBytes)
+	attsSum := sha256.Sum256(attsBytes)
+	return Manifest{
+		SessionsSha256:     "sha256:" + hex.EncodeToString(sessionsSum[:]),
+		AttestationsSha256: "sha256:" + hex.EncodeToString(attsSum[:]),
+	}, nil
+}
+
+// --- GraphQL fetch helpers ---
+
+// auditEventQueryFields is the field set every fetcher requests; kept
+// as a string constant so a future schema bump only needs touching
+// here.
+const auditEventQueryFields = `
+    id
+    ts
+    sessionId
+    kind
+    actor { type id model }
+    payload
+    hash
+    prevHash
+    refs
+    links { fromEvent toEvent relation confidence inferredBy }
+`
+
+const eventByIDForAudit = `query AuditEventByID($id: ID!) {
+  event(id: $id) {` + auditEventQueryFields + `}
+}`
+
+const eventsBySessionForAudit = `query AuditEventsBySession($s: String!) {
+  events(sessionId: $s, limit: 100000) {` + auditEventQueryFields + `}
+}`
+
+const sessionHeadForAudit = `query AuditSessionHead($s: String!) {
+  sessionHead(sessionId: $s)
+}`
+
+func fetchEventByID(ctx context.Context, opts BuildOptions, id string) (*Event, error) {
+	var out struct {
+		Data struct {
+			Event *Event `json:"event"`
+		} `json:"data"`
+	}
+	if err := graphqlPost(ctx, opts, eventByIDForAudit, map[string]any{"id": id}, &out); err != nil {
+		return nil, err
+	}
+	return out.Data.Event, nil
+}
+
+func fetchSessionEvents(ctx context.Context, opts BuildOptions, sessionID string) ([]Event, error) {
+	var out struct {
+		Data struct {
+			Events []Event `json:"events"`
+		} `json:"data"`
+	}
+	if err := graphqlPost(ctx, opts, eventsBySessionForAudit, map[string]any{"s": sessionID}, &out); err != nil {
+		return nil, err
+	}
+	return out.Data.Events, nil
+}
+
+func fetchSessionHead(ctx context.Context, opts BuildOptions, sessionID string) (string, error) {
+	var out struct {
+		Data struct {
+			SessionHead string `json:"sessionHead"`
+		} `json:"data"`
+	}
+	if err := graphqlPost(ctx, opts, sessionHeadForAudit, map[string]any{"s": sessionID}, &out); err != nil {
+		return "", err
+	}
+	return out.Data.SessionHead, nil
+}
+
+// graphqlPost POSTs a query+variables and decodes into out. Decodes
+// with UseNumber so payload integers don't lose precision in float64
+// (build / deploy webhook ids can grow).
+func graphqlPost(ctx context.Context, opts BuildOptions, query string, vars map[string]any, out any) error {
+	body, err := json.Marshal(map[string]any{
+		"query":     query,
+		"variables": vars,
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, opts.URL+"/v1/graphql", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if opts.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+opts.Token)
+	}
+	resp, err := (&http.Client{Timeout: opts.Timeout}).Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(raw))
+	}
+
+	// Surface graphql-level errors before trying to decode the payload —
+	// the schema is guaranteed to omit `data` when there are errors,
+	// so json.Unmarshal into a zero out would just leave it empty and
+	// the caller would get a confusing "session has 0 events".
+	var ep struct {
+		Errors []struct {
+			Message string `json:"message"`
+		} `json:"errors"`
+	}
+	if err := json.Unmarshal(raw, &ep); err == nil && len(ep.Errors) > 0 {
+		return fmt.Errorf("graphql: %s", ep.Errors[0].Message)
+	}
+
+	// Decoder over a bytes.Reader so we keep UseNumber semantics for
+	// payload integers (build / deploy webhook ids can grow).
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	return dec.Decode(out)
+}

--- a/internal/audit/builder_test.go
+++ b/internal/audit/builder_test.go
@@ -1,0 +1,283 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+
+	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dongqiu/agent-lens/internal/linking"
+	"github.com/dongqiu/agent-lens/internal/query"
+	"github.com/dongqiu/agent-lens/internal/store"
+)
+
+// startTestServer wires ingest + query + linking against an in-memory
+// store, mirroring the production assembly minus auth. Returns the
+// httptest URL for direct GraphQL POSTs. The linker runs in a
+// goroutine cancelled at test end.
+func startTestServer(t *testing.T) string {
+	t.Helper()
+	st := store.NewMemory()
+
+	ingestH := ingest.NewHandler(st)
+	linker := linking.New(st, 1024)
+	ingestH.AfterAppend(func(_ context.Context, ev *ingest.WireEvent) {
+		linker.Notify(ev)
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		linker.Run(ctx)
+	}()
+	t.Cleanup(func() {
+		cancel()
+		<-done
+	})
+
+	r := chi.NewRouter()
+	r.Route("/v1", func(sub chi.Router) {
+		sub.Post("/events", ingestH.IngestNDJSON)
+		query.RegisterRoutes(sub, st)
+	})
+	srv := httptest.NewServer(r)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// waitForLinks polls until the named session has at least one event
+// with non-empty links, then returns. Caps at ~1s to avoid hanging
+// CI if the linker isn't running. The linker is async (Notify is
+// non-blocking) so a test posting events and immediately reading
+// back the link graph would otherwise race the worker.
+func waitForLinks(t *testing.T, url, sessionID string) {
+	t.Helper()
+	deadline := time.Now().Add(1 * time.Second)
+	for time.Now().Before(deadline) {
+		body, _ := json.Marshal(map[string]any{
+			"query":     `query($s: String!) { events(sessionId: $s, limit: 10) { id links { fromEvent } } }`,
+			"variables": map[string]any{"s": sessionID},
+		})
+		resp, err := http.Post(url+"/v1/graphql", "application/json", strings.NewReader(string(body)))
+		if err != nil {
+			time.Sleep(20 * time.Millisecond)
+			continue
+		}
+		var out struct {
+			Data struct {
+				Events []struct {
+					Links []struct{ FromEvent string } `json:"links"`
+				} `json:"events"`
+			} `json:"data"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&out)
+		resp.Body.Close()
+		for _, e := range out.Data.Events {
+			if len(e.Links) > 0 {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("linker didn't produce links for session %q within 1s", sessionID)
+}
+
+// postNDJSON helper — caller passes the raw NDJSON body.
+func postNDJSON(t *testing.T, url, body string) {
+	t.Helper()
+	resp, err := http.Post(url+"/v1/events", "application/x-ndjson", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+}
+
+// firstEventID does a minimal GraphQL `events(sessionId)` to discover
+// the server-assigned id of an event in the named session — most
+// builder tests need this to pass --root.
+func firstEventID(t *testing.T, url, sessionID string) string {
+	t.Helper()
+	body, _ := json.Marshal(map[string]any{
+		"query":     `query($s: String!) { events(sessionId: $s, limit: 1) { id } }`,
+		"variables": map[string]any{"s": sessionID},
+	})
+	resp, err := http.Post(url+"/v1/graphql", "application/json", strings.NewReader(string(body)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var out struct {
+		Data struct {
+			Events []struct {
+				ID string `json:"id"`
+			} `json:"events"`
+		} `json:"data"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	if len(out.Data.Events) == 0 {
+		t.Fatalf("no events for session %q", sessionID)
+	}
+	return out.Data.Events[0].ID
+}
+
+func TestBuildSingleSession(t *testing.T) {
+	url := startTestServer(t)
+	postNDJSON(t, url, strings.Join([]string{
+		`{"session_id":"s-only","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"hi"}}`,
+		`{"session_id":"s-only","actor":{"type":"agent","id":"claude-code"},"kind":"thought","payload":{"text":"plan"}}`,
+	}, "\n"))
+
+	rootID := firstEventID(t, url, "s-only")
+	r, err := Build(context.Background(), BuildOptions{
+		URL:         url,
+		RootEventID: rootID,
+		Generator:   "test",
+	})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if r.Version != Version {
+		t.Errorf("version = %q", r.Version)
+	}
+	if len(r.Sessions) != 1 || r.Sessions[0].SessionID != "s-only" {
+		t.Errorf("sessions = %+v", r.Sessions)
+	}
+	if len(r.Sessions[0].Events) != 2 {
+		t.Errorf("events = %d, want 2", len(r.Sessions[0].Events))
+	}
+	if r.Manifest.SessionsSha256 == "" || r.Manifest.AttestationsSha256 == "" {
+		t.Errorf("manifest empty: %+v", r.Manifest)
+	}
+
+	// The fresh report should pass Verify on its own.
+	res, err := Verify(r, VerifyOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Issues) != 0 {
+		t.Errorf("self-verify failed: %v", res.Issues)
+	}
+}
+
+func TestBuildLinkedSessionsBFS(t *testing.T) {
+	// Two sessions sharing a git: ref → linker creates a Link →
+	// builder should walk from one root and pull both sessions in.
+	url := startTestServer(t)
+	postNDJSON(t, url, strings.Join([]string{
+		`{"session_id":"s-prompt","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"build it"},"refs":["git:abc123"]}`,
+		`{"session_id":"s-build","actor":{"type":"system","id":"CI"},"kind":"build","payload":{"sha":"abc123"},"refs":["git:abc123"]}`,
+	}, "\n"))
+	waitForLinks(t, url, "s-prompt")
+
+	rootID := firstEventID(t, url, "s-prompt")
+	r, err := Build(context.Background(), BuildOptions{
+		URL:         url,
+		RootEventID: rootID,
+		Generator:   "test",
+	})
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if len(r.Sessions) != 2 {
+		t.Fatalf("expected 2 sessions (prompt+build), got %d (%+v)", len(r.Sessions), sessionIDs(r))
+	}
+	have := map[string]bool{}
+	for _, s := range r.Sessions {
+		have[s.SessionID] = true
+	}
+	if !have["s-prompt"] || !have["s-build"] {
+		t.Errorf("missing sessions: %+v", have)
+	}
+}
+
+func TestBuildMaxSessionsCap(t *testing.T) {
+	// Hit the cap by setting MaxSessions=1 against a 2-session graph.
+	url := startTestServer(t)
+	postNDJSON(t, url, strings.Join([]string{
+		`{"session_id":"s-a","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"x"},"refs":["git:cap"]}`,
+		`{"session_id":"s-b","actor":{"type":"system","id":"CI"},"kind":"build","payload":{"sha":"cap"},"refs":["git:cap"]}`,
+	}, "\n"))
+	waitForLinks(t, url, "s-a")
+
+	rootID := firstEventID(t, url, "s-a")
+	_, err := Build(context.Background(), BuildOptions{
+		URL:         url,
+		RootEventID: rootID,
+		MaxSessions: 1,
+		Generator:   "test",
+	})
+	if err == nil {
+		t.Fatal("expected max-sessions cap error")
+	}
+	if !strings.Contains(err.Error(), "max-sessions") {
+		t.Errorf("error didn't mention cap: %v", err)
+	}
+}
+
+func TestBuildMissingRootEventErrors(t *testing.T) {
+	url := startTestServer(t)
+	_, err := Build(context.Background(), BuildOptions{
+		URL:         url,
+		RootEventID: "01HNOSUCH",
+		Generator:   "test",
+	})
+	if err == nil {
+		t.Fatal("expected error on unknown root id")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected not-found error, got: %v", err)
+	}
+}
+
+func TestBuildEmbedsAttestationsAndManifest(t *testing.T) {
+	url := startTestServer(t)
+	postNDJSON(t, url, `{"session_id":"s-att","actor":{"type":"human","id":"alice"},"kind":"prompt","payload":{"text":"x"}}`)
+	rootID := firstEventID(t, url, "s-att")
+
+	dir := t.TempDir()
+	att := filepath.Join(dir, "deploy.intoto.jsonl")
+	if err := os.WriteFile(att, []byte("ATTEST-CONTENTS"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := Build(context.Background(), BuildOptions{
+		URL:          url,
+		RootEventID:  rootID,
+		Attestations: []string{att},
+		Generator:    "test",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Attestations) != 1 {
+		t.Fatalf("attestations = %d", len(r.Attestations))
+	}
+	if r.Attestations[0].Filename != "deploy.intoto.jsonl" {
+		t.Errorf("filename = %q", r.Attestations[0].Filename)
+	}
+	if !strings.HasPrefix(r.Attestations[0].Sha256, "sha256:") {
+		t.Errorf("sha256 = %q", r.Attestations[0].Sha256)
+	}
+
+	// And it should round-trip through Verify cleanly.
+	res, _ := Verify(r, VerifyOptions{})
+	if len(res.Issues) != 0 {
+		t.Errorf("self-verify of fresh report failed: %v", res.Issues)
+	}
+}
+
+func sessionIDs(r *Report) []string {
+	out := make([]string, 0, len(r.Sessions))
+	for _, s := range r.Sessions {
+		out = append(out, s.SessionID)
+	}
+	return out
+}

--- a/internal/audit/report.go
+++ b/internal/audit/report.go
@@ -1,0 +1,95 @@
+// Package audit produces and verifies M3-D audit report bundles —
+// self-contained JSON files that capture an evidence chain rooted at
+// a single event id, plus optional in-toto / SLSA attestations, plus
+// a sha256 manifest making the bundle tamper-evident.
+//
+// A bundle is built by the agent-lens-hook CLI by walking the link
+// graph via GraphQL (single-hop links → linked sessions → events),
+// and is verified offline by re-hashing the canonicalized sections
+// and re-walking each session's prev_hash → hash chain.
+package audit
+
+// Version identifies the report schema. Bumped only on breaking
+// shape changes; verifiers are expected to refuse unknown versions.
+const Version = "agent-lens.dev/audit-report/v1"
+
+// Report is the on-disk JSON shape. Marshaled with json.MarshalIndent
+// for human readability; verifiers re-hash the canonical (compact)
+// form of `Sessions` and `Attestations` to compare against
+// `Manifest.{SessionsSha256,AttestationsSha256}`.
+//
+// JSON field tags use snake_case to match the rest of the agent-lens
+// wire format (events, predicates).
+type Report struct {
+	Version      string        `json:"version"`
+	GeneratedAt  string        `json:"generated_at"`
+	Generator    string        `json:"generator"`
+	StoreURL     string        `json:"store_url,omitempty"`
+	RootEventID  string        `json:"root_event_id"`
+	Sessions     []Session     `json:"sessions"`
+	Attestations []Attestation `json:"attestations,omitempty"`
+	Manifest     Manifest      `json:"manifest"`
+}
+
+// Session bundles every event in one session_id, plus the head hash
+// the server reported at fetch time. The head lets a verifier notice
+// "we have N events and the head matches event[N-1]; nothing was
+// truncated mid-fetch".
+type Session struct {
+	SessionID string  `json:"session_id"`
+	HeadHash  string  `json:"head_hash"`
+	Events    []Event `json:"events"`
+}
+
+// Event is the per-event record. Mirrors the GraphQL `Event` type
+// (so JSON tags are camelCase to decode straight from the server)
+// but only carries the fields a verifier needs: id + ts + kind +
+// actor for audit context, hash + prevHash for chain integrity,
+// payload for re-derivation if (when) we add server-side hash
+// recompute.
+type Event struct {
+	ID        string         `json:"id"`
+	TS        string         `json:"ts"`
+	SessionID string         `json:"sessionId"`
+	Kind      string         `json:"kind"`
+	Actor     Actor          `json:"actor"`
+	Payload   map[string]any `json:"payload,omitempty"`
+	Hash      string         `json:"hash"`
+	PrevHash  string         `json:"prevHash,omitempty"`
+	Refs      []string       `json:"refs,omitempty"`
+	Links     []Link         `json:"links,omitempty"`
+}
+
+// Actor mirrors the GraphQL Actor type.
+type Actor struct {
+	Type  string `json:"type"`
+	ID    string `json:"id"`
+	Model string `json:"model,omitempty"`
+}
+
+// Link mirrors the GraphQL Link type. Carried so a verifier can
+// re-render the trace graph offline without re-querying.
+type Link struct {
+	FromEvent  string  `json:"fromEvent"`
+	ToEvent    string  `json:"toEvent"`
+	Relation   string  `json:"relation"`
+	Confidence float64 `json:"confidence"`
+	InferredBy string  `json:"inferredBy"`
+}
+
+// Attestation embeds one .intoto.jsonl envelope verbatim. The bytes
+// are *not* re-encoded — Sha256 is computed over the original file
+// bytes so a verifier hashes the same input cosign / sigstore would.
+type Attestation struct {
+	Filename    string `json:"filename"`
+	Sha256      string `json:"sha256"` // sha256:<hex>
+	EnvelopeB64 string `json:"envelope_b64"`
+}
+
+// Manifest carries the canonical sha256 of each bulky section so the
+// report itself is tamper-evident: a verifier re-marshals Sessions
+// and Attestations, hashes, and compares.
+type Manifest struct {
+	SessionsSha256     string `json:"sessions_sha256"`
+	AttestationsSha256 string `json:"attestations_sha256"`
+}

--- a/internal/audit/verify.go
+++ b/internal/audit/verify.go
@@ -1,0 +1,134 @@
+package audit
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/dongqiu/agent-lens/internal/attest"
+)
+
+// VerifyOptions configures Verify. PubKey is optional — if nil, DSSE
+// envelope verification is skipped (the manifest + chain checks still
+// run, so the report is meaningfully checked even on hosts without
+// the signing key).
+type VerifyOptions struct {
+	PubKey *attest.PublicKey
+}
+
+// VerifyResult records what passed and what didn't. A non-nil result
+// with len(Issues) == 0 means the report is internally consistent.
+type VerifyResult struct {
+	SessionsCount        int
+	EventsCount          int
+	AttestationsVerified int // 0 if PubKey nil; otherwise attestations whose DSSE signature checked out
+	AttestationsSkipped  int // counted only when PubKey is nil
+	Issues               []string
+}
+
+// Verify checks a Report's internal consistency:
+//  1. Version is recognized.
+//  2. Manifest sha256s match a fresh hash of Sessions / Attestations.
+//  3. Each session's events have prev_hash → hash linkage and the
+//     last event's hash matches Session.HeadHash.
+//  4. Each attestation's recorded sha256 matches the embedded bytes.
+//  5. (Optional) Each DSSE envelope verifies with PubKey.
+//
+// Returns the result regardless of pass/fail; callers decide how to
+// surface issues. Returns a non-nil error only on programming-level
+// problems (failed json.Marshal, etc.).
+func Verify(r *Report, opts VerifyOptions) (*VerifyResult, error) {
+	if r == nil {
+		return nil, errors.New("nil report")
+	}
+	res := &VerifyResult{}
+
+	if r.Version != Version {
+		res.Issues = append(res.Issues, fmt.Sprintf(
+			"unrecognized report version %q (expected %q); refusing to interpret further",
+			r.Version, Version))
+		return res, nil
+	}
+
+	// Manifest re-hash. Use the same canonical encoding the builder
+	// used (encoding/json with default settings).
+	wantManifest, err := computeManifest(r)
+	if err != nil {
+		return nil, fmt.Errorf("recompute manifest: %w", err)
+	}
+	if wantManifest.SessionsSha256 != r.Manifest.SessionsSha256 {
+		res.Issues = append(res.Issues, fmt.Sprintf(
+			"manifest.sessions_sha256 mismatch: report says %s, recomputed %s",
+			r.Manifest.SessionsSha256, wantManifest.SessionsSha256))
+	}
+	if wantManifest.AttestationsSha256 != r.Manifest.AttestationsSha256 {
+		res.Issues = append(res.Issues, fmt.Sprintf(
+			"manifest.attestations_sha256 mismatch: report says %s, recomputed %s",
+			r.Manifest.AttestationsSha256, wantManifest.AttestationsSha256))
+	}
+
+	// Per-session chain walk. Server returns events in append order
+	// (ts ASC, id ASC); each prev_hash should equal the previous
+	// event's hash, and the head should equal the last event's hash.
+	res.SessionsCount = len(r.Sessions)
+	for _, s := range r.Sessions {
+		res.EventsCount += len(s.Events)
+		for i, e := range s.Events {
+			var want string
+			if i > 0 {
+				want = s.Events[i-1].Hash
+			}
+			if e.PrevHash != want {
+				res.Issues = append(res.Issues, fmt.Sprintf(
+					"session %q event[%d] (id=%s): prev_hash=%q, expected %q",
+					s.SessionID, i, e.ID, e.PrevHash, want))
+			}
+		}
+		if len(s.Events) > 0 && s.HeadHash != "" {
+			lastHash := s.Events[len(s.Events)-1].Hash
+			if s.HeadHash != lastHash {
+				res.Issues = append(res.Issues, fmt.Sprintf(
+					"session %q: head_hash %s != last event hash %s (truncated mid-fetch?)",
+					s.SessionID, s.HeadHash, lastHash))
+			}
+		}
+	}
+
+	// Attestation re-hash.
+	for _, a := range r.Attestations {
+		envBytes, err := base64.StdEncoding.DecodeString(a.EnvelopeB64)
+		if err != nil {
+			res.Issues = append(res.Issues, fmt.Sprintf(
+				"attestation %q: base64 decode: %v", a.Filename, err))
+			continue
+		}
+		sum := sha256.Sum256(envBytes)
+		got := "sha256:" + hex.EncodeToString(sum[:])
+		if got != a.Sha256 {
+			res.Issues = append(res.Issues, fmt.Sprintf(
+				"attestation %q: recorded sha256 %s != computed %s",
+				a.Filename, a.Sha256, got))
+		}
+
+		if opts.PubKey == nil {
+			res.AttestationsSkipped++
+			continue
+		}
+		var env attest.Envelope
+		if err := json.Unmarshal(envBytes, &env); err != nil {
+			res.Issues = append(res.Issues, fmt.Sprintf(
+				"attestation %q: decode envelope: %v", a.Filename, err))
+			continue
+		}
+		if _, _, err := attest.Verify(opts.PubKey, &env); err != nil {
+			res.Issues = append(res.Issues, fmt.Sprintf(
+				"attestation %q: DSSE verify: %v", a.Filename, err))
+			continue
+		}
+		res.AttestationsVerified++
+	}
+	return res, nil
+}

--- a/internal/audit/verify.go
+++ b/internal/audit/verify.go
@@ -1,6 +1,7 @@
 package audit
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -10,6 +11,18 @@ import (
 
 	"github.com/dongqiu/agent-lens/internal/attest"
 )
+
+// DecodeReport unmarshals a report file with UseNumber so payload
+// integers stay as json.Number rather than float64 — that's what
+// Build wrote, and re-marshaling a float64 of a >2^53 integer would
+// drift bytes and surface as a spurious manifest mismatch. Use this
+// in preference to plain json.Unmarshal when reading a report off
+// disk.
+func DecodeReport(raw []byte, r *Report) error {
+	dec := json.NewDecoder(bytes.NewReader(raw))
+	dec.UseNumber()
+	return dec.Decode(r)
+}
 
 // VerifyOptions configures Verify. PubKey is optional — if nil, DSSE
 // envelope verification is skipped (the manifest + chain checks still

--- a/internal/audit/verify_test.go
+++ b/internal/audit/verify_test.go
@@ -1,0 +1,235 @@
+package audit
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/dongqiu/agent-lens/internal/attest"
+)
+
+// makeReport returns a tiny, internally-consistent Report that
+// individual tests then mutate to introduce specific failures.
+func makeReport(t *testing.T) *Report {
+	t.Helper()
+	r := &Report{
+		Version:     Version,
+		GeneratedAt: "2026-04-28T00:00:00Z",
+		Generator:   "test",
+		StoreURL:    "http://lens.test",
+		RootEventID: "e1",
+		Sessions: []Session{
+			{
+				SessionID: "s1",
+				HeadHash:  "h2",
+				Events: []Event{
+					{ID: "e1", TS: "2026-04-28T00:00:00Z", SessionID: "s1", Kind: "PROMPT",
+						Actor: Actor{Type: "HUMAN", ID: "alice"},
+						Hash:  "h1"},
+					{ID: "e2", TS: "2026-04-28T00:00:01Z", SessionID: "s1", Kind: "THOUGHT",
+						Actor: Actor{Type: "AGENT", ID: "claude-code"},
+						Hash:  "h2", PrevHash: "h1"},
+				},
+			},
+		},
+	}
+	m, err := computeManifest(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r.Manifest = m
+	return r
+}
+
+func TestVerifyHappyPath(t *testing.T) {
+	r := makeReport(t)
+	res, err := Verify(r, VerifyOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Issues) != 0 {
+		t.Errorf("expected zero issues on a clean report, got: %v", res.Issues)
+	}
+	if res.SessionsCount != 1 || res.EventsCount != 2 {
+		t.Errorf("counts wrong: %+v", res)
+	}
+}
+
+func TestVerifyRejectsUnknownVersion(t *testing.T) {
+	r := makeReport(t)
+	r.Version = "agent-lens.dev/audit-report/v999"
+	res, _ := Verify(r, VerifyOptions{})
+	if len(res.Issues) == 0 || !strings.Contains(res.Issues[0], "unrecognized") {
+		t.Errorf("expected version issue, got %v", res.Issues)
+	}
+}
+
+func TestVerifyDetectsSessionsTamper(t *testing.T) {
+	r := makeReport(t)
+	// Mutate an event after manifest is computed → sessions hash drifts.
+	r.Sessions[0].Events[0].Kind = "TAMPERED"
+	res, _ := Verify(r, VerifyOptions{})
+	if len(res.Issues) == 0 {
+		t.Fatal("expected manifest mismatch issue")
+	}
+	found := false
+	for _, iss := range res.Issues {
+		if strings.Contains(iss, "sessions_sha256") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected sessions_sha256 issue, got: %v", res.Issues)
+	}
+}
+
+func TestVerifyDetectsBrokenChain(t *testing.T) {
+	r := makeReport(t)
+	r.Sessions[0].Events[1].PrevHash = "not-the-right-hash"
+	// Recompute manifest so we don't also trip the sessions_sha256 check —
+	// the test isolates the chain-walk failure.
+	m, _ := computeManifest(r)
+	r.Manifest = m
+	res, _ := Verify(r, VerifyOptions{})
+	if len(res.Issues) == 0 {
+		t.Fatal("expected chain mismatch")
+	}
+	if !strings.Contains(res.Issues[0], "prev_hash") {
+		t.Errorf("expected prev_hash issue, got: %v", res.Issues)
+	}
+}
+
+func TestVerifyDetectsHeadHashMismatch(t *testing.T) {
+	r := makeReport(t)
+	r.Sessions[0].HeadHash = "wrong-head"
+	m, _ := computeManifest(r)
+	r.Manifest = m
+	res, _ := Verify(r, VerifyOptions{})
+	found := false
+	for _, iss := range res.Issues {
+		if strings.Contains(iss, "head_hash") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected head_hash issue, got: %v", res.Issues)
+	}
+}
+
+func TestVerifyAttestationRehashAndDSSE(t *testing.T) {
+	priv, pub, err := attest.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stmt := attest.Statement{
+		Type: attest.InTotoStatementType,
+		Subject: []attest.Subject{
+			{Name: "x", Digest: map[string]string{"sha256": "abc"}},
+		},
+		PredicateType: "agent-lens.dev/code-provenance/v1",
+		Predicate:     json.RawMessage(`{}`),
+	}
+	stmtBytes, _ := json.Marshal(stmt)
+	env, err := attest.Sign(priv, attest.InTotoPayloadType, stmtBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	envBytes, _ := json.Marshal(env)
+
+	atts, err := loadAttestationBytes(map[string][]byte{"test.intoto.jsonl": envBytes})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	r := makeReport(t)
+	r.Attestations = atts
+	m, _ := computeManifest(r)
+	r.Manifest = m
+
+	// With pub key: DSSE verifies, count goes up.
+	res, _ := Verify(r, VerifyOptions{PubKey: pub})
+	if len(res.Issues) != 0 {
+		t.Fatalf("clean report with valid attestation should have no issues, got: %v", res.Issues)
+	}
+	if res.AttestationsVerified != 1 || res.AttestationsSkipped != 0 {
+		t.Errorf("expected 1 verified, got %+v", res)
+	}
+
+	// Without pub key: skipped, no issues.
+	res2, _ := Verify(r, VerifyOptions{})
+	if len(res2.Issues) != 0 {
+		t.Errorf("nil pub key should skip without issues, got: %v", res2.Issues)
+	}
+	if res2.AttestationsVerified != 0 || res2.AttestationsSkipped != 1 {
+		t.Errorf("expected skip when pub key nil, got %+v", res2)
+	}
+
+	// Tampered attestation bytes (change one byte AFTER hash recorded) →
+	// re-hash mismatch.
+	tampered := append([]byte{}, envBytes...)
+	tampered[0] = 'X'
+	r.Attestations[0].EnvelopeB64 = base64.StdEncoding.EncodeToString(tampered)
+	m, _ = computeManifest(r) // re-record manifest so we isolate the rehash issue
+	r.Manifest = m
+	res3, _ := Verify(r, VerifyOptions{PubKey: pub})
+	if len(res3.Issues) == 0 {
+		t.Fatal("expected attestation rehash mismatch")
+	}
+}
+
+func TestVerifyWrongPubKeyFlagsAttestation(t *testing.T) {
+	priv, _, _ := attest.GenerateKey()
+	_, otherPub, _ := attest.GenerateKey()
+	stmt := attest.Statement{
+		Type:          attest.InTotoStatementType,
+		Subject:       []attest.Subject{{Name: "x", Digest: map[string]string{"sha256": "abc"}}},
+		PredicateType: "x", Predicate: json.RawMessage(`{}`),
+	}
+	stmtBytes, _ := json.Marshal(stmt)
+	env, _ := attest.Sign(priv, attest.InTotoPayloadType, stmtBytes)
+	envBytes, _ := json.Marshal(env)
+	atts, _ := loadAttestationBytes(map[string][]byte{"x.intoto.jsonl": envBytes})
+
+	r := makeReport(t)
+	r.Attestations = atts
+	m, _ := computeManifest(r)
+	r.Manifest = m
+
+	res, _ := Verify(r, VerifyOptions{PubKey: otherPub})
+	if len(res.Issues) == 0 {
+		t.Fatal("expected DSSE verify failure with wrong key")
+	}
+	if !strings.Contains(strings.Join(res.Issues, "|"), "DSSE") {
+		t.Errorf("expected DSSE error, got: %v", res.Issues)
+	}
+}
+
+// loadAttestationBytes is a test helper that mirrors loadAttestations
+// without needing files on disk — keyed by name → bytes.
+func loadAttestationBytes(in map[string][]byte) ([]Attestation, error) {
+	out := make([]Attestation, 0, len(in))
+	// Iterate in deterministic order so tests don't flake on map order.
+	keys := make([]string, 0, len(in))
+	for k := range in {
+		keys = append(keys, k)
+	}
+	// No sort.Strings here on purpose — tests pass a single key today;
+	// add sort if multi-attestation cases land later.
+	for _, k := range keys {
+		raw := in[k]
+		out = append(out, Attestation{
+			Filename:    k,
+			Sha256:      hexHash(raw),
+			EnvelopeB64: base64.StdEncoding.EncodeToString(raw),
+		})
+	}
+	return out, nil
+}
+
+func hexHash(b []byte) string {
+	sum := sha256.Sum256(b)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}


### PR DESCRIPTION
## Summary

Closes the M3 milestone per SPEC §14 — single-file JSON audit bundle + offline verifier.

- **`agent-lens-hook export audit-report --root <event-id>`** — BFS walk through the link graph from the root event, collects every reachable event grouped by session (hash / prev_hash / payload preserved), embeds optional `--attestation <file>` envelopes verbatim, computes sha256 manifest. JSON output is suitable for archiving / mailing / pasting into a compliance tracker.
- **`agent-lens-hook verify-audit-report <file>`** — recomputes manifest hashes (Sessions / Attestations sections), re-walks each session's `prev_hash → hash` chain, re-hashes each embedded envelope, and (optional) DSSE-verifies signatures with `--pub`. Exit 0 clean / 1 issue found / 2 usage error — same gate semantics as `verify-attestation`.
- Walk is capped by `--max-sessions` (default 50) and errors out rather than silently truncating, so a partial bundle can't be mistaken for a complete one.
- New `internal/audit` package with the `Report` / `Builder` / `Verify` API; CLI wrappers in `cmd/agent-lens-hook/audit_report.go`.

This also delivers the last item on SPEC §14 M3 ("审计报告导出"), so §17 dogfooding is now unblocked.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...` — all pass
- [x] Unit tests: manifest re-hash detects tampered events; broken prev_hash chain detected; head_hash mismatch detected; attestation re-hash detects byte tamper; DSSE verify catches wrong-key signatures
- [x] E2E: build a real bundle from httptest server (ingest + linker + query), then verify it round-trips cleanly through verify-audit-report
- [x] Builder BFS test exercises the linker producing cross-session links via shared `git:` ref, then walks both sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)