### PR TITLE
feat(linking): refine link relations per SPEC §7 vocabulary

### DIFF
--- a/internal/linking/linker.go
+++ b/internal/linking/linker.go
@@ -20,10 +20,10 @@ import (
 	"github.com/dongqiu/agent-lens/internal/store"
 )
 
-// DefaultRelation is the relation written for all v0 shared-ref links.
-// Refinement (commit→pr "produces", commit→build "builds", etc.)
-// belongs in M3.
-const DefaultRelation = "references"
+// DefaultRelation is the fallback when InferRelation has no specific
+// rule for the (kindA, kindB) pair. SPEC §7 vocabulary lives in
+// relation.go; the linker calls InferRelation per link.
+const DefaultRelation = RelationReferences
 
 // Linker is started once by the main process. Notify is safe to call
 // from any goroutine; Run owns the worker loop and exits on context
@@ -35,6 +35,7 @@ type Linker struct {
 
 type job struct {
 	eventID string
+	kind    string // event kind, used to refine the link's relation
 	refs    []string
 }
 
@@ -57,7 +58,7 @@ func (l *Linker) Notify(ev *ingest.WireEvent) {
 	if ev == nil || ev.ID == "" || len(ev.Refs) == 0 {
 		return
 	}
-	j := job{eventID: ev.ID, refs: append([]string(nil), ev.Refs...)}
+	j := job{eventID: ev.ID, kind: ev.Kind, refs: append([]string(nil), ev.Refs...)}
 	select {
 	case l.queue <- j:
 	default:
@@ -103,7 +104,7 @@ func (l *Linker) process(ctx context.Context, j job) error {
 			link := &store.Link{
 				FromEvent:  peer.ID,
 				ToEvent:    j.eventID,
-				Relation:   DefaultRelation,
+				Relation:   InferRelation(peer.Kind, j.kind),
 				Confidence: 1.0,
 				InferredBy: "shared_ref:" + ref,
 			}
@@ -125,5 +126,5 @@ func (l *Linker) ProcessOnce(ctx context.Context, ev *ingest.WireEvent) error {
 	if ev == nil || ev.ID == "" || len(ev.Refs) == 0 {
 		return nil
 	}
-	return l.process(ctx, job{eventID: ev.ID, refs: ev.Refs})
+	return l.process(ctx, job{eventID: ev.ID, kind: ev.Kind, refs: ev.Refs})
 }

--- a/internal/linking/linker_test.go
+++ b/internal/linking/linker_test.go
@@ -228,3 +228,61 @@ func (f *flakyAppendStore) AppendLink(ctx context.Context, l *store.Link) error 
 	}
 	return f.Memory.AppendLink(ctx, l)
 }
+
+// TestProcessOnceRefinedRelation verifies that the linker emits a
+// SPEC §7 relation more specific than "references" when the kind
+// pair is recognised. Phase A's tool_result + commit case is the
+// most operationally important — that's what shows up in the live
+// dogfood whenever the agent runs `git commit`.
+func TestProcessOnceRefinedRelation(t *testing.T) {
+	cases := []struct {
+		name                  string
+		peerKind, newKind     string
+		wantRelation          string
+	}{
+		{"agent tool_result + commit → produces", "tool_result", "commit", RelationProduces},
+		{"commit + build → builds", "commit", "build", RelationBuilds},
+		{"commit + deploy → deploys", "commit", "deploy", RelationDeploys},
+		{"commit + review → reviews", "commit", "review", RelationReviews},
+		{"unknown pair falls back to references", "prompt", "thought", RelationReferences},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := store.NewMemory()
+			l := New(st, 0)
+			ctx := context.Background()
+
+			peer := &store.Event{
+				ID: "peer-" + tc.peerKind, TS: time.Now().UTC(),
+				SessionID: "s-peer", ActorType: "agent", ActorID: "claude-code",
+				Kind: tc.peerKind, Hash: "h-peer", Refs: []string{"git:abc"},
+			}
+			if err := st.AppendEvent(ctx, peer); err != nil {
+				t.Fatal(err)
+			}
+			newID := "new-" + tc.newKind
+			newEv := &store.Event{
+				ID: newID, TS: time.Now().UTC(),
+				SessionID: "s-new", ActorType: "human", ActorID: "alice",
+				Kind: tc.newKind, Hash: "h-new", Refs: []string{"git:abc"},
+			}
+			if err := st.AppendEvent(ctx, newEv); err != nil {
+				t.Fatal(err)
+			}
+			// The job carries the new event's kind so InferRelation has
+			// both kinds without an extra GetEvent.
+			if err := l.ProcessOnce(ctx, &ingest.WireEvent{
+				ID: newID, Kind: tc.newKind, Refs: []string{"git:abc"},
+			}); err != nil {
+				t.Fatalf("ProcessOnce: %v", err)
+			}
+			links, _ := st.LinksForEvent(ctx, newID)
+			if len(links) != 1 {
+				t.Fatalf("got %d links, want 1", len(links))
+			}
+			if links[0].Relation != tc.wantRelation {
+				t.Errorf("relation = %q, want %q", links[0].Relation, tc.wantRelation)
+			}
+		})
+	}
+}

