### PR TITLE
feat(web): causal graph view v1 (single-session, ReactFlow + dagre)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -11,6 +11,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
+    "@dagrejs/dagre": "^3.0.0",
     "@tanstack/react-query": "^5.59.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@dagrejs/dagre':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@tanstack/react-query':
         specifier: ^5.59.0
         version: 5.100.5(react@18.3.1)
@@ -146,6 +149,12 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@dagrejs/dagre@3.0.0':
+    resolution: {integrity: sha512-ZzhnTy1rfuoew9Ez3EIw4L2znPGnYYhfn8vc9c4oB8iw6QAsszbiU0vRhlxWPFnmmNSFAkrYeF1PhM5m4lAN0Q==}
+
+  '@dagrejs/graphlib@4.0.1':
+    resolution: {integrity: sha512-IvcV6FduIIAmLwnH+yun+QtV36SC7mERqa86aClNqmMN09WhmPPYU8ckHrZBozErf+UvHPWOTJYaGYiIcs0DgA==}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -1637,6 +1646,12 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@dagrejs/dagre@3.0.0':
+    dependencies:
+      '@dagrejs/graphlib': 4.0.1
+
+  '@dagrejs/graphlib@4.0.1': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,41 +1,60 @@
 import { useEffect, useState } from "react";
 import { Timeline } from "./components/Timeline";
 import { SessionList } from "./components/SessionList";
+import { CausalGraph } from "./components/CausalGraph";
+
+type View = "timeline" | "graph";
 
 function getInitialSession(): string {
   return new URLSearchParams(window.location.search).get("session") ?? "";
 }
 
