### PR TITLE
feat(transcript): record thinking blocks redacted by Claude Code

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -177,6 +177,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 **已知局限**：
 - Claude Code transcript jsonl 不是公开稳定契约，解析按 fail-soft：未识别行跳过，不中断流。最低支持版本随发版迭代标注于 README。
 - `<synthetic>` 模型标记的消息（Claude Code 自身注入的 stop-sequence 占位，usage 全 0）按已知形态跳过 usage 提取，不报错、不丢消息体。
+- **思考内容（thinking 文本）**：Claude Code 写 transcript 时只保留 `signature` 字段，**原文不持久化**。§10.1 拿不到原文。每条 assistant 消息中被丢弃的 thinking 块**数量**显式记录在派生 DECISION 事件的 `payload.thinking_redacted_by_claude_code`，避免审计报告把"被吞"误读为"无思考"。要拿原文得走 §10.4。
 - 仍**没有**的能力：实时拦截 / token 流式即时反馈 / policy gate。要这些得走 §10.4。
 
 ### 10.4 代理深模式（M4+，未启用）

--- a/cmd/agent-lens-hook/claude.go
+++ b/cmd/agent-lens-hook/claude.go
@@ -196,11 +196,19 @@ func makeStopEvents(in *claudeHookInput) ([]map[string]any, func() error) {
 				"source":     "transcript",
 			}))
 		case "text":
-			events = append(events, baseEvent(in, agentActorWithModel(b.Model), "decision", map[string]any{
+			payload := map[string]any{
 				"marker":     "assistant_message",
 				"text":       b.Content,
 				"message_id": b.MessageID,
-			}))
+			}
+			// Surface Claude-Code-side redaction of `thinking` content
+			// so audit readers don't mistake "transcript field empty"
+			// for "model didn't think". Capturing the actual content
+			// requires §10.4 proxy mode.
+			if b.RedactedThinking > 0 {
+				payload["thinking_redacted_by_claude_code"] = b.RedactedThinking
+			}
+			events = append(events, baseEvent(in, agentActorWithModel(b.Model), "decision", payload))
 		}
 	}
 	events = append(events, turnEnd)

--- a/internal/transcript/reader.go
+++ b/internal/transcript/reader.go
@@ -16,11 +16,20 @@ import (
 )
 
 // Block is a single content block extracted from one assistant message.
+//
+// RedactedThinking carries a per-message count of `thinking` content
+// blocks Claude Code wrote to the transcript with an empty `thinking`
+// field (only the `signature` was preserved). The count is attached to
+// the first `text` block of the same message so the derived
+// `assistant_message` DECISION event can surface it; thinking blocks
+// themselves do not carry the count to avoid mis-attributing the
+// redaction signal to the THOUGHT event.
 type Block struct {
-	Kind      string // "thinking" or "text"
-	Content   string
-	MessageID string
-	Model     string
+	Kind             string // "thinking" or "text"
+	Content          string
+	MessageID        string
+	Model            string
+	RedactedThinking int
 }
 
 // Reader reads new content from a transcript file since the last
@@ -143,11 +152,20 @@ func parseLine(line []byte) []Block {
 	if err := json.Unmarshal(msg.Content, &blocks); err != nil {
 		return nil
 	}
-	var out []Block
+	var (
+		out              []Block
+		redactedThinking int
+	)
 	for _, b := range blocks {
 		switch b.Type {
 		case "thinking":
 			if b.Thinking == "" {
+				// Claude Code persists `signature` but drops the
+				// thinking content; remember that the redaction
+				// happened so audit reports can say "N blocks
+				// redacted by Claude Code" instead of silently
+				// looking like the model didn't think at all.
+				redactedThinking++
 				continue
 			}
 			out = append(out, Block{Kind: "thinking", Content: b.Thinking, MessageID: msg.ID, Model: msg.Model})
@@ -156,6 +174,29 @@ func parseLine(line []byte) []Block {
 				continue
 			}
 			out = append(out, Block{Kind: "text", Content: b.Text, MessageID: msg.ID, Model: msg.Model})
+		}
+	}
+	if redactedThinking > 0 {
+		// Attach the count to the first text block so the
+		// `assistant_message` DECISION carries it. If the message had
+		// only redacted thinking (no text), emit a stub text block
+		// so the DECISION still fires; downstream UI shows just the
+		// "redacted" pill in that case.
+		attached := false
+		for i := range out {
+			if out[i].Kind == "text" {
+				out[i].RedactedThinking = redactedThinking
+				attached = true
+				break
+			}
+		}
+		if !attached {
+			out = append(out, Block{
+				Kind:             "text",
+				MessageID:        msg.ID,
+				Model:            msg.Model,
+				RedactedThinking: redactedThinking,
+			})
 		}
 	}
 	return out

--- a/internal/transcript/reader_test.go
+++ b/internal/transcript/reader_test.go
@@ -137,6 +137,33 @@ func TestRedactedThinkingOnlyEmitsStubTextBlock(t *testing.T) {
 	}
 }
 