--- a/internal/linking/relation.go
+++ b/internal/linking/relation.go
@@ -1,0 +1,55 @@
+package linking
+
+import "strings"
+
+// SPEC §7 vocabulary. The linker emits exactly one of these per link.
+const (
+	RelationProduces   = "produces"
+	RelationBuilds     = "builds"
+	RelationDeploys    = "deploys"
+	RelationReviews    = "reviews"
+	RelationReferences = "references" // neutral fallback
+)
+
+// InferRelation maps a (kindA, kindB) pair to a SPEC §7 relation. The
+// match is symmetric on the args — order doesn't matter — so the linker
+// can call it with either (peer.Kind, new.Kind) ordering and get the
+// same answer.
+//
+// Direction in the (FromEvent, ToEvent) tuple is currently arrival
+// order, which usually aligns with semantic direction (the agent action
+// arrives before its commit, the commit arrives before its build) but
+// isn't guaranteed under hook timing skew. The relation label
+// identifies the relationship *type* regardless; flipping From/To is a
+// follow-up if audit reports demand strict directional semantics.
+//
+// Fallback is `references` — a link whose pair we don't yet recognise
+// is still informative as "these two events share an artifact".
+func InferRelation(a, b string) string {
+	a = strings.ToLower(a)
+	b = strings.ToLower(b)
+	pair := func(x, y string) bool {
+		return (a == x && b == y) || (a == y && b == x)
+	}
+
+	// Any agent-side event paired with a commit event = the agent
+	// action `produces` the commit. Phase A's git-commit linking
+	// surfaces this exact case via shared `git:<sha>` ref.
+	for _, agent := range []string{"prompt", "thought", "tool_call", "tool_result", "decision"} {
+		if pair(agent, "commit") {
+			return RelationProduces
+		}
+	}
+
+	switch {
+	case pair("commit", "pr"):
+		return RelationProduces
+	case pair("commit", "build"):
+		return RelationBuilds
+	case pair("commit", "deploy"):
+		return RelationDeploys
+	case pair("commit", "review"):
+		return RelationReviews
+	}
+	return RelationReferences
+}

