### PR TITLE
chore: ignore .claude/{settings.local.json,worktrees/}

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ deploy/compose/.data/
 
 # Backups
 /backups/
+
+# Claude Code runtime (per-developer; never commit)
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## Summary

Two `.claude/` runtime paths weren't being ignored by the repo's own `.gitignore`:

- **`.claude/settings.local.json`** — `script/install-dogfood.sh` writes this per-developer file and its comment claims "gitignore 命中", but the repo's `.gitignore` has no matching rule. The pattern `*.local` matches files with `.local` extension, not files containing `.local` mid-name (i.e. `settings.local.json` ends in `.json`, not `.local`). The file is currently only ignored via individual users' global `~/.config/git/ignore` — fragile.
- **`.claude/worktrees/`** — the runtime path Claude Code creates when an agent uses `isolation: "worktree"`. Discovered post-merge of #69 (the ADR 0006 worktree showed as untracked in the main worktree).

Both should never be committed.

## Why exact paths instead of `.claude/*` with negate

`.claude/skills/` and `.claude/settings.example.json` are project-shared and intentionally tracked. An exact-path approach avoids the surprise of a future tracked file getting accidentally ignored.

## Test plan

- [x] `git check-ignore -v` confirms both paths now match repo `.gitignore` (lines 38-39), not just user-global config
- [x] `git status` clean after change (no other side-effects)
- [x] `.claude/settings.example.json` and `.claude/skills/` remain tracked