### PR TITLE
feat(claude): /self-review skill + CLAUDE.md pointer

### DIFF
--- a/.claude/skills/self-review/SKILL.md
+++ b/.claude/skills/self-review/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: self-review
+description: Pre-merge self-review checklist for the agent-lens repo. Runs the mechanical pass automatically (git staging hygiene, codegen drift, tests, vet, typecheck, debug-marker scan) for the current branch, walks through judgment-pass prompts (hostile-reviewer view, "fine for v1" rationalizations, UX coverage), and recommends `/review` or `/ultrareview` escalation when the PR touches public schema or spans multiple packages. Always ends with an explicit "what this review did not cover" disclaimer so manual smoke gets handed off rather than implied. Use BEFORE submitting a self-review summary or before merging any PR. Triggers on `/self-review`, "self review", "ready to merge", "before merge", "pre-merge check".
+---
+
+# /self-review
+
+Pre-merge ritual codified from observed failure modes during ADR 0002 phase A/B (#63, #67) and the graph/chip tooltip work (#61, #67). Three passes plus a coverage disclaimer.
+
+The mechanical pass MUST run before any human-judgment review — past misses (codegen drift, `git add -A` sweeping ADR drafts) were all binary checks dressed up as judgment problems.
+
+## Phase 1 — mechanical pass (run automatically, gate on failure)
+
+Pull the change scope first, then run only the checks that apply:
+
+```bash
+# Confirm the PR scope and that staging is clean
+git status --short
+git log --oneline origin/main..HEAD
+CHANGED=$(git diff --name-only origin/main..HEAD)
+echo "$CHANGED"
+```
+
+Then, conditionally:
+
+| Trigger | Command | Pass criterion |
+|---|---|---|
+| Any `proto/*.proto` | `make proto && git diff --exit-code` | exit 0 |
+| Any `internal/query/schema.graphql` or `gqlgen.yml` | `make gqlgen && git diff --exit-code` | exit 0 |
+| Any `*.go` | `go test ./... -count=1 && go vet ./...` | both exit 0 |
+| Any `web/**/*.{ts,tsx,css}` | `(cd web && npx tsc --noEmit)` | exit 0 |
+| (always) | `git diff origin/main..HEAD \| grep -nE 'DEBUG\|console\.log\|debugger\|FIXME\|XXX'` | no matches |
+| (always) | `git status --short \| grep '^??'` | confirm any untracked files are intentionally NOT in the PR |
+
+Report each as ✅ or ❌ with exact context. **If any check fails, STOP and surface to the user — do not proceed to Phase 2.** Fixing a mechanical miss before the judgment pass keeps the two failure modes cleanly separated.
+
+## Phase 2 — judgment prompts (answer honestly, in writing)
+
+Walk through each prompt and produce a real answer; vague or absent answers are signal to look harder.
+
+1. **Hostile reviewer.** "If a reviewer who wanted to reject this PR read it, what would they catch?" Name at least one concrete concern, even if you'd defend it.
+
+2. **"Fine for v1" rationalizations.** Grep your own mental notes for "fine", "acceptable", "for now", "later", "v1", "good enough". Each occurrence resolves to either:
+   - (a) **fix in this PR** — change the implementation now, or
+   - (b) **open a follow-up issue** with explicit activation conditions ("revisit when X"), and link the issue from the PR description.
+
+   Leaving any as an unowned comment guarantees it's forgotten.
+
+3. **Comment-to-code ratio.** Find the longest comment in the diff. If it's longer than the code it documents, re-examine — over-long comments often signal unresolved confusion the author talked themselves into.
+
+4. **UX / visual / perception scope.** Does this PR change tooltip behavior, animation, layout, color contrast, or anything a user perceives? **Self-review does NOT cover these.** Flag explicitly for manual smoke and list the specific surfaces to test.
+
+## Phase 3 — external-view escalation
+
+Inspect the changed paths to decide whether to recommend a fresh-context second opinion:
+
+- Touches `internal/query/schema.graphql`, `proto/*.proto`, `cmd/*/main.go` (CLI surface), `internal/attest/*` (attestation predicates), or `internal/hashchain/*` (chain integrity): **recommend `/review`**.
+- Spans 3+ packages OR includes both Go backend and `web/`: **surface to the user about running `/ultrareview`** (it's user-triggered and billed; cannot be launched directly).
+
+For < 100 LOC single-concern PRs, mechanical + judgment passes are sufficient.
+
+## Phase 4 — coverage disclaimer (always output)
+
+End the self-review summary with an explicit "this review did not cover" list. Pick the categories that apply:
+
+- UX latency / animation / layout shift
+- Visual rendering / color / theming / dark mode
+- Load behavior / production scale (e.g., session size beyond dogfood)
+- Real-user data scenarios (i18n, very long IDs, edge inputs)
+
+Format: **"Manual smoke needed for: [...]"**. If genuinely none apply (pure backend / docs / tests / pure refactor), say so explicitly — silence is ambiguous.
+
+---
+
+## Why this skill exists (specific failure modes guarded)
+
+If a new class of miss recurs, add a phase-1 check for it.
+
+- **Codegen drift**: forgot `make gqlgen` after a `schema.graphql` doc-comment edit; CI rejected (#67). Mechanical, not judgment — phase 1's gqlgen check.
+- **`git add -A` trap**: three unrelated ADR drafts in untracked working tree got swept into a commit; required soft-reset + force-push. Phase 1 explicitly lists untracked files so you choose what to stage.
+- **UX-miss repetition**: 700 ms native-`title` tooltip delay was hit on graph node (#61), fixed via React state + portal, then **identically repeated** on token chip (#67) — same root cause, same fix, missed by self-review both times. Phase 2's UX prompt and Phase 4's coverage disclaimer push these onto manual smoke instead of pretending self-review covers them.
+- **"Fine for v1" orphan comments**: deferred trade-offs that aren't tracked become invisible. Phase 2 forces the resolve-or-ticket discipline that produced #58 / #62 / #65 / #66.
+
+## What this skill does NOT cover
+
+This skill enforces the *checklist*. It does not replace:
+
+- Manual UI smoke tests (run dev server, hover, click, watch latency, try keyboard nav).
+- Load or soak testing under production-like data volume.
+- The user's own validation on real dogfood — always preferred over self-claim of "looks good".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,29 +30,15 @@ These were settled during initial scoping and are referenced throughout `SPEC.md
 - Architecture decisions live in `docs/ADR/` (see `docs/ADR/README.md` for the SPEC vs ADR vs Patch mechanism). Accepted ADRs are append-only — propose a new ADR rather than editing one in place. Non-trivial design choices (new EventKind, schema change, irreversible tech selection) should land as a draft ADR before code.
 - Common commands are wired in the `Makefile`: `make build`, `make proto`, `make gqlgen`, `make test`, `make test-integration`, `make migrate-up`, `make compose-up`, `make web-dev`, `make web-build`. `make help` lists them all.
 
-## Self-review checklist before merge
+## Self-review before merge
 
-Self-review is the main quality gate in this repo. Two distinct failure modes to guard against — mechanical (CI catches them, but only after pushing) and judgment (CI can't catch; we have to). Treat them as separate passes.
+**Run `/self-review` before submitting any self-review summary or merging a PR.** The skill (in `.claude/skills/self-review/SKILL.md`) runs the mechanical pass automatically (git staging hygiene, codegen drift, tests, typecheck, debug-marker scan), walks the judgment-pass prompts, recommends `/review` or `/ultrareview` escalation when the PR warrants it, and ends with an explicit "what this review didn't cover" disclaimer.
 
-**Mechanical pass — run before every PR**:
-- `git status --short` — confirm only intended files are staged. Use `git add <paths>` rather than `git add -A` when there are untracked files in the working tree.
-- If the PR touches `proto/` or `internal/query/schema.graphql`: run `make proto && make gqlgen`. The `codegen drift` CI check will reject the PR otherwise.
-- `make test && go vet ./...`; for web changes, `(cd web && npx tsc --noEmit)`.
-- `git diff --cached` (or `git show HEAD` after committing) — visually scan for `DEBUG`, `console.log`, leftover stub comments, or `// TODO` you meant to resolve.
+The skill exists because passive checklists (this file alone) didn't prevent the failure modes that motivated it — codegen drift, accidental file inclusion, repeated UX misses. Mechanical hygiene is enforced by code that runs, not docs that have to be remembered.
 
-**Judgment pass — explicit prompts to challenge the implementation**:
-- "If a hostile reviewer wanted to reject this, what would they catch?"
-- "What did I write off as 'fine for v1' or 'acceptable trade-off'? Either fix in this PR or open a follow-up issue with explicit activation conditions — leaving it as an unowned comment guarantees it'll be forgotten."
-- "What's the longest comment I wrote? If it's longer than the code it documents, I probably wasn't sure — re-examine."
-- "Does the change have UX / visual / perception aspects (tooltip latency, animation, layout shift, color contrast)? **Self-review does NOT cover these** — flag explicitly and ask the user for manual smoke."
+**Self-review structurally cannot cover** UX latency, visual rendering, layout shift, or perception. Static analysis won't see a 700 ms tooltip delay or a misaligned chip. The skill surfaces these as explicit "manual smoke needed" handoffs to the user — not as items the review claims to subsume.
 
-**External view for non-trivial PRs**:
-- < 100 LOC, single concern: self-review + mechanical pass is enough.
-- Touches GraphQL schema / event payload shape / attestation predicates / public CLI flags: run `/review` for a fresh-context second opinion before submitting self-review.
-- Cross-stage or spans multiple packages: ask the user about running `/ultrareview`.
-
-**Post-merge calibration**:
-- If CI catches something self-review missed, the same mechanical check goes into the pre-flight pass next time. Add it here so the next contributor (or future-me) inherits the lesson.
+**Post-merge calibration**: if CI catches something `/self-review` missed, add a check to the skill's Phase 1. The next contributor (or future-me) inherits the lesson via skill update, not by reading docs.
 
 ## Local development with persistence
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,30 @@ These were settled during initial scoping and are referenced throughout `SPEC.md
 - Architecture decisions live in `docs/ADR/` (see `docs/ADR/README.md` for the SPEC vs ADR vs Patch mechanism). Accepted ADRs are append-only — propose a new ADR rather than editing one in place. Non-trivial design choices (new EventKind, schema change, irreversible tech selection) should land as a draft ADR before code.
 - Common commands are wired in the `Makefile`: `make build`, `make proto`, `make gqlgen`, `make test`, `make test-integration`, `make migrate-up`, `make compose-up`, `make web-dev`, `make web-build`. `make help` lists them all.
 
+## Self-review checklist before merge
+
+Self-review is the main quality gate in this repo. Two distinct failure modes to guard against — mechanical (CI catches them, but only after pushing) and judgment (CI can't catch; we have to). Treat them as separate passes.
+
+**Mechanical pass — run before every PR**:
+- `git status --short` — confirm only intended files are staged. Use `git add <paths>` rather than `git add -A` when there are untracked files in the working tree.
+- If the PR touches `proto/` or `internal/query/schema.graphql`: run `make proto && make gqlgen`. The `codegen drift` CI check will reject the PR otherwise.
+- `make test && go vet ./...`; for web changes, `(cd web && npx tsc --noEmit)`.
+- `git diff --cached` (or `git show HEAD` after committing) — visually scan for `DEBUG`, `console.log`, leftover stub comments, or `// TODO` you meant to resolve.
+
+**Judgment pass — explicit prompts to challenge the implementation**:
+- "If a hostile reviewer wanted to reject this, what would they catch?"
+- "What did I write off as 'fine for v1' or 'acceptable trade-off'? Either fix in this PR or open a follow-up issue with explicit activation conditions — leaving it as an unowned comment guarantees it'll be forgotten."
+- "What's the longest comment I wrote? If it's longer than the code it documents, I probably wasn't sure — re-examine."
+- "Does the change have UX / visual / perception aspects (tooltip latency, animation, layout shift, color contrast)? **Self-review does NOT cover these** — flag explicitly and ask the user for manual smoke."
+
+**External view for non-trivial PRs**:
+- < 100 LOC, single concern: self-review + mechanical pass is enough.
+- Touches GraphQL schema / event payload shape / attestation predicates / public CLI flags: run `/review` for a fresh-context second opinion before submitting self-review.
+- Cross-stage or spans multiple packages: ask the user about running `/ultrareview`.
+
+**Post-merge calibration**:
+- If CI catches something self-review missed, the same mechanical check goes into the pre-flight pass next time. Add it here so the next contributor (or future-me) inherits the lesson.
+
 ## Local development with persistence
 
 The collector defaults to `AGENT_LENS_STORE=postgres`. To run the dogfood loop with data that survives restarts:


### PR DESCRIPTION
Codifies the self-review process discipline as an active skill rather than a passive doc, motivated by failure modes observed during ADR 0002 phase A/B (#63, #67) and the graph/chip tooltip work (#61, #67).

## What's in this PR

- **`.claude/skills/self-review/SKILL.md`** — invokable as `/self-review`. Four phases:
  1. **Mechanical pass** (gated, stops on failure): \`git status\`, codegen drift via \`make proto\` / \`make gqlgen\` when \`proto/\` or \`schema.graphql\` is in the diff, \`go test ./... && go vet ./...\` for Go changes, \`(cd web && npx tsc --noEmit)\` for web, debug-marker scan.
  2. **Judgment pass** (explicit prompts): hostile-reviewer view, "fine for v1" → fix-now or follow-up issue with activation conditions, comment-to-code ratio, UX scope check.
  3. **External-view escalation**: detects schema / proto / CLI / attestation / hashchain touches → recommends \`/review\`; multi-package PRs → surfaces \`/ultrareview\` to user.
  4. **Coverage disclaimer**: always outputs a "manual smoke needed for: [...]" line so UX / visual / load aspects get handed off, never implied.

- **CLAUDE.md** — rewritten to point at the skill instead of duplicating the checklist. Keeps the structural disclaimer (self-review can't cover UX) in human-readable docs.

## Why active over passive

Three concrete failure modes during the work that motivated this happened *with* a docs-only checklist visible:

1. **Codegen drift** (#67) — forgot \`make gqlgen\` after \`schema.graphql\` doc-comment edit; CI rejected. Mechanical, binary.
2. **\`git add -A\` trap** (#67) — three unrelated ADR drafts in untracked working tree got swept into a commit; required soft-reset + force-push.
3. **UX-miss repetition** (#61 → #67) — 700 ms native-\`title\` tooltip delay was hit on graph node, fixed via React state + portal, then **identically repeated** on token chip. Same root cause, same fix, missed by self-review both times.

The issue was never "didn't know what to check" but "didn't think to check". A skill invocation forces the ritual; a doc has to be remembered.

## Test plan

- [x] CLAUDE.md and SKILL.md render cleanly.
- [x] No code changes — pure docs + skill definition.
- [ ] Apply on the next non-trivial PR (e.g. follow-ups for #65 or #66) and verify the mechanical pass surfaces the right checks for the changed scope.
- [ ] Verify \`/self-review\` is discoverable as a slash command in a fresh conversation in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)