### PR TITLE
chore(web): self-bundle Monaco, stop loading from jsdelivr CDN

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -14,6 +14,7 @@
     "@dagrejs/dagre": "^3.0.0",
     "@monaco-editor/react": "^4.7.0",
     "@tanstack/react-query": "^5.59.0",
+    "monaco-editor": "^0.55.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "reactflow": "^11.11.4"

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.59.0
         version: 5.100.5(react@18.3.1)
+      monaco-editor:
+        specifier: ^0.55.1
+        version: 0.55.1
       react:
         specifier: ^18.3.1
         version: 18.3.1

--- a/web/src/components/DiffView.tsx
+++ b/web/src/components/DiffView.tsx
@@ -1,22 +1,39 @@
-import { DiffEditor } from "@monaco-editor/react";
+// Self-bundled Monaco. Importing this module loads ~600 KB gzipped of
+// Monaco core; keep it isolated and React.lazy it from the consumer
+// (EventCard) so the cost is only paid when a user actually expands a
+// diff. The CDN-loader fallback Monaco/react would otherwise use is
+// fully bypassed — see issue #45.
 
-export type DiffSlice = {
-  // Path is shown as a header above the editor and used to infer
-  // syntax highlighting language. Stays raw (absolute path is fine —
-  // basename is shown in the header for readability).
-  filePath: string;
-  before: string;
-  after: string;
-  // Optional caption (e.g. "edit 2 of 3" for MultiEdit), rendered next
-  // to the basename.
-  note?: string;
+// Vite's ?worker query bundles Monaco's editor worker into a separate
+// chunk we can construct on demand. We deliberately do NOT bundle the
+// language workers (typescript / json / css / html); DiffEditor uses
+// only Monarch tokenization, which lives in the editor module itself.
+import EditorWorker from "monaco-editor/esm/vs/editor/editor.worker?worker";
+
+// MonacoEnvironment must be set before any Monaco editor instance is
+// created. ES module imports are hoisted, but module *body* runs in
+// source order and before any consumer can render <DiffEditor>, so
+// this assignment is in time as long as nothing imports monaco-editor
+// before this module.
+type MonacoSelf = typeof self & {
+  MonacoEnvironment?: { getWorker: (workerId: string, label: string) => Worker };
+};
+(self as MonacoSelf).MonacoEnvironment = {
+  getWorker(_workerId, _label) {
+    return new EditorWorker();
+  },
 };
 
-// Minimal extension → Monaco language map. Falls back to plaintext for
-// anything not listed; the user still sees a clean diff, just without
-// syntax highlighting. We deliberately do not pull all of Monaco's
-// language registry — covering the languages this repo touches is
-// enough for the dogfood loop.
+import * as monaco from "monaco-editor";
+import { DiffEditor, loader } from "@monaco-editor/react";
+
+// Tell the React wrapper to use our bundled monaco instead of fetching
+// it from jsdelivr. Once configured, all subsequent <DiffEditor> /
+// <Editor> mounts use the local copy.
+loader.config({ monaco });
+
+import type { DiffSlice } from "../lib/payloadToDiff";
+
 const LANGUAGE_BY_EXT: Record<string, string> = {
   ts: "typescript",
   tsx: "typescript",
@@ -51,7 +68,7 @@ const LANGUAGE_BY_EXT: Record<string, string> = {
 
 function languageFor(filePath: string): string {
   const base = filePath.split("/").pop() ?? filePath;
-  if (LANGUAGE_BY_EXT[base]) return LANGUAGE_BY_EXT[base]; // exact basename match (e.g. Dockerfile)
+  if (LANGUAGE_BY_EXT[base]) return LANGUAGE_BY_EXT[base];
   const dot = base.lastIndexOf(".");
   if (dot < 0) return "plaintext";
   const ext = base.slice(dot + 1).toLowerCase();
@@ -64,14 +81,14 @@ function basename(filePath: string): string {
 
 // Heuristic editor height: every diff has at least header + a few
 // lines, but very large diffs get capped so a single Edit can't push
-// the timeline page kilometers tall. The user can still scroll inside
-// the editor when content exceeds the viewport.
+// the timeline page kilometers tall. Content scrolls inside the editor
+// when it exceeds the viewport.
 function heightFor(slice: DiffSlice): number {
   const lines = Math.max(
     slice.before.split("\n").length,
     slice.after.split("\n").length,
   );
-  const px = Math.min(Math.max(lines, 4), 30) * 19 + 24; // 19px line + padding
+  const px = Math.min(Math.max(lines, 4), 30) * 19 + 24;
   return px;
 }
 
@@ -119,56 +136,6 @@ export function DiffView({ slice }: { slice: DiffSlice }) {
   );
 }
 
-// Convert a TOOL_CALL payload into zero or more diff slices. Returns
-// [] for tools that aren't file mutators (so the EventCard can decide
-// whether to show the diff affordance with a single truthy check on
-// length). Defensive about unexpected payload shapes — we'd rather
-// return [] than throw and break Timeline rendering.
-export function payloadToDiff(
-  payload: Record<string, unknown> | null | undefined,
-): DiffSlice[] {
-  if (!payload) return [];
-  const name = typeof payload.name === "string" ? payload.name : "";
-  const input = (payload.input ?? {}) as Record<string, unknown>;
-  const filePath =
-    typeof input.file_path === "string" ? input.file_path : "";
-  if (!filePath) return [];
-
-  if (name === "Edit") {
-    const before = stringField(input.old_string);
-    const after = stringField(input.new_string);
-    if (before === null && after === null) return [];
-    return [{ filePath, before: before ?? "", after: after ?? "" }];
-  }
-  if (name === "Write") {
-    const after = stringField(input.content);
-    if (after === null) return [];
-    // Treat Write as a file creation: before is empty. Existing-file
-    // overwrites will display as full insert, which is technically
-    // correct but loses the implicit before — see issue #43 follow-ups.
-    return [{ filePath, before: "", after }];
-  }
-  if (name === "MultiEdit") {
-    const edits = Array.isArray(input.edits) ? input.edits : [];
-    const slices: DiffSlice[] = [];
-    edits.forEach((raw, i) => {
-      if (!raw || typeof raw !== "object") return;
-      const e = raw as Record<string, unknown>;
-      const before = stringField(e.old_string);
-      const after = stringField(e.new_string);
-      if (before === null && after === null) return;
-      slices.push({
-        filePath,
-        before: before ?? "",
-        after: after ?? "",
-        note: `edit ${i + 1} of ${edits.length}`,
-      });
-    });
-    return slices;
-  }
-  return [];
-}
-
-function stringField(v: unknown): string | null {
-  return typeof v === "string" ? v : null;
-}
+// Default export so EventCard can React.lazy this module — React.lazy
+// expects a function returning a module with a default export.
+export default DiffView;

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -1,7 +1,13 @@
-import { useMemo, useState } from "react";
+import { lazy, Suspense, useMemo, useState } from "react";
 import type { Event } from "../types";
 import { styleFor, formatTimestamp } from "./kindStyle";
-import { DiffView, payloadToDiff } from "./DiffView";
+import { payloadToDiff } from "../lib/payloadToDiff";
+
+// React.lazy keeps the ~600 KB Monaco bundle out of the eager chunk:
+// users who never expand a diff never pay for it. The dynamic import
+// triggers Vite to emit Monaco as its own chunk loaded on first
+// expansion.
+const DiffView = lazy(() => import("./DiffView"));
 
 export function EventCard({ event }: { event: Event }) {
   const [open, setOpen] = useState(false);
@@ -80,9 +86,17 @@ export function EventCard({ event }: { event: Event }) {
 
       {open && diffs.length > 0 && (
         <div className="mt-3 space-y-2">
-          {diffs.map((slice, i) => (
-            <DiffView key={`${slice.filePath}:${i}`} slice={slice} />
-          ))}
+          <Suspense
+            fallback={
+              <div className="rounded border border-zinc-200 bg-white px-3 py-6 text-center text-xs text-zinc-500">
+                Loading diff editor…
+              </div>
+            }
+          >
+            {diffs.map((slice, i) => (
+              <DiffView key={`${slice.filePath}:${i}`} slice={slice} />
+            ))}
+          </Suspense>
           {hasPayload && (
             <button
               type="button"

--- a/web/src/lib/payloadToDiff.ts
+++ b/web/src/lib/payloadToDiff.ts
@@ -1,0 +1,66 @@
+// Pure helpers for deriving file diffs from TOOL_CALL payloads.
+// Lives outside components/DiffView so EventCard can import these
+// synchronously without dragging Monaco into the eager bundle —
+// DiffView itself is React.lazy-loaded.
+
+export type DiffSlice = {
+  filePath: string;
+  before: string;
+  after: string;
+  // Optional caption (e.g. "edit 2 of 3" for MultiEdit).
+  note?: string;
+};
+
+// Convert a TOOL_CALL payload into zero or more diff slices. Returns
+// [] for tools that aren't file mutators so EventCard can decide
+// whether to show the diff affordance with a single truthy length
+// check. Defensive about unexpected payload shapes — we'd rather
+// return [] than throw and break Timeline rendering.
+export function payloadToDiff(
+  payload: Record<string, unknown> | null | undefined,
+): DiffSlice[] {
+  if (!payload) return [];
+  const name = typeof payload.name === "string" ? payload.name : "";
+  const input = (payload.input ?? {}) as Record<string, unknown>;
+  const filePath =
+    typeof input.file_path === "string" ? input.file_path : "";
+  if (!filePath) return [];
+
+  if (name === "Edit") {
+    const before = stringField(input.old_string);
+    const after = stringField(input.new_string);
+    if (before === null && after === null) return [];
+    return [{ filePath, before: before ?? "", after: after ?? "" }];
+  }
+  if (name === "Write") {
+    const after = stringField(input.content);
+    if (after === null) return [];
+    // Treat Write as a file creation: before is empty. Existing-file
+    // overwrites display as full insert, which is correct but loses
+    // the implicit before — see #43 follow-ups.
+    return [{ filePath, before: "", after }];
+  }
+  if (name === "MultiEdit") {
+    const edits = Array.isArray(input.edits) ? input.edits : [];
+    const slices: DiffSlice[] = [];
+    edits.forEach((raw, i) => {
+      if (!raw || typeof raw !== "object") return;
+      const e = raw as Record<string, unknown>;
+      const before = stringField(e.old_string);
+      const after = stringField(e.new_string);
+      if (before === null && after === null) return;
+      slices.push({
+        filePath,
+        before: before ?? "",
+        after: after ?? "",
+        note: `edit ${i + 1} of ${edits.length}`,
+      });
+    });
+    return slices;
+  }
+  return [];
+}
+
+function stringField(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Closes #45.

## Summary

- \`pnpm add monaco-editor\` and configure \`@monaco-editor/react\`'s loader to use the bundled copy via \`loader.config({ monaco })\`. No more CDN dependency.
- Vite \`?worker\` import for \`editor.worker\` only; language workers (typescript / json / css / html) are deliberately not bundled — read-only diff display needs only Monarch tokenization, not IntelliSense.
- \`DiffSlice\` + \`payloadToDiff\` extracted to \`web/src/lib/payloadToDiff.ts\` so \`EventCard\` can import them synchronously without dragging Monaco into the eager chunk. Pure helper, no JSX.
- \`EventCard\` loads \`DiffView\` via \`React.lazy\` + \`Suspense\`. The Monaco chunk is only fetched when a user first expands a diff; Timelines without expansions cost zero.
- \`web/src/vite-env.d.ts\` adds the standard \`vite/client\` triple-slash so TypeScript recognises \`?worker\`.

## Build evidence

\`pnpm build\` output, key chunks:

| Chunk | Size | Gzipped | Eager? |
|---|---|---|---|
| \`index-*.js\` (app) | 391 kB | 127 kB | yes — no Monaco |
| \`DiffView-*.js\` (Monaco core) | 3.8 MB | 990 kB | **lazy** |
| ~30 language chunks (\`go\`, \`typescript\`, \`json\`, …) | 5–22 kB each | 2–8 kB | lazy, on demand |

## Test plan

- [x] \`pnpm exec tsc --noEmit\` clean (after vite-env.d.ts).
- [x] \`pnpm build\` produces the chunks above; no warning beyond the expected "DiffView chunk > 500 kB" (Monaco itself).
- [x] Vite dev HMR optimizes monaco-editor and reloads cleanly.
- [ ] Visual: open Timeline, expand an Edit row — Monaco loads from \`/assets/DiffView-*.js\` (Network tab), no \`cdn.jsdelivr.net\` request.
- [ ] Visual: blocking jsdelivr.net in DevTools → diff still renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)