+func TestRedactedThinkingPlusRealThinkingNoText(t *testing.T) {
+	// Message has both real thinking AND redacted thinking but no text
+	// block. The non-empty thinking block must still emit a THOUGHT event
+	// without picking up the redaction count, AND a stub text block must
+	// fire with the count so the assistant_message DECISION carries it.
+	// Verifies we attach the count to the stub even when other (non-text)
+	// blocks were emitted before the loop reached its end.
+	line := `{"type":"assistant","message":{"id":"msg_w","content":[` +
+		`{"type":"thinking","thinking":"real reasoning"},` +
+		`{"type":"thinking","thinking":""},` +
+		`{"type":"thinking","thinking":""}` +
+		`],"model":"claude-opus-4-7"}}`
+	got := parseLine([]byte(line))
+	if len(got) != 2 {
+		t.Fatalf("len(got)=%d, want 2 (real thinking + stub text); got=%+v", len(got), got)
+	}
+	if got[0].Kind != "thinking" || got[0].Content != "real reasoning" || got[0].RedactedThinking != 0 {
+		t.Errorf("real thinking block must not carry redaction count: %+v", got[0])
+	}
+	if got[1].Kind != "text" || got[1].Content != "" || got[1].RedactedThinking != 2 {
+		t.Errorf("stub text block should be empty with count=2: %+v", got[1])
+	}
+	if got[1].MessageID != "msg_w" {
+		t.Errorf("stub should carry message id: %+v", got[1])
+	}
+}
+
 func TestNoRedactionWhenAllThinkingNonEmpty(t *testing.T) {
 	// Sanity: when no thinking blocks are empty, the text block must
 	// not pick up a stale RedactedThinking value (default zero).

--- a/internal/transcript/reader_test.go
+++ b/internal/transcript/reader_test.go
@@ -94,6 +94,67 @@ func TestReadIgnoresPartialTrailingLine(t *testing.T) {
 	}
 }
 
+func TestRedactedThinkingAttachedToTextBlock(t *testing.T) {
+	// Claude Code's transcript writes `signature` but drops `thinking`
+	// content (the field is empty). Verify we count those instead of
+	// silently dropping them, and attach the count to the first text
+	// block so the derived assistant_message DECISION carries it.
+	line := `{"type":"assistant","message":{"id":"msg_x","content":[` +
+		`{"type":"thinking","thinking":""},` +
+		`{"type":"thinking","thinking":""},` +
+		`{"type":"thinking","thinking":"real reasoning"},` +
+		`{"type":"text","text":"hello"}` +
+		`],"model":"claude-opus-4-7"}}`
+	got := parseLine([]byte(line))
+	if len(got) != 2 {
+		t.Fatalf("len(got)=%d, want 2 (one non-empty thinking + one text); got=%+v", len(got), got)
+	}
+	if got[0].Kind != "thinking" || got[0].Content != "real reasoning" || got[0].RedactedThinking != 0 {
+		t.Errorf("non-empty thinking should not carry redaction count: %+v", got[0])
+	}
+	if got[1].Kind != "text" || got[1].Content != "hello" || got[1].RedactedThinking != 2 {
+		t.Errorf("text block should carry redaction count of 2: %+v", got[1])
+	}
+}
+
+func TestRedactedThinkingOnlyEmitsStubTextBlock(t *testing.T) {
+	// When a message has only redacted thinking and no text, we still
+	// need to produce a DECISION event so the count surfaces. The
+	// reader emits a stub text block (empty content) to drive that.
+	line := `{"type":"assistant","message":{"id":"msg_y","content":[` +
+		`{"type":"thinking","thinking":""},` +
+		`{"type":"thinking","thinking":""}` +
+		`],"model":"claude-opus-4-7"}}`
+	got := parseLine([]byte(line))
+	if len(got) != 1 {
+		t.Fatalf("len(got)=%d, want 1 stub text block; got=%+v", len(got), got)
+	}
+	if got[0].Kind != "text" || got[0].Content != "" || got[0].RedactedThinking != 2 {
+		t.Errorf("stub text block should be empty with count=2: %+v", got[0])
+	}
+	if got[0].MessageID != "msg_y" {
+		t.Errorf("stub should carry message id: %+v", got[0])
+	}
+}
+
+func TestNoRedactionWhenAllThinkingNonEmpty(t *testing.T) {
+	// Sanity: when no thinking blocks are empty, the text block must
+	// not pick up a stale RedactedThinking value (default zero).
+	line := `{"type":"assistant","message":{"id":"msg_z","content":[` +
+		`{"type":"thinking","thinking":"real"},` +
+		`{"type":"text","text":"hi"}` +
+		`],"model":"claude-opus-4-7"}}`
+	got := parseLine([]byte(line))
+	if len(got) != 2 {
+		t.Fatalf("len(got)=%d, want 2; got=%+v", len(got), got)
+	}
+	for _, b := range got {
+		if b.RedactedThinking != 0 {
+			t.Errorf("expected RedactedThinking=0, got %+v", b)
+		}
+	}
+}
+
 func TestParseLineSkipsUnknownAndMalformed(t *testing.T) {
 	cases := []string{
 		``,

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -65,6 +65,20 @@ export function EventCard({ event }: { event: Event }) {
                 </span>
               ) : null;
             })()}
