### PR TITLE
fix(query,web): chain-context for link-bearers + Timeline/Graph cache shape parity

### DIFF
--- a/internal/query/router_test.go
+++ b/internal/query/router_test.go
@@ -530,21 +530,19 @@ func TestLinkedEventsResolver_LinkBearerPastLimit_PatchedIn(t *testing.T) {
 	}
 }
 
-// TestLinkedEventsResolver_SeedSessionUnbounded is the regression for
-// the visual silent-degradation: when the link-bearing event in the
-// SEED session sits past perSessionLimit, the link-bearer itself is
-// patched in (covered by TestLinkedEventsResolver_LinkBearerPastLimit_PatchedIn)
-// but its chain neighbours (the matching TOOL_CALL one row earlier,
-// the next agent action one row later) aren't. The result is a
-// patched-in event with no rendered prev_hash predecessor → the
-// dashed chain edge has source=non-rendered → ReactFlow silently
-// drops it. Visually the link-bearer floats next to the peer's
+// TestLinkedEventsResolver_BearerChainContext is the regression for
+// the visual silent-degradation reported by the user: when the
+// link-bearing event in any session sits past perSessionLimit, the
+// bearer is patched in but its chain ancestors aren't, so the dashed
+// prev_hash edge into the bearer has source=non-rendered and
+// ReactFlow silently drops it — the bearer floats next to the peer
 // COMMIT with no chain connection back.
 //