+function getInitialView(): View {
+  const v = new URLSearchParams(window.location.search).get("view");
+  return v === "graph" ? "graph" : "timeline";
+}
+
 export default function App() {
   const [sessionId, setSessionId] = useState<string>(getInitialSession);
+  const [view, setView] = useState<View>(getInitialView);
 
   // Browser back/forward replays whatever URL was last pushed; mirror
-  // it back into component state.
+  // it back into component state for both session and view.
   useEffect(() => {
-    const onPop = () => setSessionId(getInitialSession());
+    const onPop = () => {
+      setSessionId(getInitialSession());
+      setView(getInitialView());
+    };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
   }, []);
 
-  // pushState (not replaceState) so each list↔timeline transition
+  // pushState (not replaceState) so each list↔timeline↔graph transition
   // gets its own history entry — otherwise back skips out of the app.
-  const navigate = (next: string) => {
-    if (next === sessionId) return;
+  const navigate = (nextSession: string, nextView: View = "timeline") => {
+    if (nextSession === sessionId && nextView === view) return;
     const params = new URLSearchParams(window.location.search);
-    if (next) params.set("session", next);
+    if (nextSession) params.set("session", nextSession);
     else params.delete("session");
+    if (nextSession && nextView !== "timeline") params.set("view", nextView);
+    else params.delete("view");
     const qs = params.toString();
     const url = `${window.location.pathname}${qs ? `?${qs}` : ""}`;
     window.history.pushState(null, "", url);
-    setSessionId(next);
+    setSessionId(nextSession);
+    setView(nextView);
   };
 
-  const subtitle = sessionId ? "M1 timeline" : "M2 sessions";
+  const subtitle = sessionId
+    ? view === "graph"
+      ? "M2 causal graph"
+      : "M1 timeline"
+    : "M2 sessions";
 
   return (
     <div className="min-h-screen bg-zinc-50 text-zinc-900">
       <header className="border-b border-zinc-200 bg-white">
-        <div className="mx-auto flex max-w-4xl items-center justify-between px-6 py-4">
+        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
           <div className="flex items-baseline gap-3">
             <button
               type="button"
@@ -47,23 +66,87 @@ export default function App() {
             <p className="text-xs text-zinc-500">{subtitle}</p>
           </div>
           {sessionId && (
-            <button
-              type="button"
-              onClick={() => navigate("")}
-              className="text-xs text-zinc-500 underline-offset-2 hover:underline"
-            >
-              ← all sessions
-            </button>
+            <div className="flex items-center gap-4">
+              <ViewToggle
+                view={view}
+                onSelect={(v) => navigate(sessionId, v)}
+              />
+              <button
+                type="button"
+                onClick={() => navigate("")}
+                className="text-xs text-zinc-500 underline-offset-2 hover:underline"
+              >
+                ← all sessions
+              </button>
+            </div>
           )}
         </div>
       </header>
-      <main className="mx-auto max-w-4xl px-6 py-6">
+      <main className="mx-auto max-w-6xl px-6 py-6">
         {sessionId ? (
-          <Timeline sessionId={sessionId} />
+          view === "graph" ? (
+            <CausalGraph sessionId={sessionId} />
+          ) : (
+            <Timeline sessionId={sessionId} />
+          )
         ) : (
-          <SessionList onSelect={navigate} />
+          <SessionList onSelect={(id) => navigate(id, "timeline")} />
         )}
       </main>
     </div>
+  );
+}
+
+function ViewToggle({
+  view,
+  onSelect,
+}: {
+  view: View;
+  onSelect: (v: View) => void;
+}) {
+  return (
+    <div
+      className="inline-flex overflow-hidden rounded border border-zinc-300 bg-white text-xs"
+      role="tablist"
+    >
+      <ToggleButton
+        active={view === "timeline"}
+        onClick={() => onSelect("timeline")}
+      >
+        Timeline
+      </ToggleButton>
+      <ToggleButton
+        active={view === "graph"}
+        onClick={() => onSelect("graph")}
+      >
+        Graph
+      </ToggleButton>
+    </div>
+  );
+}
+
+function ToggleButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`px-3 py-1 transition ${
+        active
+          ? "bg-zinc-900 text-white"
+          : "text-zinc-600 hover:bg-zinc-50"
+      }`}
+    >
+      {children}
+    </button>
   );
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -51,10 +51,16 @@ export default function App() {
       : "M1 timeline"
     : "M2 sessions";
 
+  // Graph view needs more horizontal room (dagre lays a wide DAG; the
+  // minimap also looks cramped at 4xl). Timeline and SessionList were
+  // designed for 4xl and look stretched at wider widths, so the
+  // wrapper width is per-view.
+  const wrapperMaxW = sessionId && view === "graph" ? "max-w-6xl" : "max-w-4xl";
+
   return (
     <div className="min-h-screen bg-zinc-50 text-zinc-900">
       <header className="border-b border-zinc-200 bg-white">
-        <div className="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+        <div className={`mx-auto flex ${wrapperMaxW} items-center justify-between px-6 py-4`}>
           <div className="flex items-baseline gap-3">
             <button
               type="button"
@@ -82,7 +88,7 @@ export default function App() {
           )}
         </div>
       </header>
-      <main className="mx-auto max-w-6xl px-6 py-6">
+      <main className={`mx-auto ${wrapperMaxW} px-6 py-6`}>
         {sessionId ? (
           view === "graph" ? (
             <CausalGraph sessionId={sessionId} />

--- a/web/src/components/CausalGraph.tsx
+++ b/web/src/components/CausalGraph.tsx
@@ -4,6 +4,7 @@ import ReactFlow, {
   Background,
   Controls,
   MarkerType,
+  MiniMap,
   type Edge,
   type Node,
 } from "reactflow";
@@ -11,8 +12,27 @@ import "reactflow/dist/style.css";
 import dagre from "@dagrejs/dagre";
 
 import { gql, eventsQuery } from "../api/client";
-import type { Event, EventsResponse } from "../types";
+import type { Event, EventKind, EventsResponse } from "../types";
 import { styleFor } from "./kindStyle";
+
+// Hex colors mirroring the Tailwind 500-shade in kindStyle.ts. The
+// MiniMap renders nodes with raw SVG fills, so we need real hex
+// strings rather than utility classes.
+const MINIMAP_HEX: Record<EventKind, string> = {
+  PROMPT: "#3b82f6",
+  THOUGHT: "#a855f7",
+  TOOL_CALL: "#f59e0b",
+  TOOL_RESULT: "#10b981",
+  CODE_CHANGE: "#0ea5e9",
+  COMMIT: "#52525b",
+  PR: "#d946ef",
+  TEST_RUN: "#14b8a6",
+  BUILD: "#f97316",
+  DEPLOY: "#ef4444",
+  REVIEW: "#6366f1",
+  DECISION: "#f43f5e",
+  PUSH: "#06b6d4",
+};
 
 const NODE_W = 180;
 const NODE_H = 56;
@@ -109,7 +129,10 @@ function buildGraph(events: Event[]): { nodes: Node[]; edges: Edge[] } {
     return {
       id: e.id,
       position: positions[e.id] ?? { x: 0, y: 0 },
+      // kind is plumbed into data so MiniMap can color minimap nodes
+      // by the same palette without re-deriving from the JSX label.
       data: {
+        kind: e.kind,
         label: (
           <div className={`flex h-full w-full flex-col gap-0.5 rounded border ${s.container} px-2 py-1`}>
             <div className="flex items-center gap-1 text-[10px]">
@@ -179,6 +202,22 @@ export function CausalGraph({ sessionId }: { sessionId: string }) {
       >
         <Background gap={16} size={1} color="#e4e4e7" />
         <Controls showInteractive={false} />
+        <MiniMap
+          pannable
+          zoomable
+          ariaLabel="Causal graph minimap"
+          nodeColor={(n) => {
+            const k = (n.data as { kind?: EventKind } | undefined)?.kind;
+            return (k && MINIMAP_HEX[k]) || "#a1a1aa";
+          }}
+          nodeStrokeWidth={0}
+          maskColor="rgba(255, 255, 255, 0.6)"
+          style={{
+            background: "#fafafa",
+            border: "1px solid #e4e4e7",
+            borderRadius: 4,
+          }}
+        />
       </ReactFlow>
     </div>
   );

--- a/web/src/components/CausalGraph.tsx
+++ b/web/src/components/CausalGraph.tsx
@@ -1,10 +1,12 @@
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import ReactFlow, {
   Background,
   Controls,
   MarkerType,
   MiniMap,
+  ReactFlowProvider,
+  useReactFlow,
   type Edge,
   type Node,
 } from "reactflow";
@@ -156,6 +158,48 @@ function buildGraph(events: Event[]): { nodes: Node[]; edges: Edge[] } {
   return { nodes, edges };
 }
 
+// Inner canvas — must live under <ReactFlowProvider> so useReactFlow()
+// can read/write the viewport. We use this primarily so MiniMap onClick
+// can pan the main canvas: pannable / zoomable on MiniMap depend on a
+// d3-zoom binding that has been observed to misfire under React 18
+// StrictMode, so onClick → setCenter is the reliable navigation path.
+function GraphCanvas({ nodes, edges }: { nodes: Node[]; edges: Edge[] }) {
+  const flow = useReactFlow();
+  const onMiniMapClick = useCallback(
+    (_evt: React.MouseEvent, position: { x: number; y: number }) => {
+      flow.setCenter(position.x, position.y, { zoom: 1, duration: 250 });
+    },
+    [flow],
+  );
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      fitView
+      nodesDraggable={false}
+      nodesConnectable={false}
+      elementsSelectable={false}
+      proOptions={{ hideAttribution: true }}
+    >
+      <Background gap={16} size={1} color="#e4e4e7" />
+      <Controls showInteractive={false} />
+      <MiniMap
+        pannable
+        zoomable
+        onClick={onMiniMapClick}
+        ariaLabel="Causal graph minimap"
+        nodeColor={(n) => {
+          const k = (n.data as { kind?: EventKind } | undefined)?.kind;
+          return (k && MINIMAP_HEX[k]) || "#a1a1aa";
+        }}
+        nodeStrokeWidth={0}
+        maskColor="rgba(255, 255, 255, 0.6)"
+      />
+    </ReactFlow>
+  );
+}
+
 export function CausalGraph({ sessionId }: { sessionId: string }) {
   // Same queryKey as Timeline: react-query dedupes the fetch and both
   // views share the cache, so toggling Timeline ↔ Graph never re-fetches.
@@ -191,34 +235,9 @@ export function CausalGraph({ sessionId }: { sessionId: string }) {
 
   return (
     <div className="h-[calc(100vh-180px)] overflow-hidden rounded border border-zinc-200 bg-white">
-      <ReactFlow
-        nodes={graph.nodes}
-        edges={graph.edges}
-        fitView
-        nodesDraggable={false}
-        nodesConnectable={false}
-        elementsSelectable={false}
-        proOptions={{ hideAttribution: true }}
-      >
-        <Background gap={16} size={1} color="#e4e4e7" />
-        <Controls showInteractive={false} />
-        <MiniMap
-          pannable
-          zoomable
-          ariaLabel="Causal graph minimap"
-          nodeColor={(n) => {
-            const k = (n.data as { kind?: EventKind } | undefined)?.kind;
-            return (k && MINIMAP_HEX[k]) || "#a1a1aa";
-          }}
-          nodeStrokeWidth={0}
-          maskColor="rgba(255, 255, 255, 0.6)"
-          style={{
-            background: "#fafafa",
-            border: "1px solid #e4e4e7",
-            borderRadius: 4,
-          }}
-        />
-      </ReactFlow>
+      <ReactFlowProvider>
+        <GraphCanvas nodes={graph.nodes} edges={graph.edges} />
+      </ReactFlowProvider>
     </div>
   );
 }

--- a/web/src/components/CausalGraph.tsx
+++ b/web/src/components/CausalGraph.tsx
@@ -1,0 +1,185 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import ReactFlow, {
+  Background,
+  Controls,
+  MarkerType,
+  type Edge,
+  type Node,
+} from "reactflow";
+import "reactflow/dist/style.css";
+import dagre from "@dagrejs/dagre";
+
+import { gql, eventsQuery } from "../api/client";
+import type { Event, EventsResponse } from "../types";
+import { styleFor } from "./kindStyle";
+
+const NODE_W = 180;
+const NODE_H = 56;
+
+// Build the dagre layout for one session's worth of events. Returns a
+// position map keyed by event id (top-left corner, since ReactFlow
+// expects top-left while dagre returns center).
+function layoutPositions(
+  events: Event[],
+  edges: Array<{ source: string; target: string }>,
+): Record<string, { x: number; y: number }> {
+  const g = new dagre.graphlib.Graph();
+  g.setDefaultEdgeLabel(() => ({}));
+  g.setGraph({ rankdir: "TB", nodesep: 24, ranksep: 56 });
+  for (const e of events) {
+    g.setNode(e.id, { width: NODE_W, height: NODE_H });
+  }
+  for (const e of edges) {
+    if (g.hasNode(e.source) && g.hasNode(e.target)) {
+      g.setEdge(e.source, e.target);
+    }
+  }
+  dagre.layout(g);
+  const out: Record<string, { x: number; y: number }> = {};
+  for (const id of g.nodes()) {
+    const n = g.node(id);
+    out[id] = { x: n.x - NODE_W / 2, y: n.y - NODE_H / 2 };
+  }
+  return out;
+}
+
+function buildGraph(events: Event[]): { nodes: Node[]; edges: Edge[] } {
+  const hashToId: Record<string, string> = {};
+  for (const e of events) {
+    if (e.hash) hashToId[e.hash] = e.id;
+  }
+
+  const edges: Edge[] = [];
+  const seenLinkIds = new Set<string>();
+
+  for (const e of events) {
+    // Explicit causal parents — the strongest semantic edge.
+    for (const p of e.parents) {
+      edges.push({
+        id: `parent:${p}->${e.id}`,
+        source: p,
+        target: e.id,
+        type: "smoothstep",
+        markerEnd: { type: MarkerType.ArrowClosed, color: "#1f2937" },
+        style: { stroke: "#1f2937", strokeWidth: 2 },
+      });
+    }
+    // Hash chain — structural, not causal. Render lightly so it doesn't
+    // dominate. Skip if the predecessor isn't in the rendered set
+    // (graceful when limit truncates the head of the chain).
+    if (e.prevHash && hashToId[e.prevHash]) {
+      edges.push({
+        id: `chain:${e.id}`,
+        source: hashToId[e.prevHash],
+        target: e.id,
+        type: "smoothstep",
+        markerEnd: { type: MarkerType.ArrowClosed, color: "#9ca3af" },
+        style: { stroke: "#9ca3af", strokeWidth: 1, strokeDasharray: "4 3" },
+      });
+    }
+    // Linker-inferred edges. event.links includes both inbound and
+    // outbound, so we'd see each edge twice if we didn't dedupe by a
+    // canonical key.
+    for (const l of e.links) {
+      const key = `link:${l.fromEvent}->${l.toEvent}:${l.relation}`;
+      if (seenLinkIds.has(key)) continue;
+      seenLinkIds.add(key);
+      edges.push({
+        id: key,
+        source: l.fromEvent,
+        target: l.toEvent,
+        type: "smoothstep",
+        label: l.relation,
+        labelStyle: { fontSize: 10, fill: "#4f46e5" },
+        labelBgPadding: [4, 2],
+        labelBgBorderRadius: 4,
+        labelBgStyle: { fill: "#eef2ff" },
+        markerEnd: { type: MarkerType.Arrow, color: "#6366f1" },
+        style: { stroke: "#6366f1", strokeWidth: 1.5 },
+      });
+    }
+  }
+
+  const positions = layoutPositions(events, edges);
+
+  const nodes: Node[] = events.map((e) => {
+    const s = styleFor(e.kind);
+    const idTail = e.id.length > 12 ? e.id.slice(-12) : e.id;
+    return {
+      id: e.id,
+      position: positions[e.id] ?? { x: 0, y: 0 },
+      data: {
+        label: (
+          <div className={`flex h-full w-full flex-col gap-0.5 rounded border ${s.container} px-2 py-1`}>
+            <div className="flex items-center gap-1 text-[10px]">
+              <span aria-hidden>{s.icon}</span>
+              <span className="font-medium uppercase tracking-wide">{s.label}</span>
+            </div>
+            <div className="truncate font-mono text-[9px] text-zinc-500">{idTail}</div>
+          </div>
+        ),
+      },
+      style: {
+        width: NODE_W,
+        height: NODE_H,
+        padding: 0,
+        border: "none",
+        background: "transparent",
+      },
+    };
+  });
+
+  return { nodes, edges };
+}
+
+export function CausalGraph({ sessionId }: { sessionId: string }) {
+  // Same queryKey as Timeline: react-query dedupes the fetch and both
+  // views share the cache, so toggling Timeline ↔ Graph never re-fetches.
+  const { data, error, isLoading } = useQuery({
+    queryKey: ["events", sessionId],
+    queryFn: () => gql<EventsResponse>(eventsQuery, { sessionId, limit: 200 }),
+    enabled: sessionId.length > 0,
+    refetchInterval: 2000,
+  });
+
+  const graph = useMemo(() => {
+    if (!data?.events?.length) return { nodes: [], edges: [] };
+    return buildGraph(data.events);
+  }, [data]);
+
+  if (isLoading) return <div className="text-sm text-zinc-500">Loading…</div>;
+  if (error) {
+    return (
+      <div className="text-sm text-rose-600">
+        Error: {(error as Error).message}
+      </div>
+    );
+  }
+  if (!data) return null;
+
+  if (graph.nodes.length === 0) {
+    return (
+      <div className="text-sm text-zinc-500">
+        No events for this session yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-[calc(100vh-180px)] overflow-hidden rounded border border-zinc-200 bg-white">
+      <ReactFlow
+        nodes={graph.nodes}
+        edges={graph.edges}
+        fitView
+        nodesDraggable={false}
+        nodesConnectable={false}
+        elementsSelectable={false}
+        proOptions={{ hideAttribution: true }}
+      >
+        <Background gap={16} size={1} color="#e4e4e7" />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
+  );
+}


### PR DESCRIPTION
Refs #41.

## Summary

- New \`CausalGraph\` web component renders a session's events as a directed graph (ReactFlow + \`@dagrejs/dagre\` v3, top-down DAG). Edges:
  - Hash chain (prev_hash) — dashed light-gray, structural.
  - Explicit causal parents — solid dark with arrowhead.
  - Linker-inferred relations — solid indigo with relation label.
- Linker links arrive on \`event.links\` for both endpoints; dedupe by \`from→to:relation\`.
- Toggle in the session view: \`Timeline / Graph\` segmented control. Deep-link via \`?view=graph\`. Toggling \`pushState\`s a new history entry so back/forward traverses both session id and view.
- Shares the \`["events", sessionId]\` react-query cache with \`Timeline\` — toggling never re-fetches.
- Page max-w bumped \`4xl → 6xl\` so the graph has room to lay out.

## Out of scope (per #41)

- Cross-session graphs.
- Click-to-expand event detail panel inside the graph.
- ELK or non-dagre layouts.
- Minimap, viewport persistence, performance work for very large sessions.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] Vite HMR reloads \`/src/App.tsx\` and the new component without errors.
- [x] \`/v1/graphql\` proxy still resolves through Vite dev server.
- [ ] Visual: open \`http://localhost:5173/?session=<id>&view=graph\` on the live dogfood (348 events) — verify nodes render with kindStyle colors, three edge types are visually distinct, fitView captures the whole DAG.
- [ ] Visual: toggle Timeline ↔ Graph; browser back/forward steps through correctly; \`Agent Lens\` brand returns to list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)