### PR TITLE
feat(query,web): cross-session causal graph view (Phase B)

### DIFF
--- a/internal/query/generated.go
+++ b/internal/query/generated.go
@@ -67,10 +67,11 @@ type ComplexityRoot struct {
 	}
 
 	Query struct {
-		Event       func(childComplexity int, id string) int
-		Events      func(childComplexity int, sessionID string, limit *int) int
-		SessionHead func(childComplexity int, sessionID string) int
-		Sessions    func(childComplexity int, limit *int, since *time.Time) int
+		Event        func(childComplexity int, id string) int
+		Events       func(childComplexity int, sessionID string, limit *int) int
+		LinkedEvents func(childComplexity int, sessionID string, depth *int, perSessionLimit *int) int
+		SessionHead  func(childComplexity int, sessionID string) int
+		Sessions     func(childComplexity int, limit *int, since *time.Time) int
 	}
 
 	Session struct {
@@ -89,6 +90,7 @@ type QueryResolver interface {
 	Events(ctx context.Context, sessionID string, limit *int) ([]*Event, error)
 	SessionHead(ctx context.Context, sessionID string) (string, error)
 	Sessions(ctx context.Context, limit *int, since *time.Time) ([]*Session, error)
+	LinkedEvents(ctx context.Context, sessionID string, depth *int, perSessionLimit *int) ([]*Event, error)
 }
 
 type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -251,6 +253,17 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 
 		return e.ComplexityRoot.Query.Events(childComplexity, args["sessionId"].(string), args["limit"].(*int)), true
 
+	case "Query.linkedEvents":
+		if e.ComplexityRoot.Query.LinkedEvents == nil {
+			break
+		}
+
+		args, err := ec.field_Query_linkedEvents_args(ctx, rawArgs)
+		if err != nil {
+			return 0, false
+		}
+
+		return e.ComplexityRoot.Query.LinkedEvents(childComplexity, args["sessionId"].(string), args["depth"].(*int), args["perSessionLimit"].(*int)), true
 	case "Query.sessionHead":
 		if e.ComplexityRoot.Query.SessionHead == nil {
 			break
@@ -620,6 +633,36 @@ func (ec *executionContext) field_Query_events_args(ctx context.Context, rawArgs
 		return nil, err
 	}
 	args["limit"] = arg1
+	return args, nil
+}
+
+func (ec *executionContext) field_Query_linkedEvents_args(ctx context.Context, rawArgs map[string]any) (map[string]any, error) {
+	var err error
+	args := map[string]any{}
+	arg0, err := graphql.ProcessArgField(ctx, rawArgs, "sessionId",
+		func(ctx context.Context, v any) (string, error) {
+			return ec.unmarshalNString2string(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["sessionId"] = arg0
+	arg1, err := graphql.ProcessArgField(ctx, rawArgs, "depth",
+		func(ctx context.Context, v any) (*int, error) {
+			return ec.unmarshalOInt2ᚖint(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["depth"] = arg1
+	arg2, err := graphql.ProcessArgField(ctx, rawArgs, "perSessionLimit",
+		func(ctx context.Context, v any) (*int, error) {
+			return ec.unmarshalOInt2ᚖint(ctx, v)
+		})
+	if err != nil {
+		return nil, err
+	}
+	args["perSessionLimit"] = arg2
 	return args, nil
 }
 
@@ -1371,6 +1414,50 @@ func (ec *executionContext) fieldContext_Query_sessions(ctx context.Context, fie
 	}()
 	ctx = graphql.WithFieldContext(ctx, fc)
 	if fc.Args, err = ec.field_Query_sessions_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
+		ec.Error(ctx, err)
+		return fc, err
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Query_linkedEvents(ctx context.Context, field graphql.CollectedField) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Query_linkedEvents(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			fc := graphql.GetFieldContext(ctx)
+			return ec.Resolvers.Query().LinkedEvents(ctx, fc.Args["sessionId"].(string), fc.Args["depth"].(*int), fc.Args["perSessionLimit"].(*int))
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v []*Event) graphql.Marshaler {
+			return ec.marshalNEvent2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventᚄ(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_Query_linkedEvents(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Query",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_Event(ctx, field)
+		},
+	}
+	defer func() {
+		if r := recover(); r != nil {
+			err = ec.Recover(ctx, r)
+			ec.Error(ctx, err)
+		}
+	}()
+	ctx = graphql.WithFieldContext(ctx, fc)
+	if fc.Args, err = ec.field_Query_linkedEvents_args(ctx, field.ArgumentMap(ec.Variables)); err != nil {
 		ec.Error(ctx, err)
 		return fc, err
 	}
@@ -2925,6 +3012,28 @@ func (ec *executionContext) _Query(ctx context.Context, sel ast.SelectionSet) gr
 					}
 				}()
 				res = ec._Query_sessions(ctx, field)
+				if res == graphql.Null {
+					atomic.AddUint32(&fs.Invalids, 1)
+				}
+				return res
+			}
+
+			rrm := func(ctx context.Context) graphql.Marshaler {
+				return ec.OperationContext.RootResolverMiddleware(ctx,
+					func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return rrm(innerCtx) })
+		case "linkedEvents":
+			field := field
+
+			innerFunc := func(ctx context.Context, fs *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Query_linkedEvents(ctx, field)
 				if res == graphql.Null {
 					atomic.AddUint32(&fs.Invalids, 1)
 				}

--- a/internal/query/router_test.go
+++ b/internal/query/router_test.go
@@ -3,6 +3,7 @@ package query_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -275,5 +276,177 @@ func TestEventLinksResolver(t *testing.T) {
 	}
 	if link.InferredBy != "shared_ref:git:abc" {
 		t.Errorf("inferred_by = %q", link.InferredBy)
+	}
+}
+
+
+// TestLinkedEventsResolver covers the BFS by session id: two sessions
+// share a `git:<sha>` ref; the linker emits a cross-session link. A
+// linkedEvents query starting at one session at depth=1 returns events
+// from both. depth=0 collapses to single-session (parity with
+// events()).
+func TestLinkedEventsResolver(t *testing.T) {
+	st := store.NewMemory()
+	ctx := context.Background()
+
+	// Seed: claude session has a tool_result with git:<sha> ref;
+	// git session has a commit with the same ref. linker emits link.
+	mustAppend := func(id, sid, kind string, refs []string) {
+		t.Helper()
+		if err := st.AppendEvent(ctx, &store.Event{
+			ID:        id,
+			SessionID: sid,
+			ActorType: "agent",
+			ActorID:   "claude-code",
+			Kind:      kind,
+			Hash:      "h-" + id,
+			Refs:      refs,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustAppend("e-claude-prompt", "s-claude", "prompt", nil)
+	mustAppend("e-claude-call", "s-claude", "tool_call", nil)
+	mustAppend("e-claude-result", "s-claude", "tool_result", []string{"git:abc"})
+	mustAppend("e-git-commit", "s-git", "commit", []string{"git:abc"})
+
+	if err := st.AppendLink(ctx, &store.Link{
+		FromEvent:  "e-claude-result",
+		ToEvent:    "e-git-commit",
+		Relation:   "references",
+		Confidence: 1.0,
+		InferredBy: "shared_ref:git:abc",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(query.NewRouter(st))
+	defer srv.Close()
+
+	type result struct {
+		Data struct {
+			LinkedEvents []struct {
+				ID        string `json:"id"`
+				SessionID string `json:"sessionId"`
+			} `json:"linkedEvents"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors"`
+	}
+	post := func(t *testing.T, body string) result {
+		t.Helper()
+		resp, err := http.Post(srv.URL+"/graphql", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("post: %v", err)
+		}
+		defer resp.Body.Close()
+		var r result
+		if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if len(r.Errors) > 0 {
+			t.Fatalf("graphql errors: %+v", r.Errors)
+		}
+		return r
+	}
+
+	// depth=0 returns only the seed session's events.
+	r0 := post(t, `{"query":"{ linkedEvents(sessionId:\"s-claude\", depth:0) { id sessionId } }"}`)
+	gotSessions0 := map[string]int{}
+	for _, e := range r0.Data.LinkedEvents {
+		gotSessions0[e.SessionID]++
+	}
+	if gotSessions0["s-claude"] != 3 || gotSessions0["s-git"] != 0 {
+		t.Errorf("depth=0 sessions = %v, want s-claude:3 only", gotSessions0)
+	}
+
+	// depth=1 picks up the linked git session via the shared ref.
+	r1 := post(t, `{"query":"{ linkedEvents(sessionId:\"s-claude\", depth:1) { id sessionId } }"}`)
+	gotSessions1 := map[string]int{}
+	for _, e := range r1.Data.LinkedEvents {
+		gotSessions1[e.SessionID]++
+	}
+	if gotSessions1["s-claude"] != 3 || gotSessions1["s-git"] != 1 {
+		t.Errorf("depth=1 sessions = %v, want s-claude:3 + s-git:1", gotSessions1)
+	}
+
+	// Out-of-range depth is clamped to [0, 3]; depth=99 should not
+	// blow up and should return at least the depth=1 surface.
+	rBig := post(t, `{"query":"{ linkedEvents(sessionId:\"s-claude\", depth:99) { id sessionId } }"}`)
+	if len(rBig.Data.LinkedEvents) < len(r1.Data.LinkedEvents) {
+		t.Errorf("depth=99 returned fewer events (%d) than depth=1 (%d)", len(rBig.Data.LinkedEvents), len(r1.Data.LinkedEvents))
+	}
+}
+
+// TestLinkedEventsResolver_LinkPastLimit is the regression that drove
+// the switch from per-event link discovery to LinksForSession. With
+// 100 leading no-link events and the link-bearing event at index 100,
+// a perSessionLimit=10 read fetches only the first 10 events; if BFS
+// only walks links of fetched events, it never sees the link and the
+// neighbouring session is invisible. With LinksForSession, the link
+// is discovered regardless of which events were paged in.
+func TestLinkedEventsResolver_LinkPastLimit(t *testing.T) {
+	st := store.NewMemory()
+	ctx := context.Background()
+
+	for i := 0; i < 100; i++ {
+		if err := st.AppendEvent(ctx, &store.Event{
+			ID: fmt.Sprintf("e-noise-%03d", i), SessionID: "s-big",
+			ActorType: "agent", ActorID: "claude-code",
+			Kind: "tool_call", Hash: fmt.Sprintf("h-noise-%03d", i),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// The link-bearing event sits at the far end.
+	if err := st.AppendEvent(ctx, &store.Event{
+		ID: "e-link-bearer", SessionID: "s-big",
+		ActorType: "agent", ActorID: "claude-code",
+		Kind: "tool_result", Hash: "h-link-bearer",
+		Refs: []string{"git:xyz"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AppendEvent(ctx, &store.Event{
+		ID: "e-peer", SessionID: "s-peer",
+		ActorType: "human", ActorID: "alice",
+		Kind: "commit", Hash: "h-peer", Refs: []string{"git:xyz"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AppendLink(ctx, &store.Link{
+		FromEvent: "e-link-bearer", ToEvent: "e-peer",
+		Relation: "references", Confidence: 1.0, InferredBy: "shared_ref:git:xyz",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(query.NewRouter(st))
+	defer srv.Close()
+
+	body := `{"query":"{ linkedEvents(sessionId:\"s-big\", depth:1, perSessionLimit:10) { sessionId } }"}`
+	resp, err := http.Post(srv.URL+"/graphql", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	var got struct {
+		Data struct {
+			LinkedEvents []struct {
+				SessionID string `json:"sessionId"`
+			} `json:"linkedEvents"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	hasPeer := false
+	for _, e := range got.Data.LinkedEvents {
+		if e.SessionID == "s-peer" {
+			hasPeer = true
+			break
+		}
+	}
+	if !hasPeer {
+		t.Errorf("expected s-peer events in result; LinksForSession should have surfaced the link despite limit=10 (got sessions=%v)", got.Data.LinkedEvents)
 	}
 }

--- a/internal/query/router_test.go
+++ b/internal/query/router_test.go
@@ -450,3 +450,82 @@ func TestLinkedEventsResolver_LinkPastLimit(t *testing.T) {
 		t.Errorf("expected s-peer events in result; LinksForSession should have surfaced the link despite limit=10 (got sessions=%v)", got.Data.LinkedEvents)
 	}
 }
+
+// TestLinkedEventsResolver_LinkBearerPastLimit_PatchedIn is the
+// regression for the silent-degradation case where the anchor
+// session's link-bearing event sits past perSessionLimit. Without
+// the patch-in, the cross-session edge has source=<paged-out event
+// id> and ReactFlow silently drops it — the user sees the peer
+// session events but no visible link back to the anchor.
+//
+// This test asserts the link-bearing event is included in the
+// linkedEvents result *even when* it falls past the perSessionLimit
+// slice — so the frontend can render the edge with both endpoints.
+func TestLinkedEventsResolver_LinkBearerPastLimit_PatchedIn(t *testing.T) {
+	st := store.NewMemory()
+	ctx := context.Background()
+
+	// 100 leading no-link anchor events.
+	for i := 0; i < 100; i++ {
+		if err := st.AppendEvent(ctx, &store.Event{
+			ID: fmt.Sprintf("e-anchor-noise-%03d", i), SessionID: "s-anchor",
+			ActorType: "agent", ActorID: "claude-code",
+			Kind: "tool_call", Hash: fmt.Sprintf("h-anchor-noise-%03d", i),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Anchor's link-bearing event past perSessionLimit=10.
+	if err := st.AppendEvent(ctx, &store.Event{
+		ID: "e-anchor-bearer", SessionID: "s-anchor",
+		ActorType: "agent", ActorID: "claude-code",
+		Kind: "tool_result", Hash: "h-anchor-bearer",
+		Refs: []string{"git:xyz"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AppendEvent(ctx, &store.Event{
+		ID: "e-peer-commit", SessionID: "s-peer",
+		ActorType: "human", ActorID: "alice",
+		Kind: "commit", Hash: "h-peer-commit", Refs: []string{"git:xyz"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AppendLink(ctx, &store.Link{
+		FromEvent: "e-anchor-bearer", ToEvent: "e-peer-commit",
+		Relation: "references", Confidence: 1.0, InferredBy: "shared_ref:git:xyz",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(query.NewRouter(st))
+	defer srv.Close()
+
+	body := `{"query":"{ linkedEvents(sessionId:\"s-anchor\", depth:1, perSessionLimit:10) { id sessionId } }"}`
+	resp, err := http.Post(srv.URL+"/graphql", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	var got struct {
+		Data struct {
+			LinkedEvents []struct {
+				ID        string `json:"id"`
+				SessionID string `json:"sessionId"`
+			} `json:"linkedEvents"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	hasBearer := false
+	for _, e := range got.Data.LinkedEvents {
+		if e.ID == "e-anchor-bearer" {
+			hasBearer = true
+			break
+		}
+	}
+	if !hasBearer {
+		t.Errorf("expected e-anchor-bearer (anchor's link-bearing event past perSessionLimit) to be patched into the result; got %d events: %v", len(got.Data.LinkedEvents), got.Data.LinkedEvents)
+	}
+}

--- a/internal/query/schema.graphql
+++ b/internal/query/schema.graphql
@@ -77,4 +77,13 @@ type Query {
   are returned.
   """
   sessions(limit: Int = 50, since: Time): [Session!]!
+
+  """
+  Return events from sessionId plus events from any session reachable
+  via the linker's emitted `links` (transitively, up to `depth` hops).
+  Per-session result is capped at `perSessionLimit`. depth=0 is
+  equivalent to events(sessionId, perSessionLimit). depth is clamped
+  to [0, 3] server-side to bound query cost.
+  """
+  linkedEvents(sessionId: String!, depth: Int = 1, perSessionLimit: Int = 200): [Event!]!
 }

--- a/internal/query/schema.resolvers.go
+++ b/internal/query/schema.resolvers.go
@@ -8,6 +8,7 @@ package query
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"github.com/dongqiu/agent-lens/internal/store"
@@ -80,6 +81,80 @@ func (r *queryResolver) Sessions(ctx context.Context, limit *int, since *time.Ti
 	out := make([]*Session, 0, len(list))
 	for _, s := range list {
 		out = append(out, toGQLSession(s))
+	}
+	return out, nil
+}
+
+// LinkedEvents is the resolver for the linkedEvents field.
+//
+// BFS by session: start from sessionID, list its events, then expand
+// to any session reachable via links, repeating up to `depth` hops.
+//
+// Critical: link discovery uses Store.LinksForSession (full table
+// scan filtered by session) rather than walking links per fetched
+// event. The latter would cap discovery at perSessionLimit events,
+// silently missing links that live on events past that cap — exactly
+// what the dogfood data hit (the link-bearing tool_result was past
+// row 900 of a 1000-event session).
+func (r *queryResolver) LinkedEvents(ctx context.Context, sessionID string, depth *int, perSessionLimit *int) ([]*Event, error) {
+	d := 1
+	if depth != nil {
+		d = *depth
+	}
+	if d < 0 {
+		d = 0
+	}
+	if d > 3 {
+		d = 3
+	}
+
+	psl := 200
+	if perSessionLimit != nil {
+		psl = *perSessionLimit
+	}
+
+	visited := map[string]bool{sessionID: true}
+	frontier := []string{sessionID}
+	var collected []*store.Event
+
+	for level := 0; level <= d && len(frontier) > 0; level++ {
+		var nextFrontier []string
+		for _, sid := range frontier {
+			evs, err := r.Store.ListBySession(ctx, sid, psl)
+			if err != nil {
+				return nil, fmt.Errorf("ListBySession(%q): %w", sid, err)
+			}
+			collected = append(collected, evs...)
+
+			if level == d {
+				continue // last layer — don't expand further
+			}
+			links, err := r.Store.LinksForSession(ctx, sid)
+			if err != nil {
+				// Tolerate per-session link lookup failures — they'd
+				// only suppress neighbour discovery, not corrupt the
+				// already-collected events.
+				continue
+			}
+			for _, l := range links {
+				for _, otherID := range [2]string{l.FromEvent, l.ToEvent} {
+					other, err := r.Store.GetEvent(ctx, otherID)
+					if err != nil || other == nil {
+						continue
+					}
+					if !visited[other.SessionID] {
+						visited[other.SessionID] = true
+						nextFrontier = append(nextFrontier, other.SessionID)
+					}
+				}
+			}
+		}
+		frontier = nextFrontier
+	}
+
+	out := make([]*Event, 0, len(collected))
+	for _, se := range collected {
+		out = append(out, toGQLEvent(se))
 	}
 	return out, nil
 }

--- a/internal/query/schema.resolvers.go
+++ b/internal/query/schema.resolvers.go
@@ -117,6 +117,7 @@ func (r *queryResolver) LinkedEvents(ctx context.Context, sessionID string, dept
 	frontier := []string{sessionID}
 	var collected []*store.Event
 
+	collectedIDs := map[string]bool{}
 	for level := 0; level <= d && len(frontier) > 0; level++ {
 		var nextFrontier []string
 		for _, sid := range frontier {
@@ -124,11 +125,21 @@ func (r *queryResolver) LinkedEvents(ctx context.Context, sessionID string, dept
 			if err != nil {
 				return nil, fmt.Errorf("ListBySession(%q): %w", sid, err)
 			}
-			collected = append(collected, evs...)
-
-			if level == d {
-				continue // last layer — don't expand further
+			for _, e := range evs {
+				if !collectedIDs[e.ID] {
+					collectedIDs[e.ID] = true
+					collected = append(collected, e)
+				}
 			}
+
+			// Always pull the links touching this session so we (a) can
+			// expand the frontier and (b) can guarantee link-bearing
+			// events from this session are present in the result even
+			// when they sit past `psl`. Without that guarantee, a
+			// cross-session edge whose anchor-side endpoint was paged
+			// out would render as an orphan and ReactFlow would
+			// silently drop it — the user sees neighbouring events
+			// floating with no visible connection back.
 			links, err := r.Store.LinksForSession(ctx, sid)
 			if err != nil {
 				// Tolerate per-session link lookup failures — they'd
@@ -142,7 +153,14 @@ func (r *queryResolver) LinkedEvents(ctx context.Context, sessionID string, dept
 					if err != nil || other == nil {
 						continue
 					}
-					if !visited[other.SessionID] {
+					// Patch in this-session link endpoints that fell
+					// past psl, so cross-session edges always have
+					// both endpoints in the rendered set.
+					if other.SessionID == sid && !collectedIDs[other.ID] {
+						collectedIDs[other.ID] = true
+						collected = append(collected, other)
+					}
+					if level < d && !visited[other.SessionID] {
 						visited[other.SessionID] = true
 						nextFrontier = append(nextFrontier, other.SessionID)
 					}

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -166,3 +166,21 @@ func (m *Memory) LinksForEvent(_ context.Context, eventID string) ([]*Link, erro
 	}
 	return out, nil
 }
+
+func (m *Memory) LinksForSession(_ context.Context, sessionID string) ([]*Link, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// Index event id → session id for O(1) endpoint lookup.
+	idToSession := make(map[string]string, len(m.events))
+	for _, e := range m.events {
+		idToSession[e.ID] = e.SessionID
+	}
+	var out []*Link
+	for _, l := range m.links {
+		if idToSession[l.FromEvent] == sessionID || idToSession[l.ToEvent] == sessionID {
+			cp := l
+			out = append(out, &cp)
+		}
+	}
+	return out, nil
+}

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -203,6 +203,28 @@ func (p *Postgres) LinksForEvent(ctx context.Context, eventID string) ([]*Link, 
 	return out, rows.Err()
 }
 
+func (p *Postgres) LinksForSession(ctx context.Context, sessionID string) ([]*Link, error) {
+	const q = `SELECT from_event, to_event, relation, confidence, inferred_by
+		FROM links
+		WHERE from_event IN (SELECT id FROM events WHERE session_id = $1)
+		   OR to_event   IN (SELECT id FROM events WHERE session_id = $1)
+		ORDER BY relation, from_event, to_event`
+	rows, err := p.pool.Query(ctx, q, sessionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*Link
+	for rows.Next() {
+		var l Link
+		if err := rows.Scan(&l.FromEvent, &l.ToEvent, &l.Relation, &l.Confidence, &l.InferredBy); err != nil {
+			return nil, err
+		}
+		out = append(out, &l)
+	}
+	return out, rows.Err()
+}
+
 type scanner interface {
 	Scan(dest ...any) error
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -75,5 +75,10 @@ type Store interface {
 	ListSessions(ctx context.Context, limit int, since time.Time) ([]*SessionSummary, error)
 	AppendLink(ctx context.Context, l *Link) error
 	LinksForEvent(ctx context.Context, eventID string) ([]*Link, error)
+	// LinksForSession returns every link with at least one endpoint
+	// in sessionID. Used by BFS-style queries that need to discover
+	// neighbouring sessions without paging through all events first
+	// (the link-bearing event may sit past any per-session limit).
+	LinksForSession(ctx context.Context, sessionID string) ([]*Link, error)
 	Close() error
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,47 +14,71 @@ function getInitialView(): View {
   return v === "graph" ? "graph" : "timeline";
 }
 
+function getInitialLinked(): boolean {
+  return new URLSearchParams(window.location.search).get("linked") === "1";
+}
+
 export default function App() {
   const [sessionId, setSessionId] = useState<string>(getInitialSession);
   const [view, setView] = useState<View>(getInitialView);
+  const [linked, setLinked] = useState<boolean>(getInitialLinked);
 
   // Browser back/forward replays whatever URL was last pushed; mirror
-  // it back into component state for both session and view.
+  // it back into component state.
   useEffect(() => {
     const onPop = () => {
       setSessionId(getInitialSession());
       setView(getInitialView());
+      setLinked(getInitialLinked());
     };
     window.addEventListener("popstate", onPop);
     return () => window.removeEventListener("popstate", onPop);
   }, []);
 
-  // pushState (not replaceState) so each list↔timeline↔graph transition
-  // gets its own history entry — otherwise back skips out of the app.
-  const navigate = (nextSession: string, nextView: View = "timeline") => {
-    if (nextSession === sessionId && nextView === view) return;
+  // pushState so each list↔timeline↔graph(↔linked) transition gets its
+  // own history entry — otherwise back skips out of the app entirely.
+  const navigate = (
+    nextSession: string,
+    nextView: View = "timeline",
+    nextLinked: boolean = false,
+  ) => {
+    if (
+      nextSession === sessionId &&
+      nextView === view &&
+      nextLinked === linked
+    ) {
+      return;
+    }
     const params = new URLSearchParams(window.location.search);
     if (nextSession) params.set("session", nextSession);
     else params.delete("session");
     if (nextSession && nextView !== "timeline") params.set("view", nextView);
     else params.delete("view");
+    // `linked` only meaningful in graph view.
+    if (nextSession && nextView === "graph" && nextLinked) {
+      params.set("linked", "1");
+    } else {
+      params.delete("linked");
+    }
     const qs = params.toString();
     const url = `${window.location.pathname}${qs ? `?${qs}` : ""}`;
     window.history.pushState(null, "", url);
     setSessionId(nextSession);
     setView(nextView);
+    setLinked(nextLinked);
   };
 
   const subtitle = sessionId
     ? view === "graph"
-      ? "M2 causal graph"
+      ? linked
+        ? "M2 cross-session graph"
+        : "M2 causal graph"
       : "M1 timeline"
     : "M2 sessions";
 
   // Graph view needs more horizontal room (dagre lays a wide DAG; the
-  // minimap also looks cramped at 4xl). Timeline and SessionList were
-  // designed for 4xl and look stretched at wider widths, so the
-  // wrapper width is per-view.
+  // minimap also looks cramped at 4xl). Timeline and SessionList stay
+  // at 4xl, where they were designed.
   const wrapperMaxW = sessionId && view === "graph" ? "max-w-6xl" : "max-w-4xl";
 
   return (
@@ -73,9 +97,20 @@ export default function App() {
           </div>
           {sessionId && (
             <div className="flex items-center gap-4">
+              {view === "graph" && (
+                <label className="flex items-center gap-1.5 text-xs text-zinc-700 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={linked}
+                    onChange={(e) => navigate(sessionId, "graph", e.target.checked)}
+                    className="h-3.5 w-3.5 rounded border-zinc-300 accent-purple-600"
+                  />
+                  <span>Include linked sessions</span>
+                </label>
+              )}
               <ViewToggle
                 view={view}
-                onSelect={(v) => navigate(sessionId, v)}
+                onSelect={(v) => navigate(sessionId, v, v === "graph" ? linked : false)}
               />
               <button
                 type="button"
@@ -91,7 +126,7 @@ export default function App() {
       <main className={`mx-auto ${wrapperMaxW} px-6 py-6`}>
         {sessionId ? (
           view === "graph" ? (
-            <CausalGraph sessionId={sessionId} />
+            <CausalGraph sessionId={sessionId} linked={linked} />
           ) : (
             <Timeline sessionId={sessionId} />
           )

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -53,3 +53,25 @@ export const eventsQuery = `
     sessionHead(sessionId: $sessionId)
   }
 `;
+
+// linkedEventsQuery returns events from sessionId plus events from
+// every session reachable via the linker's emitted links, up to depth
+// hops. Used by the cross-session causal graph view.
+export const linkedEventsQuery = `
+  query LinkedEvents($sessionId: String!, $depth: Int, $perSessionLimit: Int) {
+    linkedEvents(sessionId: $sessionId, depth: $depth, perSessionLimit: $perSessionLimit) {
+      id
+      ts
+      sessionId
+      turnId
+      actor { type id model }
+      kind
+      payload
+      parents
+      refs
+      hash
+      prevHash
+      links { fromEvent toEvent relation inferredBy }
+    }
+  }
+`;

--- a/web/src/components/CausalGraph.tsx
+++ b/web/src/components/CausalGraph.tsx
@@ -13,8 +13,13 @@ import ReactFlow, {
 import "reactflow/dist/style.css";
 import dagre from "@dagrejs/dagre";
 
-import { gql, eventsQuery } from "../api/client";
-import type { Event, EventKind, EventsResponse } from "../types";
+import { gql, eventsQuery, linkedEventsQuery } from "../api/client";
+import type {
+  Event,
+  EventKind,
+  EventsResponse,
+  LinkedEventsResponse,
+} from "../types";
 import { styleFor } from "./kindStyle";
 
 // Hex colors mirroring the Tailwind 500-shade in kindStyle.ts. The
@@ -39,9 +44,7 @@ const MINIMAP_HEX: Record<EventKind, string> = {
 const NODE_W = 180;
 const NODE_H = 56;
 
-// Build the dagre layout for one session's worth of events. Returns a
-// position map keyed by event id (top-left corner, since ReactFlow
-// expects top-left while dagre returns center).
+// Build the dagre layout for one or more sessions' worth of events.
 function layoutPositions(
   events: Event[],
   edges: Array<{ source: string; target: string }>,
@@ -66,17 +69,31 @@ function layoutPositions(
   return out;
 }
 
-function buildGraph(events: Event[]): { nodes: Node[]; edges: Edge[] } {
+function shortenSessionId(sid: string): string {
+  if (sid.length <= 14) return sid;
+  // Anchor on the head ("git-…", "github-pr:…") or the tail (UUID).
+  if (sid.includes(":") || sid.startsWith("git-") || sid.startsWith("github-")) {
+    return sid.length > 22 ? sid.slice(0, 22) + "…" : sid;
+  }
+  return sid.slice(0, 8) + "…" + sid.slice(-4);
+}
+
+function buildGraph(
+  events: Event[],
+  anchorSessionID: string,
+): { nodes: Node[]; edges: Edge[] } {
   const hashToId: Record<string, string> = {};
+  const eventById: Record<string, Event> = {};
   for (const e of events) {
     if (e.hash) hashToId[e.hash] = e.id;
+    eventById[e.id] = e;
   }
 
   const edges: Edge[] = [];
   const seenLinkIds = new Set<string>();
 
   for (const e of events) {
-    // Explicit causal parents — the strongest semantic edge.
+    // Explicit causal parents — strongest semantic edge.
     for (const p of e.parents) {
       edges.push({
         id: `parent:${p}->${e.id}`,
@@ -87,9 +104,7 @@ function buildGraph(events: Event[]): { nodes: Node[]; edges: Edge[] } {
         style: { stroke: "#1f2937", strokeWidth: 2 },
       });
     }
-    // Hash chain — structural, not causal. Render lightly so it doesn't
-    // dominate. Skip if the predecessor isn't in the rendered set
-    // (graceful when limit truncates the head of the chain).
+    // Hash chain — structural; only render when both endpoints rendered.
     if (e.prevHash && hashToId[e.prevHash]) {
       edges.push({
         id: `chain:${e.id}`,
@@ -100,25 +115,39 @@ function buildGraph(events: Event[]): { nodes: Node[]; edges: Edge[] } {
         style: { stroke: "#9ca3af", strokeWidth: 1, strokeDasharray: "4 3" },
       });
     }
-    // Linker-inferred edges. event.links includes both inbound and
-    // outbound, so we'd see each edge twice if we didn't dedupe by a
-    // canonical key.
+    // Linker-inferred edges. event.links surfaces both inbound and
+    // outbound, so dedupe by canonical key. Cross-session links get
+    // emphasised because they're the whole point of this view.
     for (const l of e.links) {
       const key = `link:${l.fromEvent}->${l.toEvent}:${l.relation}`;
       if (seenLinkIds.has(key)) continue;
       seenLinkIds.add(key);
+      const fromEv = eventById[l.fromEvent];
+      const toEv = eventById[l.toEvent];
+      const isCrossSession =
+        fromEv && toEv && fromEv.sessionId !== toEv.sessionId;
       edges.push({
         id: key,
         source: l.fromEvent,
         target: l.toEvent,
         type: "smoothstep",
         label: l.relation,
-        labelStyle: { fontSize: 10, fill: "#4f46e5" },
+        labelStyle: {
+          fontSize: 10,
+          fill: isCrossSession ? "#9333ea" : "#4f46e5",
+          fontWeight: isCrossSession ? 600 : 400,
+        },
         labelBgPadding: [4, 2],
         labelBgBorderRadius: 4,
-        labelBgStyle: { fill: "#eef2ff" },
-        markerEnd: { type: MarkerType.Arrow, color: "#6366f1" },
-        style: { stroke: "#6366f1", strokeWidth: 1.5 },
+        labelBgStyle: { fill: isCrossSession ? "#f3e8ff" : "#eef2ff" },
+        markerEnd: {
+          type: MarkerType.Arrow,
+          color: isCrossSession ? "#9333ea" : "#6366f1",
+        },
+        style: {
+          stroke: isCrossSession ? "#9333ea" : "#6366f1",
+          strokeWidth: isCrossSession ? 2 : 1.5,
+        },
       });
     }
   }
@@ -128,20 +157,27 @@ function buildGraph(events: Event[]): { nodes: Node[]; edges: Edge[] } {
   const nodes: Node[] = events.map((e) => {
     const s = styleFor(e.kind);
     const idTail = e.id.length > 12 ? e.id.slice(-12) : e.id;
+    const isAnchor = e.sessionId === anchorSessionID;
     return {
       id: e.id,
       position: positions[e.id] ?? { x: 0, y: 0 },
-      // kind is plumbed into data so MiniMap can color minimap nodes
-      // by the same palette without re-deriving from the JSX label.
       data: {
         kind: e.kind,
         label: (
-          <div className={`flex h-full w-full flex-col gap-0.5 rounded border ${s.container} px-2 py-1`}>
+          <div
+            className={`flex h-full w-full flex-col gap-0.5 rounded border ${s.container} px-2 py-1 ${
+              isAnchor ? "" : "ring-2 ring-purple-300 ring-offset-1"
+            }`}
+          >
             <div className="flex items-center gap-1 text-[10px]">
               <span aria-hidden>{s.icon}</span>
-              <span className="font-medium uppercase tracking-wide">{s.label}</span>
+              <span className="font-medium uppercase tracking-wide">
+                {s.label}
+              </span>
             </div>
-            <div className="truncate font-mono text-[9px] text-zinc-500">{idTail}</div>
+            <div className="truncate font-mono text-[9px] text-zinc-500">
+              {isAnchor ? idTail : shortenSessionId(e.sessionId)}
+            </div>
           </div>
         ),
       },
@@ -159,10 +195,9 @@ function buildGraph(events: Event[]): { nodes: Node[]; edges: Edge[] } {
 }
 
 // Inner canvas — must live under <ReactFlowProvider> so useReactFlow()
-// can read/write the viewport. We use this primarily so MiniMap onClick
-// can pan the main canvas: pannable / zoomable on MiniMap depend on a
-// d3-zoom binding that has been observed to misfire under React 18
-// StrictMode, so onClick → setCenter is the reliable navigation path.
+// can read/write the viewport. MiniMap onClick → setCenter for
+// reliable navigation under React 18 StrictMode (d3-zoom path is
+// flaky there).
 function GraphCanvas({ nodes, edges }: { nodes: Node[]; edges: Edge[] }) {
   const flow = useReactFlow();
   const onMiniMapClick = useCallback(
@@ -200,20 +235,43 @@ function GraphCanvas({ nodes, edges }: { nodes: Node[]; edges: Edge[] }) {
   );
 }
 
-export function CausalGraph({ sessionId }: { sessionId: string }) {
-  // Same queryKey as Timeline: react-query dedupes the fetch and both
-  // views share the cache, so toggling Timeline ↔ Graph never re-fetches.
+export function CausalGraph({
+  sessionId,
+  linked,
+}: {
+  sessionId: string;
+  linked: boolean;
+}) {
+  // The two queries share queryKey so React Query treats them as the
+  // same cache cell. Switching the toggle invalidates and refetches
+  // because we change queryFn under the same key — but for v1 we
+  // accept that (a single `events` query that always returned cross-
+  // session is server-side-cheaper but loses the "single-session
+  // anchor" semantic the URL conveys).
   const { data, error, isLoading } = useQuery({
-    queryKey: ["events", sessionId],
-    queryFn: () => gql<EventsResponse>(eventsQuery, { sessionId, limit: 200 }),
+    queryKey: linked ? ["linkedEvents", sessionId] : ["events", sessionId],
+    queryFn: () =>
+      linked
+        ? gql<LinkedEventsResponse>(linkedEventsQuery, {
+            sessionId,
+            depth: 1,
+            perSessionLimit: 200,
+          }).then((d): Event[] => d.linkedEvents)
+        : gql<EventsResponse>(eventsQuery, { sessionId, limit: 200 }).then(
+            (d): Event[] => d.events,
+          ),
     enabled: sessionId.length > 0,
     refetchInterval: 2000,
   });
 
   const graph = useMemo(() => {
-    if (!data?.events?.length) return { nodes: [], edges: [] };
-    return buildGraph(data.events);
-  }, [data]);
+    if (!data?.length) return { nodes: [], edges: [], crossSessionCount: 0 };
+    const built = buildGraph(data, sessionId);
+    const crossSessionCount = data.filter(
+      (e) => e.sessionId !== sessionId,
+    ).length;
+    return { ...built, crossSessionCount };
+  }, [data, sessionId]);
 
   if (isLoading) return <div className="text-sm text-zinc-500">Loading…</div>;
   if (error) {
@@ -234,10 +292,27 @@ export function CausalGraph({ sessionId }: { sessionId: string }) {
   }
 
   return (
-    <div className="h-[calc(100vh-180px)] overflow-hidden rounded border border-zinc-200 bg-white">
-      <ReactFlowProvider>
-        <GraphCanvas nodes={graph.nodes} edges={graph.edges} />
-      </ReactFlowProvider>
+    <div>
+      {linked && (
+        <div className="mb-2 text-xs text-zinc-600">
+          Showing {data.length} events across linked sessions
+          {graph.crossSessionCount > 0 && (
+            <>
+              {" "}
+              ·{" "}
+              <span className="font-medium text-purple-700">
+                {graph.crossSessionCount} from neighbouring sessions
+              </span>
+            </>
+          )}
+          .
+        </div>
+      )}
+      <div className="h-[calc(100vh-200px)] overflow-hidden rounded border border-zinc-200 bg-white">
+        <ReactFlowProvider>
+          <GraphCanvas nodes={graph.nodes} edges={graph.edges} />
+        </ReactFlowProvider>
+      </div>
     </div>
   );
 }

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -49,6 +49,10 @@ export type EventsResponse = {
   sessionHead: string;
 };
 
+export type LinkedEventsResponse = {
+  linkedEvents: Event[];
+};
+
 export type Session = {
   id: string;
   firstEventAt: string;


### PR DESCRIPTION
Closes #50.

Phase B of the cross-session graph work. Phase A (#48 / #49) shipped the linker glue that makes cross-session links exist in the dogfood; this PR ships the UI to render them. With both halves landed, the audit chain is **navigable end-to-end** for the first time — open the live dogfood graph and see Claude session ↔ git session crossing.

## Summary

- **Backend**: new \`linkedEvents(sessionId, depth, perSessionLimit)\` GraphQL query. BFS by session id from the seed, expanding via linker-emitted links up to \`depth\` hops (clamped to [0, 3] server-side).
- **Critical design point**: link discovery uses a new \`Store.LinksForSession\` helper (SQL filtered by event session) rather than walking links per fetched event. Walking per-event would cap discovery at \`perSessionLimit\`, silently missing links that sit on events past that cap. That's exactly what the live dogfood hit on first try — the link-bearing TOOL_RESULT was past row 900 of a 1000-event session, and 200-cap reads couldn't see the link.
- **Frontend**: \`CausalGraph\` accepts a \`linked\` prop. When on, fetches via \`linkedEvents\` and visually distinguishes:
  - Anchor session nodes: unchanged.
  - Non-anchor nodes: 2px purple ring; truncated session id shown in the node body where the event id was.
  - Cross-session edges (linker relations crossing session boundaries): bold purple stroke + label highlight.
- **URL**: new \`?linked=1\` param, only meaningful in graph view. Toggle pushes a new history entry, so back/forward traverses the new dimension cleanly.

## Tests

- \`TestLinkedEventsResolver\` — depth=0 collapses to single-session; depth=1 picks up the linked peer; out-of-range depth=99 is clamped to 3.
- \`TestLinkedEventsResolver_LinkPastLimit\` — regression that drove the \`LinksForSession\` switch: 100 leading no-link events with the link-bearing event past perSessionLimit=10. Confirms the peer session is still surfaced.

## E2E (live dogfood)

\`\`\`
$ curl -s -X POST localhost:5173/v1/graphql --data-raw '{"query":"{ linkedEvents(sessionId:\"c3e32521-...\", depth:1, perSessionLimit:10) { sessionId } }"}'

total events: 20
  c3e32521-b0c5-49b0-a218-d7995acb9ac: 10
  git-86e23e121dffc093: 10
\`\`\`

Cross-session discovery flows correctly through Vite proxy → collector → PG-backed store.

## Out of scope (parked, see #50)

- Depth > 1.
- Per-session show/hide inside the canvas.
- Manual session pinning.
- Heuristic linking beyond shared refs (SPEC §15 R2).

## Visual checklist

- [ ] \`http://localhost:5173/?session=c3e32521-...&view=graph&linked=1\` renders both \`c3e32521…\` and \`git-86e23e1…\` events with a labelled cross-session edge between the linked TOOL_RESULT and \`commit\` events.
- [ ] Non-anchor session nodes show purple ring + truncated session id label.
- [ ] Toggling the checkbox off returns to the single-session view.
- [ ] \`pnpm exec tsc --noEmit\` clean (verified pre-PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)