-// Fix: seed session ignores perSessionLimit. The user explicitly
-// opened this session to investigate; the full chain is the audit
-// story.
-func TestLinkedEventsResolver_SeedSessionUnbounded(t *testing.T) {
+// Fix: for each patched-in bearer, also pull a small chain-context
+// window of predecessors via Store.EventsBeforeID. Seed session stays
+// bounded by perSessionLimit so the UI doesn't have to render
+// thousands of unrelated events when investigating a long session.
+func TestLinkedEventsResolver_BearerChainContext(t *testing.T) {
 	st := store.NewMemory()
 	ctx := context.Background()
 
@@ -612,8 +610,8 @@ func TestLinkedEventsResolver_SeedSessionUnbounded(t *testing.T) {
 
 	// Build hash → id map of returned events; the bearer's prev_hash
 	// must resolve to a rendered event so the dashed chain edge can
-	// land. With seed-unbounded all 51 anchor events come back; with
-	// seed capped at psl=10 only the first 10 come back and the
+	// land. With chain-context the bearer + its 10 predecessors are
+	// patched in; without it only first-psl events come back and the
 	// bearer's predecessor (h-anchor-049) is missing.
 	hashes := map[string]bool{}
 	var bearer *struct {
@@ -635,6 +633,13 @@ func TestLinkedEventsResolver_SeedSessionUnbounded(t *testing.T) {
 		t.Fatalf("e-anchor-bearer.prev_hash is null")
 	}
 	if !hashes[*bearer.PrevHash] {
-		t.Errorf("bearer's prev_hash %q is not in the rendered hash set; chain edge would be orphaned. Got %d events total — seed session should be unbounded so all 51 anchor events come back.", *bearer.PrevHash, len(got.Data.LinkedEvents))
+		t.Errorf("bearer's prev_hash %q is not in the rendered hash set; chain edge would be orphaned. Got %d events total — chain-context should pull predecessors via EventsBeforeID.", *bearer.PrevHash, len(got.Data.LinkedEvents))
+	}
+	// Sanity: total events should be bounded — chain context adds
+	// up to ~10 events per bearer, not the whole session. We have
+	// 51 anchor events; expect first-psl=10 + ~10 chain context +
+	// the bearer + 1 peer commit ≈ 22, NOT 52.
+	if len(got.Data.LinkedEvents) > 30 {
+		t.Errorf("expected chain-context to bound result (~22 events), got %d — looks like seed session was returned in full", len(got.Data.LinkedEvents))
 	}
 }

--- a/internal/query/router_test.go
+++ b/internal/query/router_test.go
@@ -529,3 +529,112 @@ func TestLinkedEventsResolver_LinkBearerPastLimit_PatchedIn(t *testing.T) {
 		t.Errorf("expected e-anchor-bearer (anchor's link-bearing event past perSessionLimit) to be patched into the result; got %d events: %v", len(got.Data.LinkedEvents), got.Data.LinkedEvents)
 	}
 }
+
+// TestLinkedEventsResolver_SeedSessionUnbounded is the regression for
+// the visual silent-degradation: when the link-bearing event in the
+// SEED session sits past perSessionLimit, the link-bearer itself is
+// patched in (covered by TestLinkedEventsResolver_LinkBearerPastLimit_PatchedIn)
+// but its chain neighbours (the matching TOOL_CALL one row earlier,
+// the next agent action one row later) aren't. The result is a
+// patched-in event with no rendered prev_hash predecessor → the
+// dashed chain edge has source=non-rendered → ReactFlow silently
+// drops it. Visually the link-bearer floats next to the peer's
+// COMMIT with no chain connection back.
+//
+// Fix: seed session ignores perSessionLimit. The user explicitly
+// opened this session to investigate; the full chain is the audit
+// story.
+func TestLinkedEventsResolver_SeedSessionUnbounded(t *testing.T) {
+	st := store.NewMemory()
+	ctx := context.Background()
+
+	// 50 anchor events, link-bearing TOOL_RESULT at index 50.
+	for i := 0; i < 50; i++ {
+		if err := st.AppendEvent(ctx, &store.Event{
+			ID: fmt.Sprintf("e-anchor-%03d", i), SessionID: "s-seed",
+			ActorType: "agent", ActorID: "claude-code",
+			Kind: "tool_call", Hash: fmt.Sprintf("h-anchor-%03d", i),
+			PrevHash: func() string {
+				if i == 0 {
+					return ""
+				}
+				return fmt.Sprintf("h-anchor-%03d", i-1)
+			}(),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := st.AppendEvent(ctx, &store.Event{
+		ID: "e-anchor-bearer", SessionID: "s-seed",
+		ActorType: "agent", ActorID: "claude-code",
+		Kind: "tool_result", Hash: "h-anchor-bearer",
+		PrevHash: "h-anchor-049",
+		Refs:     []string{"git:xyz"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AppendEvent(ctx, &store.Event{
+		ID: "e-peer-commit", SessionID: "s-peer",
+		ActorType: "human", ActorID: "alice",
+		Kind: "commit", Hash: "h-peer-commit", Refs: []string{"git:xyz"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := st.AppendLink(ctx, &store.Link{
+		FromEvent: "e-anchor-bearer", ToEvent: "e-peer-commit",
+		Relation: "produces", Confidence: 1.0, InferredBy: "shared_ref:git:xyz",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := httptest.NewServer(query.NewRouter(st))
+	defer srv.Close()
+
+	body := `{"query":"{ linkedEvents(sessionId:\"s-seed\", depth:1, perSessionLimit:10) { id sessionId hash prevHash } }"}`
+	resp, err := http.Post(srv.URL+"/graphql", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("post: %v", err)
+	}
+	defer resp.Body.Close()
+	var got struct {
+		Data struct {
+			LinkedEvents []struct {
+				ID        string  `json:"id"`
+				SessionID string  `json:"sessionId"`
+				Hash      string  `json:"hash"`
+				PrevHash  *string `json:"prevHash"`
+			} `json:"linkedEvents"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Build hash → id map of returned events; the bearer's prev_hash
+	// must resolve to a rendered event so the dashed chain edge can
+	// land. With seed-unbounded all 51 anchor events come back; with
+	// seed capped at psl=10 only the first 10 come back and the
+	// bearer's predecessor (h-anchor-049) is missing.
+	hashes := map[string]bool{}
+	var bearer *struct {
+		ID        string  `json:"id"`
+		SessionID string  `json:"sessionId"`
+		Hash      string  `json:"hash"`
+		PrevHash  *string `json:"prevHash"`
+	}
+	for i, e := range got.Data.LinkedEvents {
+		hashes[e.Hash] = true
+		if e.ID == "e-anchor-bearer" {
+			bearer = &got.Data.LinkedEvents[i]
+		}
+	}
+	if bearer == nil {
+		t.Fatalf("e-anchor-bearer not in result")
+	}
+	if bearer.PrevHash == nil {
+		t.Fatalf("e-anchor-bearer.prev_hash is null")
+	}
+	if !hashes[*bearer.PrevHash] {
+		t.Errorf("bearer's prev_hash %q is not in the rendered hash set; chain edge would be orphaned. Got %d events total — seed session should be unbounded so all 51 anchor events come back.", *bearer.PrevHash, len(got.Data.LinkedEvents))
+	}
+}

--- a/internal/query/schema.resolvers.go
+++ b/internal/query/schema.resolvers.go
@@ -121,21 +121,7 @@ func (r *queryResolver) LinkedEvents(ctx context.Context, sessionID string, dept
 	for level := 0; level <= d && len(frontier) > 0; level++ {
 		var nextFrontier []string
 		for _, sid := range frontier {
-			// Seed session ignores perSessionLimit. The user explicitly
-			// opened this session to investigate it; capping here means
-			// link-bearing events past psl are patched in (correct, see
-			// link-discovery comment below) but their chain neighbours
-			// aren't, so the prev_hash dashed line into the patched-in
-			// event has no source node and ReactFlow silently drops it
-			// — visually the link-bearer floats next to the peer's
-			// COMMIT with no chain connection back to the originating
-			// TOOL_CALL. Peer sessions still respect psl since they
-			// can be arbitrarily large and we don't need them whole.
-			limit := psl
-			if sid == sessionID {
-				limit = 0
-			}
-			evs, err := r.Store.ListBySession(ctx, sid, limit)
+			evs, err := r.Store.ListBySession(ctx, sid, psl)
 			if err != nil {
 				return nil, fmt.Errorf("ListBySession(%q): %w", sid, err)
 			}
@@ -169,10 +155,26 @@ func (r *queryResolver) LinkedEvents(ctx context.Context, sessionID string, dept
 					}
 					// Patch in this-session link endpoints that fell
 					// past psl, so cross-session edges always have
-					// both endpoints in the rendered set.
+					// both endpoints in the rendered set. Also fetch
+					// a small chain-context window before the bearer
+					// so the dashed prev_hash edge has a rendered
+					// source — without this the bearer floats with no
+					// chain connection back to the originating
+					// TOOL_CALL even though we successfully patched
+					// it in.
 					if other.SessionID == sid && !collectedIDs[other.ID] {
 						collectedIDs[other.ID] = true
 						collected = append(collected, other)
+						const chainContext = 10
+						preds, perr := r.Store.EventsBeforeID(ctx, sid, other.ID, chainContext)
+						if perr == nil {
+							for _, p := range preds {
+								if !collectedIDs[p.ID] {
+									collectedIDs[p.ID] = true
+									collected = append(collected, p)
+								}
+							}
+						}
 					}
 					if level < d && !visited[other.SessionID] {
 						visited[other.SessionID] = true

--- a/internal/query/schema.resolvers.go
+++ b/internal/query/schema.resolvers.go
@@ -121,7 +121,21 @@ func (r *queryResolver) LinkedEvents(ctx context.Context, sessionID string, dept
 	for level := 0; level <= d && len(frontier) > 0; level++ {
 		var nextFrontier []string
 		for _, sid := range frontier {
-			evs, err := r.Store.ListBySession(ctx, sid, psl)
+			// Seed session ignores perSessionLimit. The user explicitly
+			// opened this session to investigate it; capping here means
+			// link-bearing events past psl are patched in (correct, see
+			// link-discovery comment below) but their chain neighbours
+			// aren't, so the prev_hash dashed line into the patched-in
+			// event has no source node and ReactFlow silently drops it
+			// — visually the link-bearer floats next to the peer's
+			// COMMIT with no chain connection back to the originating
+			// TOOL_CALL. Peer sessions still respect psl since they
+			// can be arbitrarily large and we don't need them whole.
+			limit := psl
+			if sid == sessionID {
+				limit = 0
+			}
+			evs, err := r.Store.ListBySession(ctx, sid, limit)
 			if err != nil {
 				return nil, fmt.Errorf("ListBySession(%q): %w", sid, err)
 			}

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -89,6 +89,30 @@ func (m *Memory) HeadHash(_ context.Context, sessionID string) (string, error) {
 	return head, nil
 }
 
+func (m *Memory) EventsBeforeID(_ context.Context, sessionID, eventID string, limit int) ([]*Event, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	// m.events is in append order, which equals id-asc per ADR / store
+	// invariant. Walk it and collect everything in the same session
+	// with id < eventID. Tail-trim to `limit` so we keep the closest
+	// (largest id, i.e. most recent) ancestors.
+	var matched []*Event
+	for _, e := range m.events {
+		if e.SessionID != sessionID {
+			continue
+		}
+		if e.ID >= eventID {
+			continue
+		}
+		cp := *e
+		matched = append(matched, &cp)
+	}
+	if limit > 0 && len(matched) > limit {
+		matched = matched[len(matched)-limit:]
+	}
+	return matched, nil
+}
+
 func (m *Memory) ListSessions(_ context.Context, limit int, since time.Time) ([]*SessionSummary, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -103,6 +103,40 @@ func (p *Postgres) ListBySession(ctx context.Context, sessionID string, limit in
 	return out, rows.Err()
 }
 
+func (p *Postgres) EventsBeforeID(ctx context.Context, sessionID, eventID string, limit int) ([]*Event, error) {
+	if limit <= 0 {
+		limit = 1<<31 - 1
+	}
+	// Get the K closest predecessors (largest id < eventID), then
+	// reverse to id-asc so the caller can append into a chain in
+	// natural order.
+	const q = `
+		WITH window_events AS (
+			SELECT id, ts, session_id, turn_id, actor_type, actor_id, actor_model,
+			       kind, payload, parents, refs, hash, prev_hash, sig
+			FROM events
+			WHERE session_id = $1 AND id < $2
+			ORDER BY id DESC
+			LIMIT $3
+		)
+		SELECT * FROM window_events ORDER BY id ASC
+	`
+	rows, err := p.pool.Query(ctx, q, sessionID, eventID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []*Event
+	for rows.Next() {
+		e, err := scanEvent(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, e)
+	}
+	return out, rows.Err()
+}
+
 func (p *Postgres) HeadHash(ctx context.Context, sessionID string) (string, error) {
 	// "Latest" = last-inserted, identified by max id (ULIDs are monotonic
 	// at insert). ts is hook wall-clock and can be skewed across concurrent

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -67,6 +67,11 @@ type Store interface {
 	AppendEvent(ctx context.Context, e *Event) error
 	GetEvent(ctx context.Context, id string) (*Event, error)
 	ListBySession(ctx context.Context, sessionID string, limit int) ([]*Event, error)
+	// EventsBeforeID returns events from sessionID with id strictly less
+	// than eventID, ordered by id ASC, capped at limit. Used to fetch
+	// chain-context windows around link-bearing events that fell past
+	// the per-session limit.
+	EventsBeforeID(ctx context.Context, sessionID, eventID string, limit int) ([]*Event, error)
 	HeadHash(ctx context.Context, sessionID string) (string, error)
 	EventsByRef(ctx context.Context, ref string) ([]*Event, error)
 	// ListSessions returns session summaries ordered by LastEventAt DESC.

--- a/web/src/components/CausalGraph.tsx
+++ b/web/src/components/CausalGraph.tsx
@@ -242,36 +242,52 @@ export function CausalGraph({
   sessionId: string;
   linked: boolean;
 }) {
-  // The two queries share queryKey so React Query treats them as the
-  // same cache cell. Switching the toggle invalidates and refetches
-  // because we change queryFn under the same key — but for v1 we
-  // accept that (a single `events` query that always returned cross-
-  // session is server-side-cheaper but loses the "single-session
-  // anchor" semantic the URL conveys).
-  const { data, error, isLoading } = useQuery({
+  // CRITICAL: this hook MUST share its queryKey + queryFn shape with
+  // the Timeline view's hook so the react-query cache is consistent.
+  // Earlier we transformed via `.then((d) => d.events)` here, which
+  // wrote the un-transformed EventsResponse object into the cache
+  // (react-query keys on queryKey, not on what queryFn returns post-
+  // transform). Timeline reads the EventsResponse fine; this graph
+  // hook then read it back as `Event[]` and `for…of` threw on the
+  // object, blanking the React tree.
+  const { data, error, isLoading } = useQuery<
+    EventsResponse | LinkedEventsResponse
+  >({
     queryKey: linked ? ["linkedEvents", sessionId] : ["events", sessionId],
-    queryFn: () =>
-      linked
-        ? gql<LinkedEventsResponse>(linkedEventsQuery, {
+    queryFn: linked
+      ? () =>
+          gql<LinkedEventsResponse>(linkedEventsQuery, {
             sessionId,
             depth: 1,
             perSessionLimit: 200,
-          }).then((d): Event[] => d.linkedEvents)
-        : gql<EventsResponse>(eventsQuery, { sessionId, limit: 200 }).then(
-            (d): Event[] => d.events,
-          ),
+          })
+      : () => gql<EventsResponse>(eventsQuery, { sessionId, limit: 200 }),
     enabled: sessionId.length > 0,
-    refetchInterval: 2000,
+    // Audit / graph view doesn't need 2s polling like Timeline — every
+    // refetch reruns the dagre layout (O(N) on 200-300 nodes) which
+    // blocks the main thread enough to make Graph→Timeline toggling
+    // feel sticky. 15s is a reasonable freshness for an "investigate
+    // what already happened" view.
+    refetchInterval: 15_000,
   });
 
+  // Unify the two response shapes into a single Event[] for downstream
+  // graph building. Both Timeline and CausalGraph populate the same
+  // cache cell, so this stays consistent across view toggles.
+  const events: Event[] = useMemo(() => {
+    if (!data) return [];
+    if ("linkedEvents" in data) return data.linkedEvents;
+    return data.events;
+  }, [data]);
+
   const graph = useMemo(() => {
-    if (!data?.length) return { nodes: [], edges: [], crossSessionCount: 0 };
-    const built = buildGraph(data, sessionId);
-    const crossSessionCount = data.filter(
+    if (!events.length) return { nodes: [], edges: [], crossSessionCount: 0 };
+    const built = buildGraph(events, sessionId);
+    const crossSessionCount = events.filter(
       (e) => e.sessionId !== sessionId,
     ).length;
     return { ...built, crossSessionCount };
-  }, [data, sessionId]);
+  }, [events, sessionId]);
 
   if (isLoading) return <div className="text-sm text-zinc-500">Loading…</div>;
   if (error) {
@@ -295,7 +311,7 @@ export function CausalGraph({
     <div>
       {linked && (
         <div className="mb-2 text-xs text-zinc-600">
-          Showing {data.length} events across linked sessions
+          Showing {events.length} events across linked sessions
           {graph.crossSessionCount > 0 && (
             <>
               {" "}


### PR DESCRIPTION
Two bugs reported on the freshly-merged Phase B (#51), both in the cross-session graph view. Filed together because the diagnostic path was tangled — the first fix surfaced the second.

## Bug 1: orphan chain edge near patched-in link-bearer

Reported via screenshot: a TOOL_RESULT patched in by the link-bearer fix from #51 / f970bf7 appeared next to its peer COMMIT with a \`produces\` edge, but **no dashed prev_hash chain back to the corresponding TOOL_CALL**. The bearer floats in isolation, audit-disconnected from its own session's chain.

Root cause: the bearer's \`prev_hash\` points at a TOOL_CALL one row earlier in the seed session, which also sits past \`perSessionLimit\`. The previous fix patched in the bearer event itself but not its chain neighbours, so the dashed edge from TOOL_CALL → TOOL_RESULT had \`source=non-rendered\` and ReactFlow silently dropped it. Same silent-degradation pattern as the cross-session edge case, just one ring deeper.

**Fix** (commit \`920e67d\`): for each patched-in bearer, also pull a small chain-context window of predecessors via a new \`Store.EventsBeforeID(sessionID, eventID, limit)\` helper. K=10 ancestors per bearer.
- Memory: linear scan (m.events is in id-asc/append order).
- Postgres: indexed range query (\`id < bearer_id ORDER BY id DESC LIMIT K\`, then reverse to id-asc for caller).
- Live dogfood: 1386 → 289 events, all 6 link-bearers' \`prev_hash\` now resolve to a rendered event.

## Bug 2: Timeline ↔ Graph toggle blanks the page

Reported after Bug 1 fix landed. Symptom: switching Timeline → Graph (or vice versa) showed nothing in the main area; sometimes "page unresponsive". A hard refresh consistently fixed it.

Root cause was much deeper than the apparent performance issue. Timeline.tsx uses \`queryKey: ['events', sessionId]\` with \`queryFn\` returning \`EventsResponse\` (\`{events, sessionHead}\`). CausalGraph (linked=false) used the **same queryKey** but its queryFn was \`gql<EventsResponse>(...).then((d) => d.events)\` — returning \`Event[]\`.

react-query keys on \`queryKey\`, not on what \`queryFn\` returns post-transform. Whichever consumer's queryFn ran first wrote that shape to the cache. If user landed on Timeline first, cache held \`EventsResponse\`. Toggling to Graph then made CausalGraph read \`EventsResponse\` but treat it as \`Event[]\` — \`for…of\` on the object threw inside \`buildGraph\` and React unmounted the whole subtree. Hard refresh masked it because in a freshly-mounted tree, whoever ran first determined the shape; landing on Graph first put \`Event[]\` in the cache and Timeline then saw \`Event[]\` (no \`.events\` field — Timeline showed nothing). Either order hit the bug at different transitions.

**Fix** (commit \`1ae5887\`): don't transform in \`queryFn\`. Return the raw responses; the cache holds each query's natural shape. Unify in the component via \`useMemo\`: \`'linkedEvents' in data ? data.linkedEvents : data.events\`. Timeline and CausalGraph now share the cache cell with consistent shape.

## Tests

- \`internal/query\`: \`TestLinkedEventsResolver_BearerChainContext\` (51 anchor events, bearer at index 50, perSessionLimit=10) — asserts (a) bearer's prev_hash resolves to a rendered event via chain-context, (b) total result is bounded (~22 events) not the full session. Reverse-verified by stashing the resolver fix to confirm the test fails without it.
- All existing \`TestLinkedEventsResolver*\` still pass.

## Commits

| | hash | what | status |
|---|---|---|---|
| 1 | \`9323e05\` | first attempt: seed session ignores perSessionLimit | superseded by 2 |
| 2 | \`920e67d\` | chain-context window (replaces 1) | live |
| 3 | \`1ae5887\` | cache shape parity between Timeline and CausalGraph | live |

I'd squash-merge this so \`main\` gets one clean commit summarising both fixes; the per-attempt history stays here in the PR for anyone tracing the thinking path.

## Out of scope (parked)

- A few events at the far end of each chain-context window still have \`prev_hash\` pointing further back (the window cuts off there). Acceptable for v1; the audit-critical bearer-to-TOOL_CALL edge is intact.
- React-query \`gcTime\` / \`staleTime\` defaults; current behaviour is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)