### PR TITLE
feat(query,web): session list API + UI (M2)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -232,6 +232,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 - GitHub App：PR 事件 + PR Review Bot。
 - GitHub Actions 插件：build 事件 + 产物 hash。
 - Linking worker：基于 SHA / PR / branch 自动拼接。
+- 会话列表：GraphQL 增加 `sessions(limit, since)` 查询;Lens UI 新增会话列表页,替代 M1 手填 session id 的输入框。
 
 ### M3（再 6–8 周）：可验证
 - Deploy webhook（K8s / Argo / 自定义）。

--- a/internal/query/generated.go
+++ b/internal/query/generated.go
@@ -70,6 +70,14 @@ type ComplexityRoot struct {
 		Event       func(childComplexity int, id string) int
 		Events      func(childComplexity int, sessionID string, limit *int) int
 		SessionHead func(childComplexity int, sessionID string) int
+		Sessions    func(childComplexity int, limit *int, since *time.Time) int
+	}
+
+	Session struct {
+		EventCount   func(childComplexity int) int
+		FirstEventAt func(childComplexity int) int
+		ID           func(childComplexity int) int
+		LastEventAt  func(childComplexity int) int
 	}
 }
 
@@ -80,6 +88,7 @@ type QueryResolver interface {
 	Event(ctx context.Context, id string) (*Event, error)
 	Events(ctx context.Context, sessionID string, limit *int) ([]*Event, error)
 	SessionHead(ctx context.Context, sessionID string) (string, error)
+	Sessions(ctx context.Context, limit *int, since *time.Time) ([]*Session, error)
 }
 
 type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -253,6 +262,42 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Query.SessionHead(childComplexity, args["sessionId"].(string)), true
+	case "Query.sessions":
+		if e.ComplexityRoot.Query.Sessions == nil {
+			break
+		}
+
+		args, err := ec.field_Query_sessions_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Query.Sessions(childComplexity, args["limit"].(*int), args["since"].(*time.Time)), true
+
+	case "Session.eventCount":
+		if e.ComplexityRoot.Session.EventCount == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Session.EventCount(childComplexity), true
+	case "Session.firstEventAt":
+		if e.ComplexityRoot.Session.FirstEventAt == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Session.FirstEventAt(childComplexity), true
+	case "Session.id":
+		if e.ComplexityRoot.Session.ID == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Session.ID(childComplexity), true
+	case "Session.lastEventAt":
+		if e.ComplexityRoot.Session.LastEventAt == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Session.LastEventAt(childComplexity), true
 
 	}
 	return 0, false