+            {(() => {
+              const n = redactedThinkingCount(event);
+              return n > 0 ? (
+                <span
+                  className="inline-flex items-center gap-1 rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-700 ring-1 ring-zinc-300"
+                  title={`Claude Code dropped ${n} thinking block${n === 1 ? "" : "s"} from this message — only the signature was preserved in the transcript. Capturing the original thinking content requires §10.4 proxy mode.`}
+                >
+                  <span>🚫</span>
+                  <span>
+                    {n} thinking redacted
+                  </span>
+                </span>
+              ) : null;
+            })()}
             {event.links?.length > 0 && (
               <span
                 className="inline-flex items-center gap-0.5 rounded bg-white px-1.5 py-0.5 text-[10px] font-medium text-zinc-700 ring-1 ring-zinc-300"
@@ -224,6 +238,17 @@ function asString(v: unknown): string {
 
 function clip(s: string, n = 280): string {
   return s.length > n ? s.slice(0, n) + "…" : s;
+}
+
+// redactedThinkingCount reads the per-message count of `thinking`
+// content blocks Claude Code dropped from the transcript. Set by the
+// hook on `assistant_message` DECISION events; absent / 0 elsewhere.
+function redactedThinkingCount(event: Event): number {
+  if (event.kind !== "DECISION") return 0;
+  const p = (event.payload ?? {}) as Record<string, unknown>;
+  if (p.marker !== "assistant_message") return 0;
+  const v = p.thinking_redacted_by_claude_code;
+  return typeof v === "number" && v > 0 ? v : 0;
 }
 
 // authorizationBadge classifies a TOOL_CALL by the authorization


### PR DESCRIPTION
Closes #56.

## Summary

- Counts the per-message number of `thinking` content blocks Claude Code wrote with an empty body (only `signature` preserved) and attaches the count to the derived `assistant_message` DECISION event as `payload.thinking_redacted_by_claude_code`.
- Falls back to a stub text block when the message had only redacted thinking, so the DECISION still fires and the count surfaces.
- Lens UI renders a grey `🚫 N thinking redacted` pill on those rows with a tooltip explaining the Claude-Code-side cause and pointing at §10.4.
- SPEC §10.1 known-limitations gains an explicit line — thinking content is dropped by Claude Code; the count is recorded.

This is a silent-degradation fix: the reader previously skipped empty thinking blocks, making "redacted" look identical to "no thinking happened" in the audit report.

## Out of scope

- Capturing the actual thinking text — requires §10.4 proxy mode (separate ADR pending).
- Sub-agent (Task tool) transparency — tracked in #58, deferred until a real workflow needs it.
- ADR 0002 token-usage emission — tracked in #57, the next §10.1 wrap-up PR.

## Test plan

- [x] `go test ./internal/transcript/... ./cmd/agent-lens-hook/...` — three new tests cover redacted+text mix, redacted-only, and no-redaction baseline.
- [x] `go build ./...` clean.
- [x] `npx tsc --noEmit` in `web/` clean.
- [ ] Live dogfood: run the collector with the new hook, verify dogfood DB shows non-zero `thinking_redacted_by_claude_code` on DECISION rows for the current session. (Will do post-merge to keep this PR scoped.)
- [ ] UI smoke: open Lens, expand an `assistant_message` row, confirm pill renders and tooltip text matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)