--- a/internal/linking/relation_test.go
+++ b/internal/linking/relation_test.go
@@ -1,0 +1,45 @@
+package linking
+
+import "testing"
+
+func TestInferRelation(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want string
+	}{
+		// Agent-side ↔ commit → produces. Symmetric on argument order.
+		{"tool_result", "commit", RelationProduces},
+		{"commit", "tool_result", RelationProduces},
+		{"tool_call", "commit", RelationProduces},
+		{"prompt", "commit", RelationProduces},
+		{"thought", "commit", RelationProduces},
+		{"decision", "commit", RelationProduces},
+		// Commit ↔ PR → produces (commit content ends up in the PR).
+		{"commit", "pr", RelationProduces},
+		{"pr", "commit", RelationProduces},
+		// Commit ↔ build → builds.
+		{"commit", "build", RelationBuilds},
+		{"build", "commit", RelationBuilds},
+		// Commit ↔ deploy → deploys.
+		{"commit", "deploy", RelationDeploys},
+		{"deploy", "commit", RelationDeploys},
+		// Commit ↔ review → reviews.
+		{"commit", "review", RelationReviews},
+		{"review", "commit", RelationReviews},
+		// Mixed case input — InferRelation lowercases internally.
+		{"COMMIT", "Tool_Result", RelationProduces},
+		// Pairs with no specific rule fall back to references.
+		{"push", "commit", RelationReferences},
+		{"pr", "review", RelationReferences},
+		{"build", "deploy", RelationReferences},
+		{"prompt", "thought", RelationReferences},
+		{"", "", RelationReferences},
+		{"unknown_kind", "commit", RelationReferences},
+	}
+	for _, c := range cases {
+		got := InferRelation(c.a, c.b)
+		if got != c.want {
+			t.Errorf("InferRelation(%q, %q) = %q, want %q", c.a, c.b, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
The linker has been emitting \`references\` for every shared-ref link since v0. SPEC §7's relation vocabulary (\`produces | references | reviews | builds | deploys\`) was carried but unused — \`linker.go\` even called this out as M3 work that never landed. After Phase B (#51) shipped cross-session edges with all-\`references\` labels, the audit chain visually loses the distinction between *what kind* of relationship two events have. This PR fills that in.

## Summary

- \`InferRelation(kindA, kindB) → relation\` in \`internal/linking/relation.go\`. Symmetric on argument order so the linker can call it with either (peer.Kind, new.Kind) ordering.
- Mapping for the audit-relevant pairs:

  | pair | relation |
  |---|---|
  | agent action (prompt / thought / tool_call / tool_result / decision) + commit | \`produces\` |
  | commit + pr | \`produces\` |
  | commit + build | \`builds\` |
  | commit + deploy | \`deploys\` |
  | commit + review | \`reviews\` |
  | anything else | \`references\` (fallback) |

- \`job.kind\` plumbed through \`Notify\` / \`ProcessOnce\` so \`process()\` has the new event's kind without an extra \`GetEvent\`.
- \`DefaultRelation\` retained as the fallback constant; existing tests still pass because their fixture is two \`prompt\`-kind events, which falls through to \`references\`.

## E2E (live dogfood)

\`\`\`
$ # before this PR's commit
$ SELECT relation, COUNT(*) FROM links GROUP BY relation;
references | 4

$ # after this PR's commit (922930d)
$ SELECT relation, COUNT(*) FROM links GROUP BY relation;
produces   | 1
references | 4

$ # the new produces link traces this exact commit
$ SELECT inferred_by FROM links WHERE relation='produces' LIMIT 1;
shared_ref:git:922930d2821e8fabda5decf2d1156ada991f9468
\`\`\`

The Phase A path (Claude Bash \`git commit\` TOOL_RESULT ↔ post-commit hook COMMIT) now emits \`produces\` instead of \`references\`. Existing 4 \`references\` links stay because the (from_event, to_event, relation) PK doesn't auto-update; only new commits are affected from this point forward.

## Tests

- \`relation_test.go\` — every documented pair, both argument orders, mixed-case, unknown pairs falling back to \`references\` (20 cases).
- \`linker_test.go\` — \`TestProcessOnceRefinedRelation\` runs each audit-relevant pair end-to-end through the linker's process loop. Existing \`TestProcessOnceLinksSharedRef\` still passes (Kind=prompt fixture → fallback \`references\` = DefaultRelation).

## Out of scope (parked)

- **Direction**: (from, to) is still arrival order, not always semantic causality. Usually aligns; not guaranteed under hook-timing skew. Strict directional flip is a follow-up if audit reports demand it.
- **Backfill scan**: existing \`references\` links from before this PR keep their old label. A periodic re-linking scan would update them — \`linker.go\` already comments on backfill as a follow-up. With backfill, the \`(from, to, relation)\` PK means a refined relation would coexist alongside the old \`references\` link rather than replace it; the policy ("update vs allow duplicates") is a small ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)