### PR TITLE
feat(web): Monaco diff for Edit/Write/MultiEdit TOOL_CALL events

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@dagrejs/dagre": "^3.0.0",
+    "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.59.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@dagrejs/dagre':
         specifier: ^3.0.0
         version: 3.0.0
+      '@monaco-editor/react':
+        specifier: ^4.7.0
+        version: 4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.59.0
         version: 5.100.5(react@18.3.1)
@@ -368,6 +371,16 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@monaco-editor/loader@1.7.0':
+    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
+
+  '@monaco-editor/react@4.7.0':
+    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -690,6 +703,9 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@typescript-eslint/eslint-plugin@8.59.0':
     resolution: {integrity: sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -930,6 +946,9 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dompurify@3.2.7:
+    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
@@ -1173,6 +1192,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1187,6 +1211,9 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  monaco-editor@0.55.1:
+    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -1396,6 +1423,9 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1803,6 +1833,17 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@monaco-editor/loader@1.7.0':
+    dependencies:
+      state-local: 1.0.7
+
+  '@monaco-editor/react@4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@monaco-editor/loader': 1.7.0
+      monaco-editor: 0.55.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2132,6 +2173,9 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@typescript-eslint/eslint-plugin@8.59.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3))(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -2394,6 +2438,10 @@ snapshots:
 
   dlv@1.1.3: {}
 
+  dompurify@3.2.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   electron-to-chromium@1.5.344: {}
 
   es-errors@1.3.0: {}
@@ -2639,6 +2687,8 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  marked@14.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -2653,6 +2703,11 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.14
+
+  monaco-editor@0.55.1:
+    dependencies:
+      dompurify: 3.2.7
+      marked: 14.0.0
 
   ms@2.1.3: {}
 
@@ -2851,6 +2906,8 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   source-map-js@1.2.1: {}
+
+  state-local@1.0.7: {}
 
   strip-json-comments@3.1.1: {}
 

--- a/web/src/components/DiffView.tsx
+++ b/web/src/components/DiffView.tsx
@@ -1,0 +1,174 @@
+import { DiffEditor } from "@monaco-editor/react";
+
+export type DiffSlice = {
+  // Path is shown as a header above the editor and used to infer
+  // syntax highlighting language. Stays raw (absolute path is fine —
+  // basename is shown in the header for readability).
+  filePath: string;
+  before: string;
+  after: string;
+  // Optional caption (e.g. "edit 2 of 3" for MultiEdit), rendered next
+  // to the basename.
+  note?: string;
+};
+
+// Minimal extension → Monaco language map. Falls back to plaintext for
+// anything not listed; the user still sees a clean diff, just without
+// syntax highlighting. We deliberately do not pull all of Monaco's
+// language registry — covering the languages this repo touches is
+// enough for the dogfood loop.
+const LANGUAGE_BY_EXT: Record<string, string> = {
+  ts: "typescript",
+  tsx: "typescript",
+  js: "javascript",
+  jsx: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  go: "go",
+  py: "python",
+  rs: "rust",
+  java: "java",
+  rb: "ruby",
+  md: "markdown",
+  json: "json",
+  jsonl: "json",
+  yaml: "yaml",
+  yml: "yaml",
+  toml: "ini",
+  ini: "ini",
+  sh: "shell",
+  bash: "shell",
+  zsh: "shell",
+  sql: "sql",
+  css: "css",
+  scss: "scss",
+  html: "html",
+  xml: "xml",
+  proto: "proto",
+  graphql: "graphql",
+  Dockerfile: "dockerfile",
+};
+
+function languageFor(filePath: string): string {
+  const base = filePath.split("/").pop() ?? filePath;
+  if (LANGUAGE_BY_EXT[base]) return LANGUAGE_BY_EXT[base]; // exact basename match (e.g. Dockerfile)
+  const dot = base.lastIndexOf(".");
+  if (dot < 0) return "plaintext";
+  const ext = base.slice(dot + 1).toLowerCase();
+  return LANGUAGE_BY_EXT[ext] ?? "plaintext";
+}
+
+function basename(filePath: string): string {
+  return filePath.split("/").pop() || filePath;
+}
+
+// Heuristic editor height: every diff has at least header + a few
+// lines, but very large diffs get capped so a single Edit can't push
+// the timeline page kilometers tall. The user can still scroll inside
+// the editor when content exceeds the viewport.
+function heightFor(slice: DiffSlice): number {
+  const lines = Math.max(
+    slice.before.split("\n").length,
+    slice.after.split("\n").length,
+  );
+  const px = Math.min(Math.max(lines, 4), 30) * 19 + 24; // 19px line + padding
+  return px;
+}
+
+export function DiffView({ slice }: { slice: DiffSlice }) {
+  const language = languageFor(slice.filePath);
+  return (
+    <div className="overflow-hidden rounded border border-zinc-300 bg-white">
+      <div className="flex items-baseline justify-between border-b border-zinc-200 bg-zinc-50 px-3 py-1.5">
+        <div className="flex items-baseline gap-2">
+          <span className="font-mono text-xs font-medium text-zinc-800">
+            {basename(slice.filePath)}
+          </span>
+          <span className="text-[10px] text-zinc-400">{language}</span>
+          {slice.note && (
+            <span className="text-[10px] text-zinc-500">{slice.note}</span>
+          )}
+        </div>
+        <span
+          className="truncate font-mono text-[10px] text-zinc-400"
+          title={slice.filePath}
+        >
+          {slice.filePath}
+        </span>
+      </div>
+      <DiffEditor
+        height={heightFor(slice)}
+        original={slice.before}
+        modified={slice.after}
+        language={language}
+        theme="vs"
+        options={{
+          readOnly: true,
+          renderSideBySide: true,
+          renderOverviewRuler: false,
+          minimap: { enabled: false },
+          scrollBeyondLastLine: false,
+          fontSize: 12,
+          lineNumbers: "on",
+          folding: false,
+          automaticLayout: true,
+          scrollbar: { alwaysConsumeMouseWheel: false },
+        }}
+      />
+    </div>
+  );
+}
+
+// Convert a TOOL_CALL payload into zero or more diff slices. Returns
+// [] for tools that aren't file mutators (so the EventCard can decide
+// whether to show the diff affordance with a single truthy check on
+// length). Defensive about unexpected payload shapes — we'd rather
+// return [] than throw and break Timeline rendering.
+export function payloadToDiff(
+  payload: Record<string, unknown> | null | undefined,
+): DiffSlice[] {
+  if (!payload) return [];
+  const name = typeof payload.name === "string" ? payload.name : "";
+  const input = (payload.input ?? {}) as Record<string, unknown>;
+  const filePath =
+    typeof input.file_path === "string" ? input.file_path : "";
+  if (!filePath) return [];
+
+  if (name === "Edit") {
+    const before = stringField(input.old_string);
+    const after = stringField(input.new_string);
+    if (before === null && after === null) return [];
+    return [{ filePath, before: before ?? "", after: after ?? "" }];
+  }
+  if (name === "Write") {
+    const after = stringField(input.content);
+    if (after === null) return [];
+    // Treat Write as a file creation: before is empty. Existing-file
+    // overwrites will display as full insert, which is technically
+    // correct but loses the implicit before — see issue #43 follow-ups.
+    return [{ filePath, before: "", after }];
+  }
+  if (name === "MultiEdit") {
+    const edits = Array.isArray(input.edits) ? input.edits : [];
+    const slices: DiffSlice[] = [];
+    edits.forEach((raw, i) => {
+      if (!raw || typeof raw !== "object") return;
+      const e = raw as Record<string, unknown>;
+      const before = stringField(e.old_string);
+      const after = stringField(e.new_string);
+      if (before === null && after === null) return;
+      slices.push({
+        filePath,
+        before: before ?? "",
+        after: after ?? "",
+        note: `edit ${i + 1} of ${edits.length}`,
+      });
+    });
+    return slices;
+  }
+  return [];
+}
+
+function stringField(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -1,13 +1,23 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import type { Event } from "../types";
 import { styleFor, formatTimestamp } from "./kindStyle";
+import { DiffView, payloadToDiff } from "./DiffView";
 
 export function EventCard({ event }: { event: Event }) {
   const [open, setOpen] = useState(false);
+  const [showRaw, setShowRaw] = useState(false);
   const style = styleFor(event.kind);
 
   const summary = summarize(event);
   const hasPayload = event.payload && Object.keys(event.payload).length > 0;
+  const diffs = useMemo(
+    () =>
+      event.kind === "TOOL_CALL"
+        ? payloadToDiff(event.payload as Record<string, unknown> | null | undefined)
+        : [],
+    [event.kind, event.payload],
+  );
+  const expandable = hasPayload || diffs.length > 0;
 
   return (
     <div className={`rounded-lg border px-4 py-3 ${style.container}`}>
@@ -15,7 +25,7 @@ export function EventCard({ event }: { event: Event }) {
         type="button"
         className="flex w-full items-start justify-between gap-3 text-left"
         onClick={() => setOpen((o) => !o)}
-        disabled={!hasPayload}
+        disabled={!expandable}
       >
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 flex-wrap">
@@ -32,6 +42,11 @@ export function EventCard({ event }: { event: Event }) {
               {event.actor.type.toLowerCase()} · {event.actor.id}
               {event.actor.model ? ` · ${event.actor.model}` : ""}
             </span>
+            {diffs.length > 0 && (
+              <span className="inline-flex items-center gap-0.5 rounded bg-sky-100 px-1.5 py-0.5 text-[10px] font-medium text-sky-900 ring-1 ring-sky-300">
+                ✎ diff{diffs.length > 1 ? ` ×${diffs.length}` : ""}
+              </span>
+            )}
             {event.links?.length > 0 && (
               <span
                 className="inline-flex items-center gap-0.5 rounded bg-white px-1.5 py-0.5 text-[10px] font-medium text-zinc-700 ring-1 ring-zinc-300"
@@ -56,14 +71,39 @@ export function EventCard({ event }: { event: Event }) {
             {event.id} · hash {event.hash.slice(0, 12)}
           </div>
         </div>
-        {hasPayload && (
+        {expandable && (
           <span className="text-xs text-zinc-400 select-none mt-0.5 shrink-0">
             {open ? "▼" : "▶"}
           </span>
         )}
       </button>
 
-      {open && hasPayload && (
+      {open && diffs.length > 0 && (
+        <div className="mt-3 space-y-2">
+          {diffs.map((slice, i) => (
+            <DiffView key={`${slice.filePath}:${i}`} slice={slice} />
+          ))}
+          {hasPayload && (
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                setShowRaw((s) => !s);
+              }}
+              className="text-[11px] text-zinc-500 underline-offset-2 hover:underline"
+            >
+              {showRaw ? "Hide" : "Show"} raw payload
+            </button>
+          )}
+          {showRaw && hasPayload && (
+            <pre className="overflow-x-auto rounded border border-zinc-200 bg-white/70 p-2 text-[11px] text-zinc-800">
+              {JSON.stringify(event.payload, null, 2)}
+            </pre>
+          )}
+        </div>
+      )}
+
+      {open && diffs.length === 0 && hasPayload && (
         <pre className="mt-3 overflow-x-auto rounded border border-zinc-200 bg-white/70 p-2 text-[11px] text-zinc-800">
           {JSON.stringify(event.payload, null, 2)}
         </pre>


### PR DESCRIPTION
Refs #43.

## Summary

- \`@monaco-editor/react\` added as web dependency.
- New \`DiffView\` component renders a read-only \`DiffEditor\` for one before/after pair, with a file-path header and language inferred from extension. Editor height capped at ~30 lines × 19px to keep a single edit from blowing out the page; content scrolls inside the editor when larger.
- New \`payloadToDiff(payload)\` adapter:
  - \`Edit\` → one slice (\`old_string\` → \`new_string\`).
  - \`Write\` → one slice (\`""\` → \`content\`, file-creation default).
  - \`MultiEdit\` → one slice per \`edits[]\` entry, captioned \`edit i of N\`.
  - Anything else → \`[]\` (affordance gated on length, not name match).
- \`EventCard\` adds a sky \`diff ×N\` pill in the row header for events with slices, renders \`DiffView\`(s) inline when expanded, and tucks the raw JSON behind a \"Show raw payload\" disclosure. Non-mutating tools keep the existing JSON-only expansion.

## Out of scope (per #43)

- Hook-side CODE_CHANGE event emission (when added, EventCard adds a \`kind === 'CODE_CHANGE'\` branch — small migration).
- \`Write\` "before" content from disk / git \`HEAD~1\` (overwrites display as full insert).
- Standalone diff browser page; diff in Graph node bodies.

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean.
- [x] Vite optimizes \`@monaco-editor/react\` and HMR reloads cleanly.
- [ ] Visual: in dogfood Timeline, expand an Edit row and a Write row — Monaco renders side-by-side diff with inferred language. Bash / Read rows show no diff pill and use the JSON expansion.
- [ ] Visual: click Show raw payload to compare the JSON original.

🤖 Generated with [Claude Code](https://claude.com/claude-code)