### PR TITLE
fix(store): ListBySession + HeadHash order by id, not ts (#38)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project status
 
-Agent Lens is in the **planning phase**. There is no source code, build system, or test suite yet — only `SPEC.md`, the project specification. Future work will scaffold the implementation based on that spec.
+M1–M3 have shipped: Claude Code hook → ingest → store → GraphQL → Lens UI is working end-to-end, with linking, in-toto/SLSA attestation, hash-chain `verify`, and audit-report export. §17 dogfood activation is live, so this repo is its own first dogfood. M2 session list (sessions GraphQL + UI list page) merged on 2026-04-28. See `SPEC.md` §14 for the milestone breakdown.
 
 ## What this project is
 
@@ -27,4 +27,27 @@ These were settled during initial scoping and are referenced throughout `SPEC.md
 ## Working in this repo
 
 - Treat `SPEC.md` as the source of truth for design. If a request conflicts with it, surface the conflict and ask before changing the spec.
-- No build / test / lint commands exist yet — don't fabricate them. The repo layout in `SPEC.md` §16.3 is the planned structure but nothing has been scaffolded.
+- Common commands are wired in the `Makefile`: `make build`, `make proto`, `make gqlgen`, `make test`, `make test-integration`, `make migrate-up`, `make compose-up`, `make web-dev`, `make web-build`. `make help` lists them all.
+
+## Local development with persistence
+
+The collector defaults to `AGENT_LENS_STORE=postgres`. To run the dogfood loop with data that survives restarts:
+
+```bash
+# 1. Start Postgres + MinIO (only the services we actually use locally;
+#    the agent-lens compose service is for production-style runs and
+#    its Dockerfile lags behind go.mod, so skip it).
+docker compose -f deploy/compose/docker-compose.yml up -d postgres minio
+
+# 2. Apply migrations (requires `golang-migrate`; `brew install golang-migrate`).
+make migrate-up
+
+# 3. Run the collector. With no AGENT_LENS_STORE override it talks to
+#    localhost:5432 using the default DSN baked into main.go.
+go run ./cmd/agent-lens
+
+# 4. Optional: Vite dev server proxies /v1 to 8787.
+make web-dev
+```
+
+Set `AGENT_LENS_STORE=memory` for an ephemeral run (used by integration tests and for one-off smoke loops). Set `AGENT_LENS_PG_DSN=...` to point at a non-default Postgres.

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -159,6 +159,17 @@ func (h *Handler) appendLocked(ctx context.Context, in *WireEvent) error {
 	if err := validateWireEvent(in); err != nil {
 		return err
 	}
+
+	// ID assignment, ts default, and canonical marshal must happen under
+	// the same lock that orders the append. Otherwise, two concurrent
+	// goroutines can call ulid.Make() in one order and acquire h.mu in
+	// the other — the resulting ids no longer reflect append order, and
+	// the store's id-asc read order (see issue #38) drifts from the hash
+	// chain. Marshal is also moved inside because canonical includes the
+	// id; doing it outside before id assignment would race.
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
 	if in.ID == "" {
 		in.ID = ulid.Make().String()
 	}
@@ -169,9 +180,6 @@ func (h *Handler) appendLocked(ctx context.Context, in *WireEvent) error {
 	if err != nil {
 		return err
 	}
-
-	h.mu.Lock()
-	defer h.mu.Unlock()
 
 	prev, hit := h.heads[in.SessionID]
 	if !hit {

--- a/internal/ingest/handler_test.go
+++ b/internal/ingest/handler_test.go
@@ -225,6 +225,13 @@ func TestIngestConcurrentWritesPreserveChain(t *testing.T) {
 		if i > 0 && e.PrevHash != events[i-1].Hash {
 			t.Errorf("chain forked at index %d: prev=%q want %q", i, e.PrevHash, events[i-1].Hash)
 		}
+		// Issue #38: id-asc ordering must match append order, so that
+		// Postgres's ORDER BY id ASC reads back the same sequence
+		// Memory does. This holds only because handler.appendLocked
+		// generates the ulid inside h.mu — see the comment there.
+		if i > 0 && e.ID <= events[i-1].ID {
+			t.Errorf("ids not monotonic at index %d: %s after %s", i, e.ID, events[i-1].ID)
+		}
 	}
 }
 

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -65,15 +65,15 @@ func (m *Memory) ListBySession(_ context.Context, sessionID string, limit int) (
 	return out, nil
 }
 
-// HeadHash returns the hash of the latest event for sessionID, where
-// "latest" matches Postgres's `ORDER BY ts DESC, id DESC LIMIT 1`:
-// max ts wins, ULID lexical max breaks ties. This keeps the two impls
-// in lockstep when clients send out-of-order timestamps.
+// HeadHash returns the hash of the last-appended event for sessionID,
+// identified by max id (ULIDs are monotonic at insert) — matches
+// Postgres's `ORDER BY id DESC LIMIT 1`. ts is set on the hook's wall
+// clock and can be skewed across concurrent hooks, so it cannot be used
+// to identify the head. See issue #38.
 func (m *Memory) HeadHash(_ context.Context, sessionID string) (string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	var (
-		maxTS time.Time
 		maxID string
 		head  string
 	)
@@ -81,8 +81,7 @@ func (m *Memory) HeadHash(_ context.Context, sessionID string) (string, error) {
 		if e.SessionID != sessionID {
 			continue
 		}
-		if e.TS.After(maxTS) || (e.TS.Equal(maxTS) && e.ID > maxID) {
-			maxTS = e.TS
+		if e.ID > maxID {
 			maxID = e.ID
 			head = e.Hash
 		}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -75,9 +75,14 @@ func (p *Postgres) GetEvent(ctx context.Context, id string) (*Event, error) {
 }
 
 func (p *Postgres) ListBySession(ctx context.Context, sessionID string, limit int) ([]*Event, error) {
+	// id ASC, not ts ASC: ULIDs are monotonic at insert time, so id-order
+	// equals append-order. ts is set by the hook on its own wall clock, so
+	// concurrent hooks can produce events whose ts is earlier than an
+	// already-appended event's ts — sorting by ts then walks the hash chain
+	// in the wrong order. See issue #38.
 	const q = `SELECT id, ts, session_id, turn_id, actor_type, actor_id, actor_model,
 		kind, payload, parents, refs, hash, prev_hash, sig
-		FROM events WHERE session_id = $1 ORDER BY ts ASC LIMIT $2`
+		FROM events WHERE session_id = $1 ORDER BY id ASC LIMIT $2`
 	// limit <= 0 means "no limit"; PG would otherwise treat 0 literally.
 	if limit <= 0 {
 		limit = 1<<31 - 1
@@ -99,9 +104,11 @@ func (p *Postgres) ListBySession(ctx context.Context, sessionID string, limit in
 }
 
 func (p *Postgres) HeadHash(ctx context.Context, sessionID string) (string, error) {
-	// Tie-break on id (ULIDs are monotonic within ms) so same-timestamp
-	// events resolve to a deterministic head.
-	const q = `SELECT hash FROM events WHERE session_id = $1 ORDER BY ts DESC, id DESC LIMIT 1`
+	// "Latest" = last-inserted, identified by max id (ULIDs are monotonic
+	// at insert). ts is hook wall-clock and can be skewed across concurrent
+	// hooks, so ordering on ts would pick the wrong head on collector
+	// restart. See issue #38.
+	const q = `SELECT hash FROM events WHERE session_id = $1 ORDER BY id DESC LIMIT 1`
 	var h string
 	err := p.pool.QueryRow(ctx, q, sessionID).Scan(&h)
 	if errors.Is(err, pgx.ErrNoRows) {

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -217,6 +217,98 @@ func openPostgresWithSchema(ctx context.Context, t *testing.T) (*Postgres, func(
 	}
 }
 
+// TestStoreReadOrderParity is the regression test for issue #38: under
+// skewed wall-clock timestamps (concurrent hooks fire at the same
+// millisecond and stamp ts on their own clocks), Memory and Postgres
+// must agree on ListBySession order — namely the append/ULID order, not
+// ts order — so the hash chain walks consistently across stores.
+//
+// Runs against both backends in one test so any future divergence shows
+// up here.
+func TestStoreReadOrderParity(t *testing.T) {
+	ctx := context.Background()
+	pg, cleanup := openPostgresWithSchema(ctx, t)
+	defer cleanup()
+	mem := NewMemory()
+
+	// Three events appended in id-monotonic order (e1 < e2 < e3) but
+	// with deliberately skewed ts: the last one carries the *earliest*
+	// timestamp, mimicking a hook with a slow clock that nevertheless
+	// reaches the collector last.
+	t0 := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	events := []*Event{
+		{ID: "01HSKEW0000000000000000001", TS: t0.Add(2 * time.Second), SessionID: "skew", ActorType: "human", ActorID: "alice", Kind: "prompt", Hash: "h1"},
+		{ID: "01HSKEW0000000000000000002", TS: t0.Add(3 * time.Second), SessionID: "skew", ActorType: "agent", ActorID: "claude", Kind: "thought", Hash: "h2", PrevHash: "h1"},
+		{ID: "01HSKEW0000000000000000003", TS: t0.Add(1 * time.Second), SessionID: "skew", ActorType: "agent", ActorID: "claude", Kind: "tool_call", Hash: "h3", PrevHash: "h2"},
+	}
+	for _, e := range events {
+		if err := pg.AppendEvent(ctx, e); err != nil {
+			t.Fatalf("pg append %s: %v", e.ID, err)
+		}
+		if err := mem.AppendEvent(ctx, e); err != nil {
+			t.Fatalf("mem append %s: %v", e.ID, err)
+		}
+	}
+
+	pgList, err := pg.ListBySession(ctx, "skew", 0)
+	if err != nil {
+		t.Fatalf("pg list: %v", err)
+	}
+	memList, err := mem.ListBySession(ctx, "skew", 0)
+	if err != nil {
+		t.Fatalf("mem list: %v", err)
+	}
+
+	wantIDs := []string{events[0].ID, events[1].ID, events[2].ID}
+	gotPGIDs := make([]string, len(pgList))
+	for i, e := range pgList {
+		gotPGIDs[i] = e.ID
+	}
+	gotMemIDs := make([]string, len(memList))
+	for i, e := range memList {
+		gotMemIDs[i] = e.ID
+	}
+	if !equalStrings(gotPGIDs, wantIDs) {
+		t.Errorf("pg list ids = %v, want %v (append order)", gotPGIDs, wantIDs)
+	}
+	if !equalStrings(gotMemIDs, wantIDs) {
+		t.Errorf("mem list ids = %v, want %v (append order)", gotMemIDs, wantIDs)
+	}
+
+	// Hash chain walks correctly under this order.
+	for i := 1; i < len(pgList); i++ {
+		if pgList[i].PrevHash != pgList[i-1].Hash {
+			t.Errorf("pg chain break at %d: prev=%q want %q", i, pgList[i].PrevHash, pgList[i-1].Hash)
+		}
+	}
+
+	// Both stores agree on head: the last-appended event (h3), even
+	// though its ts is the earliest of the three.
+	pgHead, err := pg.HeadHash(ctx, "skew")
+	if err != nil {
+		t.Fatalf("pg head: %v", err)
+	}
+	memHead, err := mem.HeadHash(ctx, "skew")
+	if err != nil {
+		t.Fatalf("mem head: %v", err)
+	}
+	if pgHead != "h3" || memHead != "h3" {
+		t.Errorf("head: pg=%q mem=%q, want h3 from both (last-appended wins)", pgHead, memHead)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // TestPostgresListSessions checks that ListSessions aggregates events
 // correctly and matches the Memory implementation's ordering: most
 // recently active session first, with eventCount and first/last


### PR DESCRIPTION
Closes #38.

## Summary

- `Postgres.ListBySession`: `ORDER BY ts ASC` → `ORDER BY id ASC`. Memory walks `m.events` in append order; PG was reading by wall-clock. Under concurrent hook fire (8 PreToolUse decisions in the same ms), the ts column diverges from append/ULID order and the hash chain walks the wrong sequence.
- `Postgres.HeadHash` and `Memory.HeadHash`: switch to max id. Last-inserted wins, regardless of clock skew across concurrent hooks. Doc comments updated to reflect the new contract.
- New `TestStoreReadOrderParity` (integration) appends three events in id-monotonic order with the last carrying the *earliest* ts; both Memory and Postgres must return them in append order and agree on head = h3.

## Discovered

`agent-lens-hook verify --session <dogfood>` failed at index 26 on the PG-backed dogfood after the M3 default switched the collector to Postgres. The same chain passed verify when read through Memory. Investigation showed PG's `ts ASC` ordering put a late-inserted event with skewed earlier ts ahead of its predecessors. Re-running verify against the fix-branch collector now reports `OK · 125 events` end-to-end.

## Test plan

- [x] `go test ./...` passes (unit tests, including existing query/store coverage).
- [x] `go test -tags integration ./internal/store/...` passes — 6 tests including the new parity test.
- [x] `agent-lens-hook verify --session persistence-smoke` ✓ (2 events).
- [x] `agent-lens-hook verify --session c3e32521-b0c5-49b0-a218-d7995acb9acd` ✓ (125 events end-to-end, was failing at index 26).

🤖 Generated with [Claude Code](https://claude.com/claude-code)