### PR TITLE
feat(query,web): GraphQL TokenUsage + UI per-message chip + session total (ADR 0002 phase B)

### DIFF
--- a/internal/query/generated.go
+++ b/internal/query/generated.go
@@ -31,6 +31,7 @@ type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
 type ResolverRoot interface {
 	Event() EventResolver
 	Query() QueryResolver
+	Session() SessionResolver
 }
 
 type DirectiveRoot struct {
@@ -44,18 +45,20 @@ type ComplexityRoot struct {
 	}
 
 	Event struct {
-		Actor     func(childComplexity int) int
-		Hash      func(childComplexity int) int
-		ID        func(childComplexity int) int
-		Kind      func(childComplexity int) int
-		Links     func(childComplexity int) int
-		Parents   func(childComplexity int) int
-		Payload   func(childComplexity int) int
-		PrevHash  func(childComplexity int) int
-		Refs      func(childComplexity int) int
-		SessionID func(childComplexity int) int
-		Ts        func(childComplexity int) int
-		TurnID    func(childComplexity int) int
+		Actor      func(childComplexity int) int
+		Hash       func(childComplexity int) int
+		ID         func(childComplexity int) int
+		Kind       func(childComplexity int) int
+		Links      func(childComplexity int) int
+		Parents    func(childComplexity int) int
+		Payload    func(childComplexity int) int
+		PrevHash   func(childComplexity int) int
+		Refs       func(childComplexity int) int
+		SessionID  func(childComplexity int) int
+		StopReason func(childComplexity int) int
+		Ts         func(childComplexity int) int
+		TurnID     func(childComplexity int) int
+		Usage      func(childComplexity int) int
 	}
 
 	Link struct {
@@ -79,11 +82,27 @@ type ComplexityRoot struct {
 		FirstEventAt func(childComplexity int) int
 		ID           func(childComplexity int) int
 		LastEventAt  func(childComplexity int) int
+		TotalUsage   func(childComplexity int) int
+	}
+
+	TokenUsage struct {
+		CacheReadTokens    func(childComplexity int) int
+		CacheWrite1hTokens func(childComplexity int) int
+		CacheWrite5mTokens func(childComplexity int) int
+		InputTokens        func(childComplexity int) int
+		Model              func(childComplexity int) int
+		OutputTokens       func(childComplexity int) int
+		ServiceTier        func(childComplexity int) int
+		Vendor             func(childComplexity int) int
+		WebFetchCalls      func(childComplexity int) int
+		WebSearchCalls     func(childComplexity int) int
 	}
 }
 
 type EventResolver interface {
 	Links(ctx context.Context, obj *Event) ([]*Link, error)
+	Usage(ctx context.Context, obj *Event) (*TokenUsage, error)
+	StopReason(ctx context.Context, obj *Event) (*string, error)
 }
 type QueryResolver interface {
 	Event(ctx context.Context, id string) (*Event, error)
@@ -91,6 +110,9 @@ type QueryResolver interface {
 	SessionHead(ctx context.Context, sessionID string) (string, error)
 	Sessions(ctx context.Context, limit *int, since *time.Time) ([]*Session, error)
 	LinkedEvents(ctx context.Context, sessionID string, depth *int, perSessionLimit *int) ([]*Event, error)
+}
+type SessionResolver interface {
+	TotalUsage(ctx context.Context, obj *Session) (*TokenUsage, error)
 }
 
 type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -186,6 +208,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Event.SessionID(childComplexity), true
+	case "Event.stopReason":
+		if e.ComplexityRoot.Event.StopReason == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Event.StopReason(childComplexity), true
 	case "Event.ts":
 		if e.ComplexityRoot.Event.Ts == nil {
 			break
@@ -198,6 +226,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Event.TurnID(childComplexity), true
+	case "Event.usage":
+		if e.ComplexityRoot.Event.Usage == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Event.Usage(childComplexity), true
 
 	case "Link.confidence":
 		if e.ComplexityRoot.Link.Confidence == nil {
@@ -311,6 +345,73 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Session.LastEventAt(childComplexity), true
+	case "Session.totalUsage":
+		if e.ComplexityRoot.Session.TotalUsage == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Session.TotalUsage(childComplexity), true
+
+	case "TokenUsage.cacheReadTokens":
+		if e.ComplexityRoot.TokenUsage.CacheReadTokens == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenUsage.CacheReadTokens(childComplexity), true
+	case "TokenUsage.cacheWrite1hTokens":
+		if e.ComplexityRoot.TokenUsage.CacheWrite1hTokens == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenUsage.CacheWrite1hTokens(childComplexity), true
+	case "TokenUsage.cacheWrite5mTokens":
+		if e.ComplexityRoot.TokenUsage.CacheWrite5mTokens == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenUsage.CacheWrite5mTokens(childComplexity), true
+	case "TokenUsage.inputTokens":
+		if e.ComplexityRoot.TokenUsage.InputTokens == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenUsage.InputTokens(childComplexity), true
+	case "TokenUsage.model":
+		if e.ComplexityRoot.TokenUsage.Model == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenUsage.Model(childComplexity), true
+	case "TokenUsage.outputTokens":
+		if e.ComplexityRoot.TokenUsage.OutputTokens == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenUsage.OutputTokens(childComplexity), true
+	case "TokenUsage.serviceTier":
+		if e.ComplexityRoot.TokenUsage.ServiceTier == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenUsage.ServiceTier(childComplexity), true
+	case "TokenUsage.vendor":
+		if e.ComplexityRoot.TokenUsage.Vendor == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenUsage.Vendor(childComplexity), true
+	case "TokenUsage.webFetchCalls":
+		if e.ComplexityRoot.TokenUsage.WebFetchCalls == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenUsage.WebFetchCalls(childComplexity), true
+	case "TokenUsage.webSearchCalls":
+		if e.ComplexityRoot.TokenUsage.WebSearchCalls == nil {
+			break
+		}
+
+		return e.ComplexityRoot.TokenUsage.WebSearchCalls(childComplexity), true
 
 	}
 	return 0, false
@@ -436,6 +537,10 @@ func (ec *executionContext) childFields_Event(ctx context.Context, field graphql
 		return ec.fieldContext_Event_prevHash(ctx, field)
 	case "links":
 		return ec.fieldContext_Event_links(ctx, field)
+	case "usage":
+		return ec.fieldContext_Event_usage(ctx, field)
+	case "stopReason":
+		return ec.fieldContext_Event_stopReason(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type Event", field.Name)
 }
@@ -466,8 +571,36 @@ func (ec *executionContext) childFields_Session(ctx context.Context, field graph
 		return ec.fieldContext_Session_lastEventAt(ctx, field)
 	case "eventCount":
 		return ec.fieldContext_Session_eventCount(ctx, field)
+	case "totalUsage":
+		return ec.fieldContext_Session_totalUsage(ctx, field)
 	}
 	return nil, fmt.Errorf("no field named %q was found under type Session", field.Name)
+}
+
+func (ec *executionContext) childFields_TokenUsage(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+	switch field.Name {
+	case "vendor":
+		return ec.fieldContext_TokenUsage_vendor(ctx, field)
+	case "model":
+		return ec.fieldContext_TokenUsage_model(ctx, field)
+	case "serviceTier":
+		return ec.fieldContext_TokenUsage_serviceTier(ctx, field)
+	case "inputTokens":
+		return ec.fieldContext_TokenUsage_inputTokens(ctx, field)
+	case "outputTokens":
+		return ec.fieldContext_TokenUsage_outputTokens(ctx, field)
+	case "cacheReadTokens":
+		return ec.fieldContext_TokenUsage_cacheReadTokens(ctx, field)
+	case "cacheWrite5mTokens":
+		return ec.fieldContext_TokenUsage_cacheWrite5mTokens(ctx, field)
+	case "cacheWrite1hTokens":
+		return ec.fieldContext_TokenUsage_cacheWrite1hTokens(ctx, field)
+	case "webSearchCalls":
+		return ec.fieldContext_TokenUsage_webSearchCalls(ctx, field)
+	case "webFetchCalls":
+		return ec.fieldContext_TokenUsage_webFetchCalls(ctx, field)
+	}
+	return nil, fmt.Errorf("no field named %q was found under type TokenUsage", field.Name)
 }
 
 func (ec *executionContext) childFields___Directive(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
@@ -1129,6 +1262,61 @@ func (ec *executionContext) fieldContext_Event_links(_ context.Context, field gr
 	return fc, nil
 }
 
+func (ec *executionContext) _Event_usage(ctx context.Context, field graphql.CollectedField, obj *Event) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Event_usage(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Event().Usage(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *TokenUsage) graphql.Marshaler {
+			return ec.marshalOTokenUsage2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐTokenUsage(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Event_usage(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Event",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_TokenUsage(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _Event_stopReason(ctx context.Context, field graphql.CollectedField, obj *Event) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Event_stopReason(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Event().StopReason(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Event_stopReason(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Event", field, true, true, errors.New("field of type String does not have child fields"))
+}
+
 func (ec *executionContext) _Link_fromEvent(ctx context.Context, field graphql.CollectedField, obj *Link) (ret graphql.Marshaler) {
 	return graphql.ResolveField(
 		ctx,
@@ -1630,6 +1818,268 @@ func (ec *executionContext) _Session_eventCount(ctx context.Context, field graph
 }
 func (ec *executionContext) fieldContext_Session_eventCount(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("Session", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _Session_totalUsage(ctx context.Context, field graphql.CollectedField, obj *Session) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Session_totalUsage(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return ec.Resolvers.Session().TotalUsage(ctx, obj)
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *TokenUsage) graphql.Marshaler {
+			return ec.marshalOTokenUsage2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐTokenUsage(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Session_totalUsage(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "Session",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: true,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.childFields_TokenUsage(ctx, field)
+		},
+	}
+	return fc, nil
+}
+
+func (ec *executionContext) _TokenUsage_vendor(ctx context.Context, field graphql.CollectedField, obj *TokenUsage) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenUsage_vendor(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Vendor, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TokenUsage_vendor(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenUsage", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _TokenUsage_model(ctx context.Context, field graphql.CollectedField, obj *TokenUsage) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenUsage_model(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.Model, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v string) graphql.Marshaler {
+			return ec.marshalNString2string(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TokenUsage_model(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenUsage", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _TokenUsage_serviceTier(ctx context.Context, field graphql.CollectedField, obj *TokenUsage) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenUsage_serviceTier(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.ServiceTier, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_TokenUsage_serviceTier(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenUsage", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _TokenUsage_inputTokens(ctx context.Context, field graphql.CollectedField, obj *TokenUsage) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenUsage_inputTokens(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.InputTokens, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int) graphql.Marshaler {
+			return ec.marshalNInt2int(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TokenUsage_inputTokens(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenUsage", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TokenUsage_outputTokens(ctx context.Context, field graphql.CollectedField, obj *TokenUsage) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenUsage_outputTokens(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.OutputTokens, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v int) graphql.Marshaler {
+			return ec.marshalNInt2int(ctx, selections, v)
+		},
+		true,
+		true,
+	)
+}
+func (ec *executionContext) fieldContext_TokenUsage_outputTokens(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenUsage", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TokenUsage_cacheReadTokens(ctx context.Context, field graphql.CollectedField, obj *TokenUsage) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenUsage_cacheReadTokens(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.CacheReadTokens, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *int) graphql.Marshaler {
+			return ec.marshalOInt2ᚖint(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_TokenUsage_cacheReadTokens(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenUsage", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TokenUsage_cacheWrite5mTokens(ctx context.Context, field graphql.CollectedField, obj *TokenUsage) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenUsage_cacheWrite5mTokens(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.CacheWrite5mTokens, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *int) graphql.Marshaler {
+			return ec.marshalOInt2ᚖint(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_TokenUsage_cacheWrite5mTokens(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenUsage", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TokenUsage_cacheWrite1hTokens(ctx context.Context, field graphql.CollectedField, obj *TokenUsage) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenUsage_cacheWrite1hTokens(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.CacheWrite1hTokens, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *int) graphql.Marshaler {
+			return ec.marshalOInt2ᚖint(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_TokenUsage_cacheWrite1hTokens(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenUsage", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TokenUsage_webSearchCalls(ctx context.Context, field graphql.CollectedField, obj *TokenUsage) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenUsage_webSearchCalls(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.WebSearchCalls, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *int) graphql.Marshaler {
+			return ec.marshalOInt2ᚖint(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_TokenUsage_webSearchCalls(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenUsage", field, false, false, errors.New("field of type Int does not have child fields"))
+}
+
+func (ec *executionContext) _TokenUsage_webFetchCalls(ctx context.Context, field graphql.CollectedField, obj *TokenUsage) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_TokenUsage_webFetchCalls(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.WebFetchCalls, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *int) graphql.Marshaler {
+			return ec.marshalOInt2ᚖint(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_TokenUsage_webFetchCalls(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("TokenUsage", field, false, false, errors.New("field of type Int does not have child fields"))
 }
 
 func (ec *executionContext) ___Directive_name(ctx context.Context, field graphql.CollectedField, obj *introspection.Directive) (ret graphql.Marshaler) {
@@ -2838,6 +3288,72 @@ func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, ob
 			}
 
 			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "usage":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Event_usage(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		case "stopReason":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Event_stopReason(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -3091,23 +3607,122 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 		case "id":
 			out.Values[i] = ec._Session_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "firstEventAt":
 			out.Values[i] = ec._Session_firstEventAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "lastEventAt":
 			out.Values[i] = ec._Session_lastEventAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				out.Invalids++
+				atomic.AddUint32(&out.Invalids, 1)
 			}
 		case "eventCount":
 			out.Values[i] = ec._Session_eventCount(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&out.Invalids, 1)
+			}
+		case "totalUsage":
+			field := field
+
+			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
+				defer func() {
+					if r := recover(); r != nil {
+						ec.Error(ctx, ec.Recover(ctx, r))
+					}
+				}()
+				res = ec._Session_totalUsage(ctx, field, obj)
+				return res
+			}
+
+			if field.Deferrable != nil {
+				dfs, ok := deferred[field.Deferrable.Label]
+				di := 0
+				if ok {
+					dfs.AddField(field)
+					di = len(dfs.Values) - 1
+				} else {
+					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
+					deferred[field.Deferrable.Label] = dfs
+				}
+				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
+					return innerFunc(ctx, dfs)
+				})
+
+				// don't run the out.Concurrently() call below
+				out.Values[i] = graphql.Null
+				continue
+			}
+
+			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+		default:
+			panic("unknown field " + strconv.Quote(field.Name))
+		}
+	}
+	out.Dispatch(ctx)
+	if out.Invalids > 0 {
+		return graphql.Null
+	}
+
+	atomic.AddInt32(&ec.Deferred, int32(min(len(deferred), math.MaxInt32)))
+
+	for label, dfs := range deferred {
+		ec.ProcessDeferredGroup(graphql.DeferredGroup{
+			Label:    label,
+			Path:     graphql.GetPath(ctx),
+			FieldSet: dfs,
+			Context:  ctx,
+		})
+	}
+
+	return out
+}
+
+var tokenUsageImplementors = []string{"TokenUsage"}
+
+func (ec *executionContext) _TokenUsage(ctx context.Context, sel ast.SelectionSet, obj *TokenUsage) graphql.Marshaler {
+	fields := graphql.CollectFields(ec.OperationContext, sel, tokenUsageImplementors)
+
+	out := graphql.NewFieldSet(fields)
+	deferred := make(map[string]*graphql.FieldSet)
+	for i, field := range fields {
+		switch field.Name {
+		case "__typename":
+			out.Values[i] = graphql.MarshalString("TokenUsage")
+		case "vendor":
+			out.Values[i] = ec._TokenUsage_vendor(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
 				out.Invalids++
 			}
+		case "model":
+			out.Values[i] = ec._TokenUsage_model(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "serviceTier":
+			out.Values[i] = ec._TokenUsage_serviceTier(ctx, field, obj)
+		case "inputTokens":
+			out.Values[i] = ec._TokenUsage_inputTokens(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "outputTokens":
+			out.Values[i] = ec._TokenUsage_outputTokens(ctx, field, obj)
+			if out.Values[i] == graphql.Null {
+				out.Invalids++
+			}
+		case "cacheReadTokens":
+			out.Values[i] = ec._TokenUsage_cacheReadTokens(ctx, field, obj)
+		case "cacheWrite5mTokens":
+			out.Values[i] = ec._TokenUsage_cacheWrite5mTokens(ctx, field, obj)
+		case "cacheWrite1hTokens":
+			out.Values[i] = ec._TokenUsage_cacheWrite1hTokens(ctx, field, obj)
+		case "webSearchCalls":
+			out.Values[i] = ec._TokenUsage_webSearchCalls(ctx, field, obj)
+		case "webFetchCalls":
+			out.Values[i] = ec._TokenUsage_webFetchCalls(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}
@@ -3948,6 +4563,13 @@ func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel
 	_ = ctx
 	res := graphql.MarshalTime(*v)
 	return res
+}
+
+func (ec *executionContext) marshalOTokenUsage2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐTokenUsage(ctx context.Context, sel ast.SelectionSet, v *TokenUsage) graphql.Marshaler {
+	if v == nil {
+		return graphql.Null
+	}
+	return ec._TokenUsage(ctx, sel, v)
 }
 
 func (ec *executionContext) marshalO__EnumValue2ᚕgithubᚗcomᚋ99designsᚋgqlgenᚋgraphqlᚋintrospectionᚐEnumValueᚄ(ctx context.Context, sel ast.SelectionSet, v []introspection.EnumValue) graphql.Marshaler {

--- a/internal/query/gqlgen.yml
+++ b/internal/query/gqlgen.yml
@@ -26,3 +26,17 @@ models:
       # nothing, and we can DataLoader-batch later.
       links:
         resolver: true
+      # usage / stopReason are derived from the event's JSON payload
+      # rather than columns on the storage struct — wire them as
+      # resolvers so the gqlgen-generated Event model stays a thin
+      # reflection of the storage layer.
+      usage:
+        resolver: true
+      stopReason:
+        resolver: true
+  Session:
+    fields:
+      # totalUsage loads all events in the session to aggregate; lazy
+      # so the cheap `sessions()` listing isn't burdened by it.
+      totalUsage:
+        resolver: true

--- a/internal/query/mapper.go
+++ b/internal/query/mapper.go
@@ -87,6 +87,19 @@ func toGQLLink(l *store.Link) *Link {
 // what the hook writes; this struct is kept here (not imported) so the
 // query package doesn't take a dependency on cmd/agent-lens-hook just
 // to decode wire format.
+//
+// Adding a new TokenUsage field requires touching FOUR places, kept
+// in lock-step intentionally so a stale producer / consumer / shape
+// fails loudly rather than dropping data:
+//   1. internal/transcript/reader.go           — TokenUsage struct + extractUsage mapping (producer)
+//   2. internal/query/mapper.go (this file)    — wireUsage struct + decodePayloadUsage assignment + aggregateSessionUsage accumulator
+//   3. internal/query/schema.graphql           — TokenUsage type (regen via `make gqlgen`)
+//   4. web/src/types.ts + UI chips             — TokenUsage type + chip / tooltip rendering
+//
+// TestTokenUsageGraphQLShape catches drift on (3); the others rely on
+// build-time field alignment between wireUsage / TokenUsage. Keep
+// snake_case wire and camelCase GraphQL — that asymmetry is forced by
+// the wire format already shipped in #63.
 type wireUsage struct {
 	Vendor             string `json:"vendor"`
 	Model              string `json:"model"`

--- a/internal/query/mapper.go
+++ b/internal/query/mapper.go
@@ -81,3 +81,181 @@ func toGQLLink(l *store.Link) *Link {
 		InferredBy: l.InferredBy,
 	}
 }
+
+// wireUsage mirrors the JSON shape produced by the transcript package's
+// TokenUsage when serialized into payload.usage. Snake_case tags match
+// what the hook writes; this struct is kept here (not imported) so the
+// query package doesn't take a dependency on cmd/agent-lens-hook just
+// to decode wire format.
+type wireUsage struct {
+	Vendor             string `json:"vendor"`
+	Model              string `json:"model"`
+	ServiceTier        string `json:"service_tier"`
+	InputTokens        int    `json:"input_tokens"`
+	OutputTokens       int    `json:"output_tokens"`
+	CacheReadTokens    int    `json:"cache_read_tokens"`
+	CacheWrite5mTokens int    `json:"cache_write_5m_tokens"`
+	CacheWrite1hTokens int    `json:"cache_write_1h_tokens"`
+	WebSearchCalls     int    `json:"web_search_calls"`
+	WebFetchCalls      int    `json:"web_fetch_calls"`
+}
+
+// decodePayloadUsage extracts payload.usage and returns a *TokenUsage
+// suitable for the GraphQL response, or nil when usage isn't present
+// or can't be decoded. Optional fields collapse to nil when their
+// underlying value is 0 — `omitempty` on the wire makes 0 and absent
+// indistinguishable, so we treat them the same on the way out.
+func decodePayloadUsage(payload map[string]any) *TokenUsage {
+	if payload == nil {
+		return nil
+	}
+	raw, ok := payload["usage"]
+	if !ok || raw == nil {
+		return nil
+	}
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil
+	}
+	var w wireUsage
+	if err := json.Unmarshal(b, &w); err != nil {
+		return nil
+	}
+	out := &TokenUsage{
+		Vendor:       w.Vendor,
+		Model:        w.Model,
+		InputTokens:  w.InputTokens,
+		OutputTokens: w.OutputTokens,
+	}
+	if w.ServiceTier != "" {
+		v := w.ServiceTier
+		out.ServiceTier = &v
+	}
+	if w.CacheReadTokens != 0 {
+		v := w.CacheReadTokens
+		out.CacheReadTokens = &v
+	}
+	if w.CacheWrite5mTokens != 0 {
+		v := w.CacheWrite5mTokens
+		out.CacheWrite5mTokens = &v
+	}
+	if w.CacheWrite1hTokens != 0 {
+		v := w.CacheWrite1hTokens
+		out.CacheWrite1hTokens = &v
+	}
+	if w.WebSearchCalls != 0 {
+		v := w.WebSearchCalls
+		out.WebSearchCalls = &v
+	}
+	if w.WebFetchCalls != 0 {
+		v := w.WebFetchCalls
+		out.WebFetchCalls = &v
+	}
+	return out
+}
+
+// decodePayloadStopReason pulls payload.stop_reason out of the JSON
+// payload. Returns nil when missing or empty so GraphQL renders null
+// rather than an empty string.
+func decodePayloadStopReason(payload map[string]any) *string {
+	if payload == nil {
+		return nil
+	}
+	v, ok := payload["stop_reason"].(string)
+	if !ok || v == "" {
+		return nil
+	}
+	return &v
+}
+
+// aggregateSessionUsage walks every event in a session and sums the
+// numeric counters of any `payload.usage` present. Non-numeric fields
+// (vendor / model / service_tier) collapse to a single value when the
+// session is homogeneous, else stay empty — multi-model sessions
+// shouldn't pretend to have a single model. Returns nil when no event
+// in the session carries usage.
+func aggregateSessionUsage(events []*store.Event) *TokenUsage {
+	var (
+		anyUsage                                                       bool
+		inputT, outputT, cacheR, cache5m, cache1h, webSearch, webFetch int
+		vendors                                                        = map[string]struct{}{}
+		models                                                         = map[string]struct{}{}
+		tiers                                                          = map[string]struct{}{}
+	)
+	for _, se := range events {
+		if len(se.Payload) == 0 {
+			continue
+		}
+		var p map[string]any
+		if err := json.Unmarshal(se.Payload, &p); err != nil {
+			continue
+		}
+		u := decodePayloadUsage(p)
+		if u == nil {
+			continue
+		}
+		anyUsage = true
+		inputT += u.InputTokens
+		outputT += u.OutputTokens
+		if u.CacheReadTokens != nil {
+			cacheR += *u.CacheReadTokens
+		}
+		if u.CacheWrite5mTokens != nil {
+			cache5m += *u.CacheWrite5mTokens
+		}
+		if u.CacheWrite1hTokens != nil {
+			cache1h += *u.CacheWrite1hTokens
+		}
+		if u.WebSearchCalls != nil {
+			webSearch += *u.WebSearchCalls
+		}
+		if u.WebFetchCalls != nil {
+			webFetch += *u.WebFetchCalls
+		}
+		if u.Vendor != "" {
+			vendors[u.Vendor] = struct{}{}
+		}
+		if u.Model != "" {
+			models[u.Model] = struct{}{}
+		}
+		if u.ServiceTier != nil && *u.ServiceTier != "" {
+			tiers[*u.ServiceTier] = struct{}{}
+		}
+	}
+	if !anyUsage {
+		return nil
+	}
+	out := &TokenUsage{InputTokens: inputT, OutputTokens: outputT}
+	if len(vendors) == 1 {
+		for v := range vendors {
+			out.Vendor = v
+		}
+	}
+	if len(models) == 1 {
+		for m := range models {
+			out.Model = m
+		}
+	}
+	if len(tiers) == 1 {
+		for t := range tiers {
+			s := t
+			out.ServiceTier = &s
+		}
+	}
+	if cacheR > 0 {
+		out.CacheReadTokens = &cacheR
+	}
+	if cache5m > 0 {
+		out.CacheWrite5mTokens = &cache5m
+	}
+	if cache1h > 0 {
+		out.CacheWrite1hTokens = &cache1h
+	}
+	if webSearch > 0 {
+		out.WebSearchCalls = &webSearch
+	}
+	if webFetch > 0 {
+		out.WebFetchCalls = &webFetch
+	}
+	return out
+}

--- a/internal/query/mapper_test.go
+++ b/internal/query/mapper_test.go
@@ -1,0 +1,255 @@
+package query
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/dongqiu/agent-lens/internal/store"
+)
+
+func TestDecodePayloadUsage_Present(t *testing.T) {
+	// Wire shape mirrors what the hook writes (transcript.TokenUsage
+	// snake_case JSON tags). Decode + map to GraphQL TokenUsage.
+	payload := map[string]any{
+		"usage": map[string]any{
+			"vendor":                "anthropic",
+			"model":                 "claude-opus-4-7",
+			"service_tier":          "priority",
+			"input_tokens":          float64(11),
+			"output_tokens":         float64(22),
+			"cache_read_tokens":     float64(33),
+			"cache_write_5m_tokens": float64(44),
+			"cache_write_1h_tokens": float64(55),
+			"web_search_calls":      float64(6),
+			"web_fetch_calls":       float64(7),
+		},
+	}
+	got := decodePayloadUsage(payload)
+	if got == nil {
+		t.Fatalf("expected non-nil")
+	}
+	checks := []struct {
+		name     string
+		got, exp any
+	}{
+		{"Vendor", got.Vendor, "anthropic"},
+		{"Model", got.Model, "claude-opus-4-7"},
+		{"InputTokens", got.InputTokens, 11},
+		{"OutputTokens", got.OutputTokens, 22},
+	}
+	for _, c := range checks {
+		if c.got != c.exp {
+			t.Errorf("%s = %v, want %v", c.name, c.got, c.exp)
+		}
+	}
+	if got.ServiceTier == nil || *got.ServiceTier != "priority" {
+		t.Errorf("ServiceTier = %v, want priority", got.ServiceTier)
+	}
+	if got.CacheReadTokens == nil || *got.CacheReadTokens != 33 {
+		t.Errorf("CacheReadTokens = %v, want 33", got.CacheReadTokens)
+	}
+	if got.CacheWrite5mTokens == nil || *got.CacheWrite5mTokens != 44 {
+		t.Errorf("CacheWrite5mTokens = %v, want 44", got.CacheWrite5mTokens)
+	}
+	if got.CacheWrite1hTokens == nil || *got.CacheWrite1hTokens != 55 {
+		t.Errorf("CacheWrite1hTokens = %v, want 55", got.CacheWrite1hTokens)
+	}
+	if got.WebSearchCalls == nil || *got.WebSearchCalls != 6 {
+		t.Errorf("WebSearchCalls = %v, want 6", got.WebSearchCalls)
+	}
+	if got.WebFetchCalls == nil || *got.WebFetchCalls != 7 {
+		t.Errorf("WebFetchCalls = %v, want 7", got.WebFetchCalls)
+	}
+}
+
+func TestDecodePayloadUsage_AbsentReturnsNil(t *testing.T) {
+	cases := []map[string]any{
+		nil,
+		{},
+		{"usage": nil},
+		{"some_other_key": "x"},
+	}
+	for i, p := range cases {
+		if got := decodePayloadUsage(p); got != nil {
+			t.Errorf("case %d: expected nil, got %+v", i, got)
+		}
+	}
+}
+
+func TestDecodePayloadUsage_ZeroOptionalsCollapseToNil(t *testing.T) {
+	// `omitempty` on the wire makes 0 and absent indistinguishable;
+	// the decoder treats them the same.
+	payload := map[string]any{
+		"usage": map[string]any{
+			"vendor":            "anthropic",
+			"model":             "claude-opus-4-7",
+			"input_tokens":      float64(1),
+			"output_tokens":     float64(2),
+			"cache_read_tokens": float64(0),
+		},
+	}
+	got := decodePayloadUsage(payload)
+	if got == nil {
+		t.Fatalf("expected non-nil")
+	}
+	if got.CacheReadTokens != nil {
+		t.Errorf("zero cache_read_tokens should collapse to nil; got %v", *got.CacheReadTokens)
+	}
+	if got.WebSearchCalls != nil || got.WebFetchCalls != nil {
+		t.Errorf("absent counters should be nil")
+	}
+}
+
+func TestDecodePayloadStopReason(t *testing.T) {
+	cases := []struct {
+		name    string
+		payload map[string]any
+		wantNil bool
+		wantVal string
+	}{
+		{"present", map[string]any{"stop_reason": "end_turn"}, false, "end_turn"},
+		{"empty string", map[string]any{"stop_reason": ""}, true, ""},
+		{"absent", map[string]any{}, true, ""},
+		{"nil payload", nil, true, ""},
+		{"non-string", map[string]any{"stop_reason": 42}, true, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := decodePayloadStopReason(c.payload)
+			if c.wantNil && got != nil {
+				t.Errorf("expected nil, got %q", *got)
+			}
+			if !c.wantNil {
+				if got == nil {
+					t.Errorf("expected %q, got nil", c.wantVal)
+				} else if *got != c.wantVal {
+					t.Errorf("got %q, want %q", *got, c.wantVal)
+				}
+			}
+		})
+	}
+}
+
+func TestAggregateSessionUsage_SumsCounters(t *testing.T) {
+	events := []*store.Event{
+		makeEventWithUsage(t, "anthropic", "claude-opus-4-7", "standard", 10, 20, 30, 0, 5),
+		makeEventWithUsage(t, "anthropic", "claude-opus-4-7", "standard", 1, 2, 3, 0, 0),
+		// Event with no usage payload — must be skipped, not counted.
+		{ID: "e3", Payload: json.RawMessage(`{"text":"plain"}`)},
+	}
+	got := aggregateSessionUsage(events)
+	if got == nil {
+		t.Fatalf("expected aggregate, got nil")
+	}
+	if got.InputTokens != 11 || got.OutputTokens != 22 {
+		t.Errorf("input/output = %d/%d, want 11/22", got.InputTokens, got.OutputTokens)
+	}
+	if got.CacheReadTokens == nil || *got.CacheReadTokens != 33 {
+		t.Errorf("cache_read_tokens = %v, want 33", got.CacheReadTokens)
+	}
+	// 5m bucket was zero in both contributors → should stay nil.
+	if got.CacheWrite5mTokens != nil {
+		t.Errorf("cache_write_5m_tokens should be nil for all-zero session; got %v", *got.CacheWrite5mTokens)
+	}
+	if got.CacheWrite1hTokens == nil || *got.CacheWrite1hTokens != 5 {
+		t.Errorf("cache_write_1h_tokens = %v, want 5", got.CacheWrite1hTokens)
+	}
+	if got.Vendor != "anthropic" {
+		t.Errorf("Vendor = %q, want anthropic", got.Vendor)
+	}
+	if got.Model != "claude-opus-4-7" {
+		t.Errorf("Model = %q, want claude-opus-4-7", got.Model)
+	}
+	if got.ServiceTier == nil || *got.ServiceTier != "standard" {
+		t.Errorf("ServiceTier = %v, want standard", got.ServiceTier)
+	}
+}
+
+func TestAggregateSessionUsage_MultiModelCollapsesIdentity(t *testing.T) {
+	// Mixed-model session: vendor/model/service_tier shouldn't claim a
+	// single value because that'd misrepresent the audit picture. They
+	// stay empty / nil while numeric counters still aggregate.
+	events := []*store.Event{
+		makeEventWithUsage(t, "anthropic", "claude-opus-4-7", "standard", 10, 20, 0, 0, 0),
+		makeEventWithUsage(t, "anthropic", "claude-sonnet-4-6", "priority", 5, 10, 0, 0, 0),
+	}
+	got := aggregateSessionUsage(events)
+	if got == nil {
+		t.Fatalf("expected aggregate")
+	}
+	if got.Model != "" {
+		t.Errorf("Model should be empty for multi-model session; got %q", got.Model)
+	}
+	if got.ServiceTier != nil {
+		t.Errorf("ServiceTier should be nil for mixed-tier session; got %v", *got.ServiceTier)
+	}
+	if got.Vendor != "anthropic" {
+		t.Errorf("Vendor stays homogeneous (both anthropic); got %q", got.Vendor)
+	}
+	if got.InputTokens != 15 || got.OutputTokens != 30 {
+		t.Errorf("counters didn't aggregate: %d/%d", got.InputTokens, got.OutputTokens)
+	}
+}
+
+func TestAggregateSessionUsage_ReturnsNilWhenNoUsage(t *testing.T) {
+	events := []*store.Event{
+		{ID: "e1", Payload: json.RawMessage(`{"text":"plain"}`)},
+		{ID: "e2", Payload: json.RawMessage(`{"name":"Bash"}`)},
+	}
+	if got := aggregateSessionUsage(events); got != nil {
+		t.Errorf("expected nil for usage-free session; got %+v", got)
+	}
+}
+
+func TestAggregateSessionUsage_EmptyInput(t *testing.T) {
+	if got := aggregateSessionUsage(nil); got != nil {
+		t.Errorf("expected nil for empty input")
+	}
+	if got := aggregateSessionUsage([]*store.Event{}); got != nil {
+		t.Errorf("expected nil for empty slice")
+	}
+}
+
+// makeEventWithUsage builds a synthetic store.Event whose payload
+// carries a usage block in the same wire format the hook writes.
+func makeEventWithUsage(t *testing.T, vendor, model, tier string, in, out, cacheR, cache5m, cache1h int) *store.Event {
+	t.Helper()
+	payload := map[string]any{
+		"usage": map[string]any{
+			"vendor":                vendor,
+			"model":                 model,
+			"service_tier":          tier,
+			"input_tokens":          in,
+			"output_tokens":         out,
+			"cache_read_tokens":     cacheR,
+			"cache_write_5m_tokens": cache5m,
+			"cache_write_1h_tokens": cache1h,
+		},
+	}
+	b, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return &store.Event{Payload: b}
+}
+
+// Ensure the GraphQL TokenUsage struct shape stays in sync with what
+// the resolver maps to. If gqlgen regenerates and changes a field, this
+// catches the drift.
+func TestTokenUsageGraphQLShape(t *testing.T) {
+	want := []string{
+		"Vendor", "Model", "ServiceTier",
+		"InputTokens", "OutputTokens",
+		"CacheReadTokens", "CacheWrite5mTokens", "CacheWrite1hTokens",
+		"WebSearchCalls", "WebFetchCalls",
+	}
+	tt := reflect.TypeOf(TokenUsage{})
+	got := make([]string, 0, tt.NumField())
+	for i := 0; i < tt.NumField(); i++ {
+		got = append(got, tt.Field(i).Name)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("TokenUsage fields drifted:\ngot:  %v\nwant: %v", got, want)
+	}
+}

--- a/internal/query/models_gen.go
+++ b/internal/query/models_gen.go
@@ -78,6 +78,10 @@ type Session struct {
 // values (see Session.totalUsage docs). Cache and server-tool fields are
 // optional because some vendors (e.g. OpenAI) don't have a directly
 // comparable concept.
+//
+// The original verbatim vendor `usage` block is intentionally NOT
+// projected onto this typed surface — clients that need it for forensic
+// re-parse can read `Event.payload.usage.raw` from the JSON payload.
 type TokenUsage struct {
 	Vendor             string  `json:"vendor"`
 	Model              string  `json:"model"`

--- a/internal/query/models_gen.go
+++ b/internal/query/models_gen.go
@@ -30,6 +30,17 @@ type Event struct {
 	PrevHash  *string        `json:"prevHash,omitempty"`
 	// All links touching this event in either direction (from/to).
 	Links []*Link `json:"links"`
+	// Token usage of the assistant message that derived this event. Present
+	// only on events derived from a real-usage assistant message (per ADR
+	// 0002 D3, `<synthetic>` placeholders and all-zero messages return
+	// null). The carrier event per message is the first text block, then
+	// the first thinking block, then a synthesized stub — so usage never
+	// double-counts in turn / session aggregation.
+	Usage *TokenUsage `json:"usage,omitempty"`
+	// Reason the model stopped on the message that derived this event:
+	// `end_turn`, `tool_use`, `stop_sequence`, etc. Sourced verbatim from
+	// the Anthropic transcript `message.stop_reason` field.
+	StopReason *string `json:"stopReason,omitempty"`
 }
 
 type Link struct {
@@ -49,6 +60,35 @@ type Session struct {
 	FirstEventAt time.Time `json:"firstEventAt"`
 	LastEventAt  time.Time `json:"lastEventAt"`
 	EventCount   int       `json:"eventCount"`
+	// Aggregate token usage across every event in this session that has
+	// `usage`. Numeric counters (input/output/cache_read/cache_write) are
+	// exact sums. Non-numeric fields summarize: `vendor` is the dominant
+	// value (or empty if mixed); `model` is empty when more than one model
+	// appeared (multi-model sessions), else the single model id;
+	// `serviceTier` likewise. Returns null when no event in the session
+	// carries usage.
+	TotalUsage *TokenUsage `json:"totalUsage,omitempty"`
+}
+
+// Vendor-neutral token-counting shape per ADR 0002 D2. Per-event usage
+// exposes vendor / model / service_tier of the originating message.
+//
+// When returned as `Session.totalUsage`, only numeric counters aggregate
+// meaningfully; vendor / model / service_tier carry best-effort summary
+// values (see Session.totalUsage docs). Cache and server-tool fields are
+// optional because some vendors (e.g. OpenAI) don't have a directly
+// comparable concept.
+type TokenUsage struct {
+	Vendor             string  `json:"vendor"`
+	Model              string  `json:"model"`
+	ServiceTier        *string `json:"serviceTier,omitempty"`
+	InputTokens        int     `json:"inputTokens"`
+	OutputTokens       int     `json:"outputTokens"`
+	CacheReadTokens    *int    `json:"cacheReadTokens,omitempty"`
+	CacheWrite5mTokens *int    `json:"cacheWrite5mTokens,omitempty"`
+	CacheWrite1hTokens *int    `json:"cacheWrite1hTokens,omitempty"`
+	WebSearchCalls     *int    `json:"webSearchCalls,omitempty"`
+	WebFetchCalls      *int    `json:"webFetchCalls,omitempty"`
 }
 
 type ActorType string

--- a/internal/query/schema.graphql
+++ b/internal/query/schema.graphql
@@ -15,6 +15,44 @@ type Event {
   prevHash: String
   """All links touching this event in either direction (from/to)."""
   links: [Link!]!
+  """
+  Token usage of the assistant message that derived this event. Present
+  only on events derived from a real-usage assistant message (per ADR
+  0002 D3, `<synthetic>` placeholders and all-zero messages return
+  null). The carrier event per message is the first text block, then
+  the first thinking block, then a synthesized stub — so usage never
+  double-counts in turn / session aggregation.
+  """
+  usage: TokenUsage
+  """
+  Reason the model stopped on the message that derived this event:
+  `end_turn`, `tool_use`, `stop_sequence`, etc. Sourced verbatim from
+  the Anthropic transcript `message.stop_reason` field.
+  """
+  stopReason: String
+}
+
+"""
+Vendor-neutral token-counting shape per ADR 0002 D2. Per-event usage
+exposes vendor / model / service_tier of the originating message.
+
+When returned as `Session.totalUsage`, only numeric counters aggregate
+meaningfully; vendor / model / service_tier carry best-effort summary
+values (see Session.totalUsage docs). Cache and server-tool fields are
+optional because some vendors (e.g. OpenAI) don't have a directly
+comparable concept.
+"""
+type TokenUsage {
+  vendor: String!
+  model: String!
+  serviceTier: String
+  inputTokens: Int!
+  outputTokens: Int!
+  cacheReadTokens: Int
+  cacheWrite5mTokens: Int
+  cacheWrite1hTokens: Int
+  webSearchCalls: Int
+  webFetchCalls: Int
 }
 
 type Link {
@@ -59,6 +97,16 @@ type Session {
   firstEventAt: Time!
   lastEventAt: Time!
   eventCount: Int!
+  """
+  Aggregate token usage across every event in this session that has
+  `usage`. Numeric counters (input/output/cache_read/cache_write) are
+  exact sums. Non-numeric fields summarize: `vendor` is the dominant
+  value (or empty if mixed); `model` is empty when more than one model
+  appeared (multi-model sessions), else the single model id;
+  `serviceTier` likewise. Returns null when no event in the session
+  carries usage.
+  """
+  totalUsage: TokenUsage
 }
 
 type Query {

--- a/internal/query/schema.graphql
+++ b/internal/query/schema.graphql
@@ -41,6 +41,10 @@ meaningfully; vendor / model / service_tier carry best-effort summary
 values (see Session.totalUsage docs). Cache and server-tool fields are
 optional because some vendors (e.g. OpenAI) don't have a directly
 comparable concept.
+
+The original verbatim vendor `usage` block is intentionally NOT
+projected onto this typed surface — clients that need it for forensic
+re-parse can read `Event.payload.usage.raw` from the JSON payload.
 """
 type TokenUsage {
   vendor: String!

--- a/internal/query/schema.resolvers.go
+++ b/internal/query/schema.resolvers.go
@@ -30,6 +30,22 @@ func (r *eventResolver) Links(ctx context.Context, obj *Event) ([]*Link, error) 
 	return out, nil
 }
 
+// Usage is the resolver for the usage field.
+func (r *eventResolver) Usage(ctx context.Context, obj *Event) (*TokenUsage, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	return decodePayloadUsage(obj.Payload), nil
+}
+
+// StopReason is the resolver for the stopReason field.
+func (r *eventResolver) StopReason(ctx context.Context, obj *Event) (*string, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	return decodePayloadStopReason(obj.Payload), nil
+}
+
 // Event is the resolver for the event field.
 func (r *queryResolver) Event(ctx context.Context, id string) (*Event, error) {
 	se, err := r.Store.GetEvent(ctx, id)
@@ -193,11 +209,33 @@ func (r *queryResolver) LinkedEvents(ctx context.Context, sessionID string, dept
 	return out, nil
 }
 
+// TotalUsage is the resolver for the totalUsage field.
+//
+// Loads every event in the session (limit=0 → unlimited) and walks
+// payload.usage on each. Aggregation is in-Go rather than SQL so the
+// memory store works the same way as Postgres; pushing this to a SQL
+// `SUM()` is a future optimization once sessions push past tens of
+// thousands of events.
+func (r *sessionResolver) TotalUsage(ctx context.Context, obj *Session) (*TokenUsage, error) {
+	if obj == nil {
+		return nil, nil
+	}
+	events, err := r.Store.ListBySession(ctx, obj.ID, 0)
+	if err != nil {
+		return nil, err
+	}
+	return aggregateSessionUsage(events), nil
+}
+
 // Event returns EventResolver implementation.
 func (r *Resolver) Event() EventResolver { return &eventResolver{r} }
 
 // Query returns QueryResolver implementation.
 func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
+// Session returns SessionResolver implementation.
+func (r *Resolver) Session() SessionResolver { return &sessionResolver{r} }
+
 type eventResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
+type sessionResolver struct{ *Resolver }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -30,6 +30,12 @@ export const sessionsQuery = `
       firstEventAt
       lastEventAt
       eventCount
+      totalUsage {
+        vendor model serviceTier
+        inputTokens outputTokens
+        cacheReadTokens cacheWrite5mTokens cacheWrite1hTokens
+        webSearchCalls webFetchCalls
+      }
     }
   }
 `;
@@ -49,6 +55,13 @@ export const eventsQuery = `
       hash
       prevHash
       links { fromEvent toEvent relation inferredBy }
+      usage {
+        vendor model serviceTier
+        inputTokens outputTokens
+        cacheReadTokens cacheWrite5mTokens cacheWrite1hTokens
+        webSearchCalls webFetchCalls
+      }
+      stopReason
     }
     sessionHead(sessionId: $sessionId)
   }
@@ -72,6 +85,13 @@ export const linkedEventsQuery = `
       hash
       prevHash
       links { fromEvent toEvent relation inferredBy }
+      usage {
+        vendor model serviceTier
+        inputTokens outputTokens
+        cacheReadTokens cacheWrite5mTokens cacheWrite1hTokens
+        webSearchCalls webFetchCalls
+      }
+      stopReason
     }
   }
 `;

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useMemo, useState } from "react";
 import type { Event } from "../types";
 import { styleFor, formatTimestamp } from "./kindStyle";
 import { payloadToDiff } from "../lib/payloadToDiff";
+import { compactNum, tokenUsageTooltip } from "../lib/tokenUsage";
 
 // React.lazy keeps the ~600 KB Monaco bundle out of the eager chunk:
 // users who never expand a diff never pay for it. The dynamic import
@@ -79,6 +80,25 @@ export function EventCard({ event }: { event: Event }) {
                 </span>
               ) : null;
             })()}
+            {event.usage && (
+              <span
+                className="inline-flex items-center gap-1 rounded bg-violet-50 px-1.5 py-0.5 text-[10px] font-medium text-violet-900 ring-1 ring-violet-200 font-mono"
+                title={tokenUsageTooltip(event.usage, event.stopReason)}
+              >
+                <span aria-hidden>↑</span>
+                <span>{compactNum(event.usage.inputTokens)}</span>
+                <span aria-hidden>↓</span>
+                <span>{compactNum(event.usage.outputTokens)}</span>
+                {event.usage.cacheReadTokens != null &&
+                  event.usage.cacheReadTokens > 0 && (
+                    <>
+                      <span className="text-violet-400">·</span>
+                      <span aria-label="cache read">◊</span>
+                      <span>{compactNum(event.usage.cacheReadTokens)}</span>
+                    </>
+                  )}
+              </span>
+            )}
             {event.links?.length > 0 && (
               <span
                 className="inline-flex items-center gap-0.5 rounded bg-white px-1.5 py-0.5 text-[10px] font-medium text-zinc-700 ring-1 ring-zinc-300"

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -2,11 +2,7 @@ import { lazy, Suspense, useMemo, useState } from "react";
 import type { Event } from "../types";
 import { styleFor, formatTimestamp } from "./kindStyle";
 import { payloadToDiff } from "../lib/payloadToDiff";
-import {
-  compactNum,
-  tokenUsageAriaLabel,
-  tokenUsageTooltip,
-} from "../lib/tokenUsage";
+import { TokenUsageChip } from "./TokenUsageChip";
 
 // React.lazy keeps the ~600 KB Monaco bundle out of the eager chunk:
 // users who never expand a diff never pay for it. The dynamic import
@@ -85,24 +81,10 @@ export function EventCard({ event }: { event: Event }) {
               ) : null;
             })()}
             {event.usage && (
-              <span
-                className="inline-flex items-center gap-1 rounded bg-violet-50 px-1.5 py-0.5 text-[10px] font-medium text-violet-900 ring-1 ring-violet-200 font-mono"
-                title={tokenUsageTooltip(event.usage, event.stopReason)}
-                aria-label={tokenUsageAriaLabel(event.usage)}
-              >
-                <span aria-hidden>↑</span>
-                <span>{compactNum(event.usage.inputTokens)}</span>
-                <span aria-hidden>↓</span>
-                <span>{compactNum(event.usage.outputTokens)}</span>
-                {event.usage.cacheReadTokens != null &&
-                  event.usage.cacheReadTokens > 0 && (
-                    <>
-                      <span className="text-violet-400">·</span>
-                      <span aria-label="cache read">◊</span>
-                      <span>{compactNum(event.usage.cacheReadTokens)}</span>
-                    </>
-                  )}
-              </span>
+              <TokenUsageChip
+                usage={event.usage}
+                stopReason={event.stopReason}
+              />
             )}
             {event.links?.length > 0 && (
               <span

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -2,7 +2,11 @@ import { lazy, Suspense, useMemo, useState } from "react";
 import type { Event } from "../types";
 import { styleFor, formatTimestamp } from "./kindStyle";
 import { payloadToDiff } from "../lib/payloadToDiff";
-import { compactNum, tokenUsageTooltip } from "../lib/tokenUsage";
+import {
+  compactNum,
+  tokenUsageAriaLabel,
+  tokenUsageTooltip,
+} from "../lib/tokenUsage";
 
 // React.lazy keeps the ~600 KB Monaco bundle out of the eager chunk:
 // users who never expand a diff never pay for it. The dynamic import
@@ -84,6 +88,7 @@ export function EventCard({ event }: { event: Event }) {
               <span
                 className="inline-flex items-center gap-1 rounded bg-violet-50 px-1.5 py-0.5 text-[10px] font-medium text-violet-900 ring-1 ring-violet-200 font-mono"
                 title={tokenUsageTooltip(event.usage, event.stopReason)}
+                aria-label={tokenUsageAriaLabel(event.usage)}
               >
                 <span aria-hidden>↑</span>
                 <span>{compactNum(event.usage.inputTokens)}</span>

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,7 +1,11 @@
 import { useQuery } from "@tanstack/react-query";
 import { gql, sessionsQuery } from "../api/client";
 import type { Session, SessionsResponse } from "../types";
-import { compactNum, tokenUsageTooltip } from "../lib/tokenUsage";
+import {
+  compactNum,
+  tokenUsageAriaLabel,
+  tokenUsageTooltip,
+} from "../lib/tokenUsage";
 
 export function SessionList({
   onSelect,
@@ -82,6 +86,9 @@ function SessionRow({
             <div
               className="inline-flex items-center gap-1 rounded bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-900 ring-1 ring-violet-200 font-mono"
               title={tokenUsageTooltip(session.totalUsage)}
+              aria-label={
+                "session total: " + tokenUsageAriaLabel(session.totalUsage)
+              }
             >
               <span aria-hidden>↑</span>
               <span>{compactNum(session.totalUsage.inputTokens)}</span>

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { gql, sessionsQuery } from "../api/client";
 import type { Session, SessionsResponse } from "../types";
+import { compactNum, tokenUsageTooltip } from "../lib/tokenUsage";
 
 export function SessionList({
   onSelect,
@@ -76,8 +77,30 @@ function SessionRow({
             {formatAbsolute(session.firstEventAt)}
           </div>
         </div>
-        <div className="shrink-0 rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-700">
-          {session.eventCount} {session.eventCount === 1 ? "event" : "events"}
+        <div className="flex shrink-0 items-center gap-2">
+          {session.totalUsage && (
+            <div
+              className="inline-flex items-center gap-1 rounded bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-900 ring-1 ring-violet-200 font-mono"
+              title={tokenUsageTooltip(session.totalUsage)}
+            >
+              <span aria-hidden>↑</span>
+              <span>{compactNum(session.totalUsage.inputTokens)}</span>
+              <span aria-hidden>↓</span>
+              <span>{compactNum(session.totalUsage.outputTokens)}</span>
+              {session.totalUsage.cacheReadTokens != null &&
+                session.totalUsage.cacheReadTokens > 0 && (
+                  <>
+                    <span className="text-violet-400">·</span>
+                    <span aria-label="cache read">◊</span>
+                    <span>{compactNum(session.totalUsage.cacheReadTokens)}</span>
+                  </>
+                )}
+            </div>
+          )}
+          <div className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-700">
+            {session.eventCount}{" "}
+            {session.eventCount === 1 ? "event" : "events"}
+          </div>
         </div>
       </button>
     </li>

--- a/web/src/components/SessionList.tsx
+++ b/web/src/components/SessionList.tsx
@@ -1,11 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { gql, sessionsQuery } from "../api/client";
 import type { Session, SessionsResponse } from "../types";
-import {
-  compactNum,
-  tokenUsageAriaLabel,
-  tokenUsageTooltip,
-} from "../lib/tokenUsage";
+import { TokenUsageChip } from "./TokenUsageChip";
 
 export function SessionList({
   onSelect,
@@ -83,26 +79,10 @@ function SessionRow({
         </div>
         <div className="flex shrink-0 items-center gap-2">
           {session.totalUsage && (
-            <div
-              className="inline-flex items-center gap-1 rounded bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-900 ring-1 ring-violet-200 font-mono"
-              title={tokenUsageTooltip(session.totalUsage)}
-              aria-label={
-                "session total: " + tokenUsageAriaLabel(session.totalUsage)
-              }
-            >
-              <span aria-hidden>↑</span>
-              <span>{compactNum(session.totalUsage.inputTokens)}</span>
-              <span aria-hidden>↓</span>
-              <span>{compactNum(session.totalUsage.outputTokens)}</span>
-              {session.totalUsage.cacheReadTokens != null &&
-                session.totalUsage.cacheReadTokens > 0 && (
-                  <>
-                    <span className="text-violet-400">·</span>
-                    <span aria-label="cache read">◊</span>
-                    <span>{compactNum(session.totalUsage.cacheReadTokens)}</span>
-                  </>
-                )}
-            </div>
+            <TokenUsageChip
+              usage={session.totalUsage}
+              ariaLabelPrefix="session total: "
+            />
           )}
           <div className="rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-700">
             {session.eventCount}{" "}

--- a/web/src/components/Timeline.tsx
+++ b/web/src/components/Timeline.tsx
@@ -4,7 +4,11 @@ import { gql, eventsQuery } from "../api/client";
 import type { Event, EventKind, EventsResponse, TokenUsage } from "../types";
 import { EventCard } from "./EventCard";
 import { styleFor } from "./kindStyle";
-import { compactNum, tokenUsageTooltip } from "../lib/tokenUsage";
+import {
+  compactNum,
+  tokenUsageAriaLabel,
+  tokenUsageTooltip,
+} from "../lib/tokenUsage";
 
 export function Timeline({ sessionId }: { sessionId: string }) {
   const [activeKinds, setActiveKinds] = useState<Set<EventKind>>(new Set());
@@ -76,6 +80,9 @@ export function Timeline({ sessionId }: { sessionId: string }) {
             <div
               className="inline-flex items-center gap-1 rounded bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-900 ring-1 ring-violet-200 font-mono"
               title={tokenUsageTooltip(usageTotal) + "\n\n(across fetched events; SessionList shows session truth-of-record)"}
+              aria-label={
+                "fetched-events total: " + tokenUsageAriaLabel(usageTotal)
+              }
             >
               <span aria-hidden>↑</span>
               <span>{compactNum(usageTotal.inputTokens)}</span>

--- a/web/src/components/Timeline.tsx
+++ b/web/src/components/Timeline.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { gql, eventsQuery } from "../api/client";
-import type { Event, EventKind, EventsResponse } from "../types";
+import type { Event, EventKind, EventsResponse, TokenUsage } from "../types";
 import { EventCard } from "./EventCard";
 import { styleFor } from "./kindStyle";
+import { compactNum, tokenUsageTooltip } from "../lib/tokenUsage";
 
 export function Timeline({ sessionId }: { sessionId: string }) {
   const [activeKinds, setActiveKinds] = useState<Set<EventKind>>(new Set());
@@ -16,6 +17,14 @@ export function Timeline({ sessionId }: { sessionId: string }) {
   });
 
   const counts = useMemo(() => countByKind(data?.events ?? []), [data?.events]);
+  // Partial-total: client aggregation across only the events fetched
+  // (limit=200). For sessions ≤ 200 events this is exact; for larger
+  // ones it under-counts. Truth-of-record `Session.totalUsage` is on
+  // the SessionList row.
+  const usageTotal = useMemo(
+    () => aggregateUsage(data?.events ?? []),
+    [data?.events],
+  );
 
   const visible = useMemo(() => {
     if (!data) return [];
@@ -63,6 +72,25 @@ export function Timeline({ sessionId }: { sessionId: string }) {
           <div className="text-xs text-zinc-500 font-mono">
             head {data.sessionHead ? data.sessionHead.slice(0, 16) : "(empty)"}
           </div>
+          {usageTotal && (
+            <div
+              className="inline-flex items-center gap-1 rounded bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-900 ring-1 ring-violet-200 font-mono"
+              title={tokenUsageTooltip(usageTotal) + "\n\n(across fetched events; SessionList shows session truth-of-record)"}
+            >
+              <span aria-hidden>↑</span>
+              <span>{compactNum(usageTotal.inputTokens)}</span>
+              <span aria-hidden>↓</span>
+              <span>{compactNum(usageTotal.outputTokens)}</span>
+              {usageTotal.cacheReadTokens != null &&
+                usageTotal.cacheReadTokens > 0 && (
+                  <>
+                    <span className="text-violet-400">·</span>
+                    <span aria-label="cache read">◊</span>
+                    <span>{compactNum(usageTotal.cacheReadTokens)}</span>
+                  </>
+                )}
+            </div>
+          )}
           {isFetching && (
             <div className="text-xs text-zinc-400">refreshing…</div>
           )}
@@ -160,4 +188,49 @@ function countByKind(events: Event[]): Partial<Record<EventKind, number>> {
     out[e.kind] = (out[e.kind] ?? 0) + 1;
   }
   return out;
+}
+
+// aggregateUsage sums per-message token counters across the events the
+// caller has on hand. Mirrors the server-side `aggregateSessionUsage`
+// shape but operates on already-fetched events; see Timeline's caveat
+// on partial totals.
+function aggregateUsage(events: Event[]): TokenUsage | null {
+  let any = false;
+  let inputT = 0;
+  let outputT = 0;
+  let cacheR = 0;
+  let cache5m = 0;
+  let cache1h = 0;
+  let webSearch = 0;
+  let webFetch = 0;
+  const vendors = new Set<string>();
+  const models = new Set<string>();
+  const tiers = new Set<string>();
+  for (const e of events) {
+    if (!e.usage) continue;
+    any = true;
+    inputT += e.usage.inputTokens;
+    outputT += e.usage.outputTokens;
+    if (e.usage.cacheReadTokens) cacheR += e.usage.cacheReadTokens;
+    if (e.usage.cacheWrite5mTokens) cache5m += e.usage.cacheWrite5mTokens;
+    if (e.usage.cacheWrite1hTokens) cache1h += e.usage.cacheWrite1hTokens;
+    if (e.usage.webSearchCalls) webSearch += e.usage.webSearchCalls;
+    if (e.usage.webFetchCalls) webFetch += e.usage.webFetchCalls;
+    if (e.usage.vendor) vendors.add(e.usage.vendor);
+    if (e.usage.model) models.add(e.usage.model);
+    if (e.usage.serviceTier) tiers.add(e.usage.serviceTier);
+  }
+  if (!any) return null;
+  return {
+    vendor: vendors.size === 1 ? [...vendors][0] : "",
+    model: models.size === 1 ? [...models][0] : "",
+    serviceTier: tiers.size === 1 ? [...tiers][0] : null,
+    inputTokens: inputT,
+    outputTokens: outputT,
+    cacheReadTokens: cacheR > 0 ? cacheR : null,
+    cacheWrite5mTokens: cache5m > 0 ? cache5m : null,
+    cacheWrite1hTokens: cache1h > 0 ? cache1h : null,
+    webSearchCalls: webSearch > 0 ? webSearch : null,
+    webFetchCalls: webFetch > 0 ? webFetch : null,
+  };
 }

--- a/web/src/components/Timeline.tsx
+++ b/web/src/components/Timeline.tsx
@@ -4,11 +4,7 @@ import { gql, eventsQuery } from "../api/client";
 import type { Event, EventKind, EventsResponse, TokenUsage } from "../types";
 import { EventCard } from "./EventCard";
 import { styleFor } from "./kindStyle";
-import {
-  compactNum,
-  tokenUsageAriaLabel,
-  tokenUsageTooltip,
-} from "../lib/tokenUsage";
+import { TokenUsageChip } from "./TokenUsageChip";
 
 export function Timeline({ sessionId }: { sessionId: string }) {
   const [activeKinds, setActiveKinds] = useState<Set<EventKind>>(new Set());
@@ -77,26 +73,11 @@ export function Timeline({ sessionId }: { sessionId: string }) {
             head {data.sessionHead ? data.sessionHead.slice(0, 16) : "(empty)"}
           </div>
           {usageTotal && (
-            <div
-              className="inline-flex items-center gap-1 rounded bg-violet-50 px-2 py-0.5 text-[11px] font-medium text-violet-900 ring-1 ring-violet-200 font-mono"
-              title={tokenUsageTooltip(usageTotal) + "\n\n(across fetched events; SessionList shows session truth-of-record)"}
-              aria-label={
-                "fetched-events total: " + tokenUsageAriaLabel(usageTotal)
-              }
-            >
-              <span aria-hidden>↑</span>
-              <span>{compactNum(usageTotal.inputTokens)}</span>
-              <span aria-hidden>↓</span>
-              <span>{compactNum(usageTotal.outputTokens)}</span>
-              {usageTotal.cacheReadTokens != null &&
-                usageTotal.cacheReadTokens > 0 && (
-                  <>
-                    <span className="text-violet-400">·</span>
-                    <span aria-label="cache read">◊</span>
-                    <span>{compactNum(usageTotal.cacheReadTokens)}</span>
-                  </>
-                )}
-            </div>
+            <TokenUsageChip
+              usage={usageTotal}
+              ariaLabelPrefix="fetched-events total: "
+              caveatNote="(across fetched events; SessionList shows session truth-of-record)"
+            />
           )}
           {isFetching && (
             <div className="text-xs text-zinc-400">refreshing…</div>

--- a/web/src/components/TokenUsageChip.tsx
+++ b/web/src/components/TokenUsageChip.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import { createPortal } from "react-dom";
+import type { TokenUsage } from "../types";
+import {
+  compactNum,
+  tokenUsageAriaLabel,
+  tokenUsageTooltip,
+} from "../lib/tokenUsage";
+
+// TokenUsageChip is the per-event / per-session violet token-count
+// pill plus its hover popup. Replaces the native `title` attribute
+// previously used inline at three call sites — that path had a
+// ~700 ms browser delay and reset on every micro-mouse-move, making
+// the audit breakdown feel sluggish or invisible.
+//
+// The popup is rendered to document.body via a portal so it can't be
+// clipped by ancestors with `overflow: hidden` (SessionList's row
+// container, Timeline's sticky header, etc.); position: fixed pegs it
+// to the cursor's viewport coordinates.
+export function TokenUsageChip({
+  usage,
+  stopReason,
+  ariaLabelPrefix,
+  caveatNote,
+}: {
+  usage: TokenUsage;
+  stopReason?: string | null;
+  /** Prepended to the screen-reader label, e.g. "session total: ". */
+  ariaLabelPrefix?: string;
+  /** Appended to the visible tooltip body, e.g. partial-total caveat. */
+  caveatNote?: string;
+}) {
+  const [hover, setHover] = useState<{ x: number; y: number } | null>(null);
+  const body = tokenUsageTooltip(usage, stopReason);
+  const tooltipText = caveatNote ? `${body}\n\n${caveatNote}` : body;
+  return (
+    <>
+      <span
+        onMouseEnter={(e) => setHover({ x: e.clientX, y: e.clientY })}
+        onMouseMove={(e) => setHover({ x: e.clientX, y: e.clientY })}
+        onMouseLeave={() => setHover(null)}
+        className="inline-flex items-center gap-1 rounded bg-violet-50 px-1.5 py-0.5 text-[10px] font-medium text-violet-900 ring-1 ring-violet-200 font-mono"
+        aria-label={(ariaLabelPrefix ?? "") + tokenUsageAriaLabel(usage)}
+      >
+        <span aria-hidden>↑</span>
+        <span>{compactNum(usage.inputTokens)}</span>
+        <span aria-hidden>↓</span>
+        <span>{compactNum(usage.outputTokens)}</span>
+        {usage.cacheReadTokens != null && usage.cacheReadTokens > 0 && (
+          <>
+            <span className="text-violet-400">·</span>
+            <span aria-label="cache read">◊</span>
+            <span>{compactNum(usage.cacheReadTokens)}</span>
+          </>
+        )}
+      </span>
+      {hover &&
+        createPortal(
+          <div
+            className="pointer-events-none fixed z-[9999] max-w-[320px] rounded bg-zinc-900 px-2 py-1.5 text-left text-[11px] text-white shadow-lg ring-1 ring-zinc-700"
+            style={{
+              left: hover.x + 14,
+              top: hover.y + 14,
+              wordBreak: "break-all",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {tooltipText}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/web/src/lib/tokenUsage.ts
+++ b/web/src/lib/tokenUsage.ts
@@ -23,6 +23,22 @@ export function compactNum(n: number | null | undefined): string {
   return `${(n / 1_000_000_000).toFixed(1)}B`;
 }
 
+// tokenUsageAriaLabel describes the chip in plain language for screen
+// readers — the visible chip uses arrows + symbols (`↑↓◊`) hidden via
+// `aria-hidden`, which would otherwise render as bare numbers without
+// context. Audit / compliance users may rely on assistive tech, so this
+// is load-bearing accessibility, not decoration.
+export function tokenUsageAriaLabel(usage: TokenUsage): string {
+  const parts = [
+    `input ${usage.inputTokens.toLocaleString()} tokens`,
+    `output ${usage.outputTokens.toLocaleString()} tokens`,
+  ];
+  if (usage.cacheReadTokens) {
+    parts.push(`cache read ${usage.cacheReadTokens.toLocaleString()} tokens`);
+  }
+  return parts.join(", ");
+}
+
 // tokenUsageTooltip builds the full breakdown shown when hovering over
 // the per-message token chip. Reads cleanly across two columns of
 // label/value, never folds cache_read into input (per ADR 0002 line 47:

--- a/web/src/lib/tokenUsage.ts
+++ b/web/src/lib/tokenUsage.ts
@@ -1,0 +1,61 @@
+import type { TokenUsage } from "../types";
+
+// compactNum renders a token count in a stable narrow format. We avoid
+// `Intl.NumberFormat` here so the chip width stays predictable across
+// locales (the audit chip is sized for 5-6 chars max).
+//
+//   123        →  "123"
+//   1_234      →  "1.2k"
+//   12_345     →  "12k"
+//   123_456    →  "123k"
+//   1_234_567  →  "1.2M"
+export function compactNum(n: number | null | undefined): string {
+  if (n == null) return "0";
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) {
+    return n < 10_000 ? `${(n / 1000).toFixed(1)}k` : `${Math.round(n / 1000)}k`;
+  }
+  if (n < 1_000_000_000) {
+    return n < 10_000_000
+      ? `${(n / 1_000_000).toFixed(1)}M`
+      : `${Math.round(n / 1_000_000)}M`;
+  }
+  return `${(n / 1_000_000_000).toFixed(1)}B`;
+}
+
+// tokenUsageTooltip builds the full breakdown shown when hovering over
+// the per-message token chip. Reads cleanly across two columns of
+// label/value, never folds cache_read into input (per ADR 0002 line 47:
+// hiding cache_read distorts audit dashboards by ~250×).
+export function tokenUsageTooltip(
+  usage: TokenUsage,
+  stopReason?: string | null,
+): string {
+  const lines: string[] = [];
+  if (usage.model) lines.push(`model: ${usage.model}`);
+  if (usage.serviceTier) lines.push(`tier: ${usage.serviceTier}`);
+  if (usage.vendor) lines.push(`vendor: ${usage.vendor}`);
+  if (lines.length > 0) lines.push("");
+  lines.push(`input:        ${usage.inputTokens.toLocaleString()}`);
+  lines.push(`output:       ${usage.outputTokens.toLocaleString()}`);
+  if (usage.cacheReadTokens) {
+    lines.push(`cache read:   ${usage.cacheReadTokens.toLocaleString()}`);
+  }
+  if (usage.cacheWrite5mTokens) {
+    lines.push(`cache write 5m: ${usage.cacheWrite5mTokens.toLocaleString()}`);
+  }
+  if (usage.cacheWrite1hTokens) {
+    lines.push(`cache write 1h: ${usage.cacheWrite1hTokens.toLocaleString()}`);
+  }
+  if (usage.webSearchCalls) {
+    lines.push(`web search:   ${usage.webSearchCalls}`);
+  }
+  if (usage.webFetchCalls) {
+    lines.push(`web fetch:    ${usage.webFetchCalls}`);
+  }
+  if (stopReason) {
+    lines.push("");
+    lines.push(`stop_reason: ${stopReason}`);
+  }
+  return lines.join("\n");
+}

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -29,6 +29,22 @@ export type Link = {
   inferredBy: string;
 };
 
+// Vendor-neutral token-counting shape. Mirrors the GraphQL `TokenUsage`
+// type — see ADR 0002. Optional fields use null over absence because
+// graphql-js renders missing/zero counters as null, not undefined.
+export type TokenUsage = {
+  vendor: string;
+  model: string;
+  serviceTier?: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number | null;
+  cacheWrite5mTokens?: number | null;
+  cacheWrite1hTokens?: number | null;
+  webSearchCalls?: number | null;
+  webFetchCalls?: number | null;
+};
+
 export type Event = {
   id: string;
   ts: string;
@@ -42,6 +58,8 @@ export type Event = {
   hash: string;
   prevHash?: string | null;
   links: Link[];
+  usage?: TokenUsage | null;
+  stopReason?: string | null;
 };
 
 export type EventsResponse = {
@@ -58,6 +76,7 @@ export type Session = {
   firstEventAt: string;
   lastEventAt: string;
   eventCount: number;
+  totalUsage?: TokenUsage | null;
 };
 
 export type SessionsResponse = {


### PR DESCRIPTION
Phase B of #57. Closes #57.

**Note**: re-opens [#64](https://github.com/dong-qiu/agent-lens/pull/64) — that PR was auto-closed by GitHub when its stacked base \`m3/token-usage-emission\` was deleted on the squash-merge of #63. Branch is the same, history rebased onto current main.

## Summary

- **GraphQL**: new \`TokenUsage\` type per ADR 0002 D2; \`Event.usage\`, \`Event.stopReason\`, \`Session.totalUsage\` resolvers (all field-resolved / lazy).
- **UI**: shared \`TokenUsageChip\` component renders the violet \`↑input ↓output · ◊cache_read\` pill plus an instant React-portal popup. Three call sites (EventCard, Timeline header, SessionList row) use the same component with variant-specific aria-label / caveat props.
- Native \`title\` attribute dropped — its ~700 ms browser delay made the audit breakdown feel laggy. Same root cause we fixed on the graph node tooltip in #61, simpler version (no ReactFlow d3-zoom complication).
- Aggregation in Go for backend parity (memory + Postgres). Multi-model sessions collapse vendor/model/service_tier to empty rather than picking arbitrarily. Cache-read rendered separately, never folded into input — per ADR 0002 line 47.

## Test plan

- [x] \`go test ./...\` clean (full suite, 9 unit tests in \`internal/query/mapper_test.go\`).
- [x] \`go vet ./...\` clean.
- [x] \`npx tsc --noEmit\` clean.
- [x] \`make gqlgen\` regenerates without diff (config locks new fields as resolver-backed).
- [x] Live GraphQL dogfood verify:
  - \`usage-verify-1777571863\` totalUsage = in:3042 out:1.69M cacheRead:706M cacheWrite1h:8.5M (matches SQL aggregation from #63)
  - Pre-#63 sessions return \`totalUsage: null\` cleanly
- [x] UI smoke: per-event chip + Timeline header band + SessionList row chip render correctly. Hover tooltip is instant, follows cursor with +14/+14 offset, doesn't get clipped by ancestor \`overflow: hidden\`.

## Self-review fixes already applied

Self-review pass (committed in this branch):
1. \`aria-label\` on all three chips (the symbol-only chip is opaque to screen readers)
2. Sync-points doc on \`wireUsage\` listing the four packages that need lock-step updates when adding a TokenUsage field
3. Schema doc note that \`payload.usage.raw\` remains accessible for forensic re-parse via the JSON \`payload\` field
4. Tooltip delivery rewritten via React portal to fix the ~700 ms native-\`title\` delay

Two follow-up issues opened:
- #65: \`Session.totalUsage\` N+1 + full-session load on every SessionList refetch
- #66: GraphQL integration test for usage round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)