### PR TITLE
chore(deploy): bump compose Dockerfile to golang:1.25-alpine

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,10 @@ These were settled during initial scoping and are referenced throughout `SPEC.md
 The collector defaults to `AGENT_LENS_STORE=postgres`. To run the dogfood loop with data that survives restarts:
 
 ```bash
-# 1. Start Postgres + MinIO (only the services we actually use locally;
-#    the agent-lens compose service is for production-style runs and
-#    its Dockerfile lags behind go.mod, so skip it).
+# 1. Start Postgres + MinIO. (`make compose-up` also builds the
+#    agent-lens server image; for the local dogfood loop we want to run
+#    the collector via `go run` so we get hot rebuilds, so bring up only
+#    the data services.)
 docker compose -f deploy/compose/docker-compose.yml up -d postgres minio
 
 # 2. Apply migrations (requires `golang-migrate`; `brew install golang-migrate`).

--- a/deploy/compose/Dockerfile.server
+++ b/deploy/compose/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine AS build
+FROM golang:1.25-alpine AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
## Summary

- `deploy/compose/Dockerfile.server`: `golang:1.23-alpine` → `golang:1.25-alpine`. go.mod requires `go 1.25.0`; the 1.23 alpine image carried `GOTOOLCHAIN=local` and refused to auto-fetch the newer toolchain, so `make compose-up` failed at \`go mod download\`. CI masked this because setup-go runs with `GOTOOLCHAIN=auto`.
- CLAUDE.md: drop the "Dockerfile lags go.mod, so skip it" caveat in the persistence runbook; the new rationale is "use \`go run\` for hot rebuilds during dogfood", which is the real reason regardless of the Dockerfile state.

## Test plan

- [x] `docker compose ... build agent-lens` against the fix-branch produces a tagged `compose-agent-lens:latest` image end-to-end.
- [x] Existing CI matrix (Go 1.23 / 1.26) unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)