@@ -396,6 +441,20 @@ func (ec *executionContext) childFields_Link(ctx context.Context, field graphql.
 		return ec.fieldContext_Link_inferredBy(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type Link", field.Name)
+}
+
+func (ec *executionContext) childFields_Session(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "id":
+		return ec.fieldContext_Session_id(ctx, field)
+	case "firstEventAt":
+		return ec.fieldContext_Session_firstEventAt(ctx, field)
+	case "lastEventAt":
+		return ec.fieldContext_Session_lastEventAt(ctx, field)
+	case "eventCount":
+		return ec.fieldContext_Session_eventCount(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
 }
 
 func (ec *executionContext) childFields___Directive(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -575,6 +634,28 @@ func (ec *executionContext) field_Query_sessionHead_args(ctx context.Context, ra
 		return nil, err
 	}
 	args["sessionId"] = arg0
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_sessions_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "limit",
+		func(ctx context.Context, v any) (*int, error) {
+			return ec.unmarshalOInt2ᚖint(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["limit"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "since",
+		func(ctx context.Context, v any) (*time.Time, error) {
+			return ec.unmarshalOTime2ᚖtimeᚐTime(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["since"] = arg1
 	return args, nil
 }
 
@@ -1252,6 +1333,50 @@ func (ec *executionContext) fieldContext_Query_sessionHead(ctx context.Context, 
 	return fc, nil
 }
 
+func (ec *executionContext) _Query_sessions(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Query_sessions(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Query().Sessions(ctx, fc.Args["limit"].(*int), fc.Args["since"].(*time.Time))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*Session) graphql.Marshaler {
+			return ec.marshalNSession2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐSessionᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Query_sessions(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Session(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_sessions_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _Query___type(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -1326,6 +1451,98 @@ func (ec *executionContext) fieldContext_Query___schema(_ context.Context, field
 		},
 	}
 	return fc, nil
+}
+
+func (ec *executionContext) _Session_id(ctx context.Context, field graphql.CollectedField, obj *Session) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Session_id(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ID, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Session_id(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Session", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _Session_firstEventAt(ctx context.Context, field graphql.CollectedField, obj *Session) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Session_firstEventAt(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.FirstEventAt, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v time.Time) graphql.Marshaler {
+			return ec.marshalNTime2timeᚐTime(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Session_firstEventAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Session", field, false, false, errors.New("field of type Time does not have child fields"))
+}
+
+func (ec *executionContext) _Session_lastEventAt(ctx context.Context, field graphql.CollectedField, obj *Session) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Session_lastEventAt(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.LastEventAt, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v time.Time) graphql.Marshaler {
+			return ec.marshalNTime2timeᚐTime(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Session_lastEventAt(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Session", field, false, false, errors.New("field of type Time does not have child fields"))
+}
+
+func (ec *executionContext) _Session_eventCount(ctx context.Context, field graphql.CollectedField, obj *Session) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Session_eventCount(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.EventCount, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int) graphql.Marshaler {
+			return ec.marshalNInt2int(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Session_eventCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Session", field, false, false, errors.New("field of type Int does not have child fields"))
 }
 
 func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql.CollectedField, obj *introspection.Directive) (ret graphql.Marshaler) {
@@ -2698,6 +2915,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "sessions":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_sessions(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
 		case "__type":
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Query___type(ctx, field)
@@ -2706,6 +2945,60 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 			out.Values[i] = ec.OperationContext.RootResolverMiddleware(innerCtx, func(ctx context.Context) (res graphql.Marshaler) {
 				return ec._Query___schema(ctx, field)
 			})
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var sessionImplementors = []string{"Session"}
+
+func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, obj *Session) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, sessionImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("Session")
+		case "id":
+			out.Values[i] = ec._Session_id(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "firstEventAt":
+			out.Values[i] = ec._Session_firstEventAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "lastEventAt":
+			out.Values[i] = ec._Session_lastEventAt(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "eventCount":
+			out.Values[i] = ec._Session_eventCount(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -3198,6 +3491,22 @@ func (ec *executionContext) marshalNID2ᚕstringᚄ(ctx context.Context, sel ast
 	return ret
 }
 
+func (ec *executionContext) unmarshalNInt2int(ctx context.Context, v any) (int, error) {
+	res, err := graphql.UnmarshalInt(v)
+	return res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.SelectionSet, v int) graphql.Marshaler {
+	_ = sel
+	res := graphql.MarshalInt(v)
+	if res == graphql.Null {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+	}
+	return res
+}
+
 func (ec *executionContext) marshalNLink2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐLinkᚄ(ctx context.Context, sel ast.SelectionSet, v []*Link) graphql.Marshaler {
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
@@ -3222,6 +3531,32 @@ func (ec *executionContext) marshalNLink2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlen
 		return graphql.Null
 	}
 	return ec._Link(ctx, sel, v)
+}
+
+func (ec *executionContext) marshalNSession2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐSessionᚄ(ctx context.Context, sel ast.SelectionSet, v []*Session) graphql.Marshaler {
+	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
+		fc := graphql.GetFieldContext(ctx)
+		fc.Result = &v[i]
+		return ec.marshalNSession2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐSession(ctx, sel, v[i])
+	})
+
+	for _, e := range ret {
+		if e == graphql.Null {
+			return graphql.Null
+		}
+	}
+
+	return ret
+}
+
+func (ec *executionContext) marshalNSession2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐSession(ctx context.Context, sel ast.SelectionSet, v *Session) graphql.Marshaler {
+	if v == nil {
+		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
+			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
+		}
+		return graphql.Null
+	}
+	return ec._Session(ctx, sel, v)
 }
 
 func (ec *executionContext) unmarshalNString2string(ctx context.Context, v any) (string, error) {
@@ -3485,6 +3820,24 @@ func (ec *executionContext) marshalOString2ᚖstring(ctx context.Context, sel as
 	_ = sel
 	_ = ctx
 	res := graphql.MarshalString(*v)
+	return res
+}
+
+func (ec *executionContext) unmarshalOTime2ᚖtimeᚐTime(ctx context.Context, v any) (*time.Time, error) {
+	if v == nil {
+		return nil, nil
+	}
+	res, err := graphql.UnmarshalTime(v)
+	return &res, graphql.ErrorOnPath(ctx, err)
+}
+
+func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel ast.SelectionSet, v *time.Time) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	_ = sel
+	_ = ctx
+	res := graphql.MarshalTime(*v)
 	return res
 }
 

--- a/internal/query/mapper.go
+++ b/internal/query/mapper.go
@@ -57,6 +57,18 @@ func nonNilStrings(s []string) []string {
 	return s
 }
 
+func toGQLSession(s *store.SessionSummary) *Session {
+	if s == nil {
+		return nil
+	}
+	return &Session{
+		ID:           s.ID,
+		FirstEventAt: s.FirstEventAt,
+		LastEventAt:  s.LastEventAt,
+		EventCount:   s.EventCount,
+	}
+}
+
 func toGQLLink(l *store.Link) *Link {
 	if l == nil {
 		return nil

--- a/internal/query/models_gen.go
+++ b/internal/query/models_gen.go
@@ -43,6 +43,14 @@ type Link struct {
 type Query struct {
 }
 
+// Aggregated view of a session: id plus first/last activity and event count.
+type Session struct {
+	ID           string    `json:"id"`
+	FirstEventAt time.Time `json:"firstEventAt"`
+	LastEventAt  time.Time `json:"lastEventAt"`
+	EventCount   int       `json:"eventCount"`
+}
+
 type ActorType string
 
 const (

--- a/internal/query/router_test.go
+++ b/internal/query/router_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
@@ -126,6 +127,86 @@ func TestQuerySessionHeadEmpty(t *testing.T) {
 	}
 	if head != "" {
 		t.Errorf("head for unknown session = %q, want empty", head)
+	}
+}
+
+// TestSessionsResolver exercises the sessions(limit, since) query.
+// Three sessions with distinct activity times are seeded; the result
+// is expected ordered by lastEventAt DESC, with eventCount and
+// lastEventAt aggregated correctly. The `since` filter is also exercised.
+func TestSessionsResolver(t *testing.T) {
+	st := store.NewMemory()
+	ctx := context.Background()
+
+	t0, _ := time.Parse(time.RFC3339, "2026-04-01T00:00:00Z")
+	mustAppend := func(id, sid string, ts time.Time) {
+		t.Helper()
+		if err := st.AppendEvent(ctx, &store.Event{
+			ID: id, SessionID: sid, TS: ts,
+			ActorType: "human", ActorID: "alice", Kind: "prompt", Hash: id,
+		}); err != nil {
+			t.Fatalf("append %s: %v", id, err)
+		}
+	}
+	// s-old: single event at t0
+	mustAppend("e-old-1", "s-old", t0)
+	// s-mid: two events at t0+1h and t0+2h
+	mustAppend("e-mid-1", "s-mid", t0.Add(1*time.Hour))
+	mustAppend("e-mid-2", "s-mid", t0.Add(2*time.Hour))
+	// s-new: one event at t0+5h (most recent)
+	mustAppend("e-new-1", "s-new", t0.Add(5*time.Hour))
+
+	srv := httptest.NewServer(query.NewRouter(st))
+	defer srv.Close()
+
+	post := func(t *testing.T, body string) []struct {
+		ID         string `json:"id"`
+		EventCount int    `json:"eventCount"`
+	} {
+		t.Helper()
+		resp, err := http.Post(srv.URL+"/graphql", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+		var got struct {
+			Data struct {
+				Sessions []struct {
+					ID         string `json:"id"`
+					EventCount int    `json:"eventCount"`
+				} `json:"sessions"`
+			} `json:"data"`
+			Errors []map[string]any `json:"errors"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(got.Errors) > 0 {
+			t.Fatalf("graphql errors: %+v", got.Errors)
+		}
+		return got.Data.Sessions
+	}
+
+	all := post(t, `{"query":"{ sessions { id eventCount } }"}`)
+	if len(all) != 3 {
+		t.Fatalf("got %d sessions, want 3", len(all))
+	}
+	wantOrder := []string{"s-new", "s-mid", "s-old"}
+	for i, s := range all {
+		if s.ID != wantOrder[i] {
+			t.Errorf("sessions[%d].id = %q, want %q", i, s.ID, wantOrder[i])
+		}
+	}
+	if all[1].EventCount != 2 {
+		t.Errorf("s-mid eventCount = %d, want 2", all[1].EventCount)
+	}
+
+	// `since` excludes s-old (lastEventAt = t0) but keeps s-mid / s-new.
+	sinceISO := t0.Add(30 * time.Minute).Format(time.RFC3339)
+	body := `{"query":"{ sessions(since: \"` + sinceISO + `\") { id } }"}`
+	filtered := post(t, body)
+	if len(filtered) != 2 {
+		t.Fatalf("got %d filtered sessions, want 2", len(filtered))
 	}
 }
 

--- a/internal/query/schema.graphql
+++ b/internal/query/schema.graphql
@@ -53,6 +53,14 @@ enum EventKind {
   PUSH
 }
 
+"""Aggregated view of a session: id plus first/last activity and event count."""
+type Session {
+  id: String!
+  firstEventAt: Time!
+  lastEventAt: Time!
+  eventCount: Int!
+}
+
 type Query {
   """Look up a single event by ID."""
   event(id: ID!): Event
@@ -62,4 +70,11 @@ type Query {
 
   """Hash of the latest event in a session, or empty string if unknown."""
   sessionHead(sessionId: String!): String!
+
+  """
+  List sessions ordered by lastEventAt DESC (most recent first), up to
+  limit. If `since` is provided, only sessions with lastEventAt >= since
+  are returned.
+  """
+  sessions(limit: Int = 50, since: Time): [Session!]!
 }

--- a/internal/query/schema.resolvers.go
+++ b/internal/query/schema.resolvers.go
@@ -8,6 +8,7 @@ package query
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/dongqiu/agent-lens/internal/store"
 )
@@ -60,6 +61,27 @@ func (r *queryResolver) Events(ctx context.Context, sessionID string, limit *int
 // SessionHead is the resolver for the sessionHead field.
 func (r *queryResolver) SessionHead(ctx context.Context, sessionID string) (string, error) {
 	return r.Store.HeadHash(ctx, sessionID)
+}
+
+// Sessions is the resolver for the sessions field.
+func (r *queryResolver) Sessions(ctx context.Context, limit *int, since *time.Time) ([]*Session, error) {
+	n := 50
+	if limit != nil {
+		n = *limit
+	}
+	var sinceVal time.Time
+	if since != nil {
+		sinceVal = *since
+	}
+	list, err := r.Store.ListSessions(ctx, n, sinceVal)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*Session, 0, len(list))
+	for _, s := range list {
+		out = append(out, toGQLSession(s))
+	}
+	return out, nil
 }
 
 // Event returns EventResolver implementation.

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"time"
 )
@@ -87,6 +88,44 @@ func (m *Memory) HeadHash(_ context.Context, sessionID string) (string, error) {
 		}
 	}
 	return head, nil
+}
+
+func (m *Memory) ListSessions(_ context.Context, limit int, since time.Time) ([]*SessionSummary, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	agg := map[string]*SessionSummary{}
+	for _, e := range m.events {
+		s, ok := agg[e.SessionID]
+		if !ok {
+			s = &SessionSummary{ID: e.SessionID, FirstEventAt: e.TS, LastEventAt: e.TS}
+			agg[e.SessionID] = s
+		}
+		s.EventCount++
+		if e.TS.Before(s.FirstEventAt) {
+			s.FirstEventAt = e.TS
+		}
+		if e.TS.After(s.LastEventAt) {
+			s.LastEventAt = e.TS
+		}
+	}
+	out := make([]*SessionSummary, 0, len(agg))
+	for _, s := range agg {
+		if !since.IsZero() && s.LastEventAt.Before(since) {
+			continue
+		}
+		cp := *s
+		out = append(out, &cp)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if !out[i].LastEventAt.Equal(out[j].LastEventAt) {
+			return out[i].LastEventAt.After(out[j].LastEventAt)
+		}
+		return out[i].ID < out[j].ID
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }
 
 func (m *Memory) EventsByRef(_ context.Context, ref string) ([]*Event, error) {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
@@ -125,6 +126,41 @@ func (p *Postgres) EventsByRef(ctx context.Context, ref string) ([]*Event, error
 			return nil, err
 		}
 		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
+func (p *Postgres) ListSessions(ctx context.Context, limit int, since time.Time) ([]*SessionSummary, error) {
+	// limit <= 0 means "no limit"; PG would otherwise treat 0 literally.
+	if limit <= 0 {
+		limit = 1<<31 - 1
+	}
+	// `since` is filtered on aggregated MAX(ts), so it goes in HAVING,
+	// not WHERE — a session with old events but a recent event still
+	// qualifies. We pass NULL via the zero check so the predicate is a
+	// no-op when the caller didn't supply `since`.
+	const q = `SELECT session_id, MIN(ts), MAX(ts), COUNT(*)
+		FROM events
+		GROUP BY session_id
+		HAVING $1::timestamptz IS NULL OR MAX(ts) >= $1::timestamptz
+		ORDER BY MAX(ts) DESC, session_id ASC
+		LIMIT $2`
+	var sinceArg any
+	if !since.IsZero() {
+		sinceArg = since
+	}
+	rows, err := p.pool.Query(ctx, q, sinceArg, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*SessionSummary
+	for rows.Next() {
+		var s SessionSummary
+		if err := rows.Scan(&s.ID, &s.FirstEventAt, &s.LastEventAt, &s.EventCount); err != nil {
+			return nil, err
+		}
+		out = append(out, &s)
 	}
 	return out, rows.Err()
 }

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -217,6 +217,69 @@ func openPostgresWithSchema(ctx context.Context, t *testing.T) (*Postgres, func(
 	}
 }
 
+// TestPostgresListSessions checks that ListSessions aggregates events
+// correctly and matches the Memory implementation's ordering: most
+// recently active session first, with eventCount and first/last
+// timestamps from MIN/MAX(ts). Also exercises the `since` filter.
+func TestPostgresListSessions(t *testing.T) {
+	ctx := context.Background()
+	st, cleanup := openPostgresWithSchema(ctx, t)
+	defer cleanup()
+
+	t0 := time.Now().UTC().Truncate(time.Microsecond)
+	mustAppend := func(id, sid string, ts time.Time) {
+		t.Helper()
+		if err := st.AppendEvent(ctx, &Event{
+			ID: id, SessionID: sid, TS: ts,
+			ActorType: "human", ActorID: "alice", Kind: "prompt", Hash: id,
+		}); err != nil {
+			t.Fatalf("append %s: %v", id, err)
+		}
+	}
+	mustAppend("01HSOLD1", "s-old", t0)
+	mustAppend("01HSMID1", "s-mid", t0.Add(1*time.Hour))
+	mustAppend("01HSMID2", "s-mid", t0.Add(2*time.Hour))
+	mustAppend("01HSNEW1", "s-new", t0.Add(5*time.Hour))
+
+	all, err := st.ListSessions(ctx, 0, time.Time{})
+	if err != nil {
+		t.Fatalf("ListSessions: %v", err)
+	}
+	if len(all) != 3 {
+		t.Fatalf("got %d sessions, want 3", len(all))
+	}
+	wantOrder := []string{"s-new", "s-mid", "s-old"}
+	for i, s := range all {
+		if s.ID != wantOrder[i] {
+			t.Errorf("sessions[%d].ID = %q, want %q", i, s.ID, wantOrder[i])
+		}
+	}
+	if all[1].EventCount != 2 {
+		t.Errorf("s-mid eventCount = %d, want 2", all[1].EventCount)
+	}
+	if !all[1].LastEventAt.Equal(t0.Add(2 * time.Hour)) {
+		t.Errorf("s-mid lastEventAt = %v, want %v", all[1].LastEventAt, t0.Add(2*time.Hour))
+	}
+
+	// since filter excludes s-old.
+	filtered, err := st.ListSessions(ctx, 0, t0.Add(30*time.Minute))
+	if err != nil {
+		t.Fatalf("ListSessions since: %v", err)
+	}
+	if len(filtered) != 2 {
+		t.Errorf("filtered len = %d, want 2", len(filtered))
+	}
+
+	// limit truncates from the front (most recent kept).
+	limited, err := st.ListSessions(ctx, 1, time.Time{})
+	if err != nil {
+		t.Fatalf("ListSessions limit: %v", err)
+	}
+	if len(limited) != 1 || limited[0].ID != "s-new" {
+		t.Errorf("limited = %+v, want [s-new]", limited)
+	}
+}
+
 // TestPostgresLinkRoundTrip exercises EventsByRef + AppendLink +
 // LinksForEvent end-to-end against the real GIN index added in 0002.
 func TestPostgresLinkRoundTrip(t *testing.T) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -30,6 +30,16 @@ type Event struct {
 	Sig       []byte
 }
 
+// SessionSummary is an aggregated view of a single session: when it
+// began, when it last saw activity, and how many events it holds.
+// Used by the UI's session list page.
+type SessionSummary struct {
+	ID           string
+	FirstEventAt time.Time
+	LastEventAt  time.Time
+	EventCount   int
+}
+
 // Link is a causal or semantic relation between two events. Links are
 // stored separately from the append-only event log so they can be
 // re-derived without rewriting history.
@@ -59,6 +69,10 @@ type Store interface {
 	ListBySession(ctx context.Context, sessionID string, limit int) ([]*Event, error)
 	HeadHash(ctx context.Context, sessionID string) (string, error)
 	EventsByRef(ctx context.Context, ref string) ([]*Event, error)
+	// ListSessions returns session summaries ordered by LastEventAt DESC.
+	// limit <= 0 means "no limit". If since is non-zero, only sessions
+	// with LastEventAt >= since are returned.
+	ListSessions(ctx context.Context, limit int, since time.Time) ([]*SessionSummary, error)
 	AppendLink(ctx context.Context, l *Link) error
 	LinksForEvent(ctx context.Context, eventID string) ([]*Link, error)
 	Close() error

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,21 +9,26 @@ function getInitialSession(): string {
 export default function App() {
   const [sessionId, setSessionId] = useState<string>(getInitialSession);
 
-  useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    if (sessionId) params.set("session", sessionId);
-    else params.delete("session");
-    const qs = params.toString();
-    const url = `${window.location.pathname}${qs ? `?${qs}` : ""}`;
-    window.history.replaceState(null, "", url);
-  }, [sessionId]);
-
-  // Keep view in sync with browser back/forward.
+  // Browser back/forward replays whatever URL was last pushed; mirror
+  // it back into component state.
   useEffect(() => {
     const onPop = () => setSessionId(getInitialSession());
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
   }, []);
+
+  // pushState (not replaceState) so each list↔timeline transition
+  // gets its own history entry — otherwise back skips out of the app.
+  const navigate = (next: string) => {
+    if (next === sessionId) return;
+    const params = new URLSearchParams(window.location.search);
+    if (next) params.set("session", next);
+    else params.delete("session");
+    const qs = params.toString();
+    const url = `${window.location.pathname}${qs ? `?${qs}` : ""}`;
+    window.history.pushState(null, "", url);
+    setSessionId(next);
+  };
 
   const subtitle = sessionId ? "M1 timeline" : "M2 sessions";
 
@@ -34,7 +39,7 @@ export default function App() {
           <div className="flex items-baseline gap-3">
             <button
               type="button"
-              onClick={() => setSessionId("")}
+              onClick={() => navigate("")}
               className="text-xl font-semibold hover:text-zinc-700"
             >
               Agent Lens
@@ -44,7 +49,7 @@ export default function App() {
           {sessionId && (
             <button
               type="button"
-              onClick={() => setSessionId("")}
+              onClick={() => navigate("")}
               className="text-xs text-zinc-500 underline-offset-2 hover:underline"
             >
               ← all sessions
@@ -56,7 +61,7 @@ export default function App() {
         {sessionId ? (
           <Timeline sessionId={sessionId} />
         ) : (
-          <SessionList onSelect={setSessionId} />
+          <SessionList onSelect={navigate} />
         )}
       </main>
     </div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { Timeline } from "./components/Timeline";
+import { SessionList } from "./components/SessionList";
 
 function getInitialSession(): string {
   return new URLSearchParams(window.location.search).get("session") ?? "";
@@ -17,25 +18,46 @@ export default function App() {
     window.history.replaceState(null, "", url);
   }, [sessionId]);
 
+  // Keep view in sync with browser back/forward.
+  useEffect(() => {
+    const onPop = () => setSessionId(getInitialSession());
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  const subtitle = sessionId ? "M1 timeline" : "M2 sessions";
+
   return (
     <div className="min-h-screen bg-zinc-50 text-zinc-900">
       <header className="border-b border-zinc-200 bg-white">
         <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
-          <div>
-            <h1 className="text-xl font-semibold">Agent Lens</h1>
-            <p className="text-xs text-zinc-500">M1 timeline</p>
+          <div className="flex items-baseline gap-3">
+            <button
+              type="button"
+              onClick={() => setSessionId("")}
+              className="text-xl font-semibold hover:text-zinc-700"
+            >
+              Agent Lens
+            </button>
+            <p className="text-xs text-zinc-500">{subtitle}</p>
           </div>
-          <input
-            type="text"
-            placeholder="session id"
-            className="w-72 rounded border border-zinc-300 bg-white px-3 py-1.5 font-mono text-sm focus:border-zinc-500 focus:outline-none"
-            value={sessionId}
-            onChange={(e) => setSessionId(e.target.value)}
-          />
+          {sessionId && (
+            <button
+              type="button"
+              onClick={() => setSessionId("")}
+              className="text-xs text-zinc-500 underline-offset-2 hover:underline"
+            >
+              ← all sessions
+            </button>
+          )}
         </div>
       </header>
       <main className="mx-auto max-w-4xl px-6 py-6">
-        <Timeline sessionId={sessionId} />
+        {sessionId ? (
+          <Timeline sessionId={sessionId} />
+        ) : (
+          <SessionList onSelect={setSessionId} />
+        )}
       </main>
     </div>
   );

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -23,6 +23,17 @@ export async function gql<T>(
   return json.data;
 }
 
+export const sessionsQuery = `
+  query Sessions($limit: Int, $since: Time) {
+    sessions(limit: $limit, since: $since) {
+      id
+      firstEventAt
+      lastEventAt
+      eventCount
+    }
+  }
+`;
+
 export const eventsQuery = `
   query Events($sessionId: String!, $limit: Int) {
     events(sessionId: $sessionId, limit: $limit) {

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,0 +1,109 @@
+import { useQuery } from "@tanstack/react-query";
+import { gql, sessionsQuery } from "../api/client";
+import type { Session, SessionsResponse } from "../types";
+
+export function SessionList({
+  onSelect,
+}: {
+  onSelect: (sessionId: string) => void;
+}) {
+  const { data, error, isLoading, isFetching } = useQuery({
+    queryKey: ["sessions"],
+    queryFn: () => gql<SessionsResponse>(sessionsQuery, { limit: 50 }),
+    refetchInterval: 5000,
+  });
+
+  if (isLoading) {
+    return <div className="text-sm text-zinc-500">Loading sessions…</div>;
+  }
+  if (error) {
+    return (
+      <div className="text-sm text-rose-600">
+        Error: {(error as Error).message}
+      </div>
+    );
+  }
+  const sessions = data?.sessions ?? [];
+
+  if (sessions.length === 0) {
+    return (
+      <div className="text-sm text-zinc-500">
+        No sessions yet. Trigger a Claude Code prompt or post events to{" "}
+        <code className="font-mono text-xs">/v1/events</code>.
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex items-baseline justify-between">
+        <div className="text-sm text-zinc-700">
+          <span className="font-medium">{sessions.length}</span> sessions
+        </div>
+        {isFetching && (
+          <div className="text-xs text-zinc-400">refreshing…</div>
+        )}
+      </div>
+      <ul className="divide-y divide-zinc-200 overflow-hidden rounded border border-zinc-200 bg-white">
+        {sessions.map((s) => (
+          <SessionRow key={s.id} session={s} onSelect={onSelect} />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function SessionRow({
+  session,
+  onSelect,
+}: {
+  session: Session;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={() => onSelect(session.id)}
+        className="flex w-full items-center justify-between gap-4 px-4 py-3 text-left transition hover:bg-zinc-50"
+      >
+        <div className="min-w-0">
+          <div className="truncate font-mono text-sm text-zinc-900">
+            {session.id}
+          </div>
+          <div className="mt-0.5 text-xs text-zinc-500">
+            last activity {formatRelative(session.lastEventAt)} · started{" "}
+            {formatAbsolute(session.firstEventAt)}
+          </div>
+        </div>
+        <div className="shrink-0 rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-700">
+          {session.eventCount} {session.eventCount === 1 ? "event" : "events"}
+        </div>
+      </button>
+    </li>
+  );
+}
+
+function formatRelative(iso: string): string {
+  const t = new Date(iso).getTime();
+  const diff = Date.now() - t;
+  if (diff < 0) return "just now";
+  const sec = Math.floor(diff / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  return `${day}d ago`;
+}
+
+function formatAbsolute(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -48,3 +48,14 @@ export type EventsResponse = {
   events: Event[];
   sessionHead: string;
 };
+
+export type Session = {
+  id: string;
+  firstEventAt: string;
+  lastEventAt: string;
+  eventCount: number;
+};
+
+export type SessionsResponse = {
+  sessions: Session[];
+};


### PR DESCRIPTION
Closes #36.

## Summary

- New GraphQL query `sessions(limit, since): [Session!]!` returning `Session{id, firstEventAt, lastEventAt, eventCount}`, ordered by `lastEventAt DESC`. Backed by `Store.ListSessions` on both Memory and Postgres (Postgres uses `GROUP BY session_id` with the `since` filter in `HAVING` so a session with old events but recent activity still qualifies).
- New `SessionList` web component replaces the M1 manual session-id input. Root `/` shows the list; clicking a row navigates to `?session=<id>` (existing timeline). Header brand returns to list; browser back/forward preserved.
- SPEC.md M2 entry for this work was added separately in `1f60af1`.

## Test plan

- [x] `go test ./...` passes (added `TestSessionsResolver` for the GraphQL layer).
- [x] Postgres integration test `TestPostgresListSessions` (ordering / `since` / `limit`) — runs under `make test-integration`.
- [x] `pnpm exec tsc --noEmit` clean.
- [x] Smoke test: post 2 events to two distinct session ids → `sessions` returns both, ordered by latest activity, with correct counts. Existing session also visible.
- [x] Visual check in `make web-dev`: verify list rendering, row click → timeline, header → list, browser back/forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)