### PR TITLE
feat: §17 dogfood activation

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -1,0 +1,46 @@
+{
+  "_comment": "Sample Claude Code hook config for §17 self-observation. Copy this file to .claude/settings.local.json (gitignored, per-developer) to opt in. Requires agent-lens-hook on PATH and a running agent-lens server (run `script/install-dogfood.sh` to set both up).",
+
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "agent-lens-hook claude", "timeout": 5}
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "agent-lens-hook claude", "timeout": 5}
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "agent-lens-hook claude", "timeout": 5}
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {"type": "command", "command": "agent-lens-hook claude", "timeout": 5}
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "agent-lens-hook claude", "timeout": 30}
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -1,6 +1,4 @@
 {
-  "_comment": "Sample Claude Code hook config for §17 self-observation. Copy this file to .claude/settings.local.json (gitignored, per-developer) to opt in. Requires agent-lens-hook on PATH and a running agent-lens server (run `script/install-dogfood.sh` to set both up).",
-
   "hooks": {
     "UserPromptSubmit": [
       {

--- a/README.md
+++ b/README.md
@@ -276,6 +276,62 @@ webhook 路径（M2-C-1）只能拿到 GitHub 那边的 lifecycle，**没有 art
 
 详细文档见 [`actions/build/README.md`](./actions/build/README.md)，完整示例 [`examples/github-actions/build.yml`](./examples/github-actions/build.yml)。session_id 跟 webhook 对齐（`github-build:<owner>/<repo>/<run_id>`），两条腿事件汇入同一时间线。
 
+## §17 自观测（Dogfooding）
+
+M3 收尾后激活：本仓库自身的开发循环跑在 agent-lens 上——prompt / thinking / tool call / commit 全链路落库，串成"工具用自己审计自己"的证据链。激活是**强 opt-in**，不会动外部贡献者的 home dir，也不在 Claude Code 里产生噪声。
+
+### 一键激活
+
+```bash
+script/install-dogfood.sh
+```
+
+干三件事：
+
+1. `go install ./cmd/agent-lens-hook`，把 hook 二进制塞进 `$GOBIN`。
+2. 复制 `.claude/settings.example.json` → `.claude/settings.local.json`（gitignore 命中，per-developer），让 Claude Code 钩子开始转发到本机服务。
+3. 写 `.git/hooks/post-commit`（per-clone，不进 git），commit 时自动上报 kind=commit 事件。
+
+opt out：`rm .claude/settings.local.json .git/hooks/post-commit`。
+
+### 跑本机服务
+
+```bash
+# 内存模式：零依赖，事件随重启清空，适合试水
+AGENT_LENS_STORE=memory go run ./cmd/agent-lens
+
+# 持久模式：Postgres + MinIO（本仓库 deploy/compose 里有现成 compose stack）
+docker compose -f deploy/compose/docker-compose.yml up -d
+go run ./cmd/agent-lens
+```
+
+默认端口 `:8787`，hook 默认走 `http://localhost:8787`。改动用 `AGENT_LENS_ADDR` / `AGENT_LENS_URL`。
+
+### 验证证据链
+
+激活后跑几轮 Claude Code，然后：
+
+```bash
+# 列你的 Claude session（hook 会用 claude-code:<uuid> 作 session_id）
+curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"query":"query { sessionHead(sessionId: \"claude-code:<uuid>\") }"}' \
+  http://localhost:8787/v1/graphql
+
+# 哈希链校验
+agent-lens-hook verify --session claude-code:<uuid>
+
+# 整条链路打成审计报告
+agent-lens-hook export audit-report --root <event-id> --out my-trace.json
+agent-lens-hook verify-audit-report my-trace.json
+```
+
+### 范围与限制
+
+- **不回填**：v1 自观测从激活日起算，激活前的 Claude Code 会话不导入。
+- **redaction**：thinking 文本里可能含未脱敏的代码片段；在 hook 出口处做的截断按 §12 默认走，敏感内容上链前请自行 review。
+- **GitHub webhook 回路**：要把 PR / push / workflow_run 也接进来，需要把本机服务通过隧道（ngrok / cloudflared）暴露到公网，再在 `dong-qiu/agent-lens` 仓库设置里挂 webhook。这一步 SPEC §17 没强制；按需做。
+- **Project 模型**：v0 没有"项目"抽象，session_id 前缀（`claude-code:` / `github-pr:` / `deploy:` ...）已经天然分隔。多项目共用一个 store 时再补 project 维度。
+
 ## 模块名
 
 `go.mod` 的 `github.com/dongqiu/agent-lens` 是占位。落定 GitHub 组织后用 `go mod edit -module <new>` 替换。

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ agent-lens-hook verify-audit-report my-trace.json
 
 ### 范围与限制
 
+- **服务挂了 ≠ 不上报**：transport 默认在 POST 失败时把 NDJSON 落到 `~/.agent-lens/sessions/<sid>.ndjson`（per-session append，0600）。这是 §13 离线/弱网兜底机制，不是"明示静默"——所以 opt-in 后即便没起 agent-lens 服务，hooks 仍会在 home dir 累积事件文件。要彻底停活：先 `rm .claude/settings.local.json .git/hooks/post-commit`，再 `rm -rf ~/.agent-lens/sessions`。
 - **不回填**：v1 自观测从激活日起算，激活前的 Claude Code 会话不导入。
 - **redaction**：thinking 文本里可能含未脱敏的代码片段；在 hook 出口处做的截断按 §12 默认走，敏感内容上链前请自行 review。
 - **GitHub webhook 回路**：要把 PR / push / workflow_run 也接进来，需要把本机服务通过隧道（ngrok / cloudflared）暴露到公网，再在 `dong-qiu/agent-lens` 仓库设置里挂 webhook。这一步 SPEC §17 没强制；按需做。

--- a/cmd/agent-lens/main.go
+++ b/cmd/agent-lens/main.go
@@ -29,13 +29,30 @@ func main() {
 
 	addr := envOr("AGENT_LENS_ADDR", ":8787")
 	pgDSN := envOr("AGENT_LENS_PG_DSN", "postgres://agentlens:agentlens@localhost:5432/agentlens?sslmode=disable")
+	storeKind := envOr("AGENT_LENS_STORE", "postgres")
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer cancel()
 
-	st, err := store.OpenPostgres(ctx, pgDSN)
-	if err != nil {
-		slog.Error("open store", "err", err)
+	// AGENT_LENS_STORE=memory enables an in-process store for local
+	// dogfood / kicking the tyres without a Postgres dependency. Events
+	// vanish on restart — fine for §17 self-observation runs and demo
+	// flows, NOT a production option (no durability, no concurrent
+	// readers across processes).
+	var st store.Store
+	switch storeKind {
+	case "memory":
+		st = store.NewMemory()
+		slog.Info("store: memory (ephemeral; events lost on restart)")
+	case "postgres", "":
+		pg, err := store.OpenPostgres(ctx, pgDSN)
+		if err != nil {
+			slog.Error("open store", "err", err)
+			os.Exit(1)
+		}
+		st = pg
+	default:
+		slog.Error("unknown AGENT_LENS_STORE", "value", storeKind, "want", "postgres|memory")
 		os.Exit(1)
 	}
 	defer func() { _ = st.Close() }()

--- a/script/install-dogfood.sh
+++ b/script/install-dogfood.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# install-dogfood.sh — opt in to §17 self-observation for THIS clone of
+# agent-lens. Idempotent; safe to re-run.
+#
+# What it does:
+#   1. Builds agent-lens-hook from source and stages it in $GOBIN (or
+#      reports the pre-built binary if it's already on PATH).
+#   2. Copies .claude/settings.example.json to .claude/settings.local.json
+#      (gitignored) so Claude Code starts firing hooks for this dir only.
+#   3. Installs .git/hooks/post-commit pointing at agent-lens-hook
+#      git-post-commit. (Per-clone; never committed.)
+#   4. Prints next steps for spinning up a local agent-lens server.
+#
+# What it does NOT do:
+#   - Touch your home directory (no ~/.agent-lens/ writes from this script).
+#   - Modify .claude/settings.json itself (project-shared config stays clean).
+#   - Auto-start agent-lens. You run that yourself; that way the hook only
+#     surfaces in Claude Code when you've explicitly opted in.
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+say() { printf "\033[1;34m==>\033[0m %s\n" "$*"; }
+ok()  { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+warn() { printf "  \033[33m!\033[0m %s\n" "$*"; }
+
+say "1/3 build agent-lens-hook"
+if ! command -v go >/dev/null 2>&1; then
+  echo "go toolchain required; install from https://go.dev/dl" >&2
+  exit 1
+fi
+go install ./cmd/agent-lens-hook
+HOOK_BIN="$(go env GOBIN)"
+[ -z "$HOOK_BIN" ] && HOOK_BIN="$(go env GOPATH)/bin"
+ok "agent-lens-hook installed at $HOOK_BIN/agent-lens-hook"
+case ":$PATH:" in
+  *":$HOOK_BIN:"*) ok "$HOOK_BIN already on PATH" ;;
+  *) warn "$HOOK_BIN is NOT on your PATH. Add: export PATH=\"$HOOK_BIN:\$PATH\"" ;;
+esac
+
+say "2/3 register Claude Code hooks (.claude/settings.local.json)"
+if [ -f .claude/settings.local.json ]; then
+  warn ".claude/settings.local.json already exists — leaving it alone"
+else
+  cp .claude/settings.example.json .claude/settings.local.json
+  ok "wrote .claude/settings.local.json (gitignored; edit freely)"
+fi
+
+say "3/3 install .git/hooks/post-commit"
+if [ -f .git/hooks/post-commit ] && ! grep -q "agent-lens-hook" .git/hooks/post-commit 2>/dev/null; then
+  warn ".git/hooks/post-commit exists and isn't from us — leaving it alone"
+else
+  cat > .git/hooks/post-commit <<'EOF'
+#!/usr/bin/env bash
+# Installed by script/install-dogfood.sh. Sends a kind=commit event to
+# the local agent-lens server. Runs in the foreground but exits 0 on
+# any failure so it never blocks the commit. Remove this file to opt
+# out.
+exec agent-lens-hook git-post-commit
+EOF
+  chmod +x .git/hooks/post-commit
+  ok "wrote .git/hooks/post-commit"
+fi
+
+cat <<EOF
+
+\033[1;32mDone.\033[0m Next:
+  1) Start a local agent-lens server:
+       AGENT_LENS_STORE=memory go run ./cmd/agent-lens
+     (Or use Postgres — see deploy/compose/.)
+  2) In a new shell, open Claude Code in this directory. Hooks fire to
+     http://localhost:8787 by default; events appear under session_id
+     'claude-code:<uuid>'.
+  3) Verify the chain after a few prompts:
+       agent-lens-hook verify --session 'claude-code:<your-session-id>'
+
+To opt out: rm .claude/settings.local.json .git/hooks/post-commit
+EOF

--- a/script/install-dogfood.sh
+++ b/script/install-dogfood.sh
@@ -64,9 +64,8 @@ EOF
   ok "wrote .git/hooks/post-commit"
 fi
 
-cat <<EOF
-
-\033[1;32mDone.\033[0m Next:
+printf '\n\033[1;32mDone.\033[0m Next:\n'
+cat <<'EOF'
   1) Start a local agent-lens server:
        AGENT_LENS_STORE=memory go run ./cmd/agent-lens
      (Or use Postgres — see deploy/compose/.)
@@ -75,6 +74,10 @@ cat <<EOF
      'claude-code:<uuid>'.
   3) Verify the chain after a few prompts:
        agent-lens-hook verify --session 'claude-code:<your-session-id>'
+
+Heads-up: when the server is NOT running, hooks fall back to
+~/.agent-lens/sessions/<sid>.ndjson rather than failing. Delete that
+dir to clear queued events.
 
 To opt out: rm .claude/settings.local.json .git/hooks/post-commit
 EOF


### PR DESCRIPTION
## Summary

Activates SPEC §17 self-observation: the agent-lens repo can now run agent-lens against its own development loop. Strong opt-in design — external contributors who clone the repo see zero surprise side effects.

- **`AGENT_LENS_STORE=memory` mode in `cmd/agent-lens`** — zero-dep local server. Events ephemeral, fine for kicking the tyres / §17 self-observation; Postgres remains the production default.
- **`.claude/settings.example.json`** — sample hook config (UserPromptSubmit / PreToolUse / PostToolUse / Stop / SessionStart). Project-shared as an *example*; the live config goes to `settings.local.json` (gitignored via `*.local`).
- **`script/install-dogfood.sh`** — idempotent one-shot installer: `go install ./cmd/agent-lens-hook`, copy example to local, write `.git/hooks/post-commit`. opt-out: `rm` two files.
- **README §17 section** — walks activation, local server flow, and how to verify the evidence chain via `verify` / `export audit-report`.

Per SPEC: no backfill, redaction stays at hook boundaries (§12), GitHub webhook loop deferred (needs public tunnel; not blocking §17).

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./...`
- [x] `bash -n script/install-dogfood.sh` — shell syntax OK
- [x] Smoke-tested memory store mode end-to-end: started server, posted a prompt event, queried back via GraphQL — got the right ULID and PROMPT kind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)