### PR TITLE
chore(v0.1): foundation — Apache-2.0 + module rename + README status

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Support. While redistributing the Work or
+      Derivative Works thereof, You may accept and charge a fee for,
+      acceptance of support, warranty, indemnity, or other liability
+      obligations and/or rights consistent with this License. However,
+      in accepting such obligations, You may act only on Your own
+      behalf and on Your sole responsibility, not on behalf of any other
+      Contributor, and only if You agree to indemnify, defend, and hold
+      each Contributor harmless for any liability incurred by, or claims
+      asserted against, such Contributor by reason of your accepting any
+      such warranty or support.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same page as the copyright notice for easier identification within
+      third-party archives.
+
+   Copyright 2026 Dong Qiu
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing permissions
+   and limitations under the License.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## 状态
 
-M1 开发中。后端 + hook + GraphQL 已就绪并有测试覆盖，UI 时间线视图已落第一版。线上 dogfood 计划在 M3 完成后激活（SPEC §17）。
+M1–M3 已交付，§17 dogfood 已激活——本仓库自身就是首个使用者。v0.1.0 personal-mode 发布筹备中（详见 [`docs/ADR/0006-release-and-distribution-v0.1.md`](./docs/ADR/0006-release-and-distribution-v0.1.md)）；当前安装路径仍是 build-from-source（见 §"一次跑通"）。Team mode、Helm chart、Windows、PR Review Bot outbound 等不在 v0.1 范围。
 
 ## 一次跑通
 
@@ -333,10 +333,6 @@ agent-lens-hook verify-audit-report my-trace.json
 - **GitHub webhook 回路**：要把 PR / push / workflow_run 也接进来，需要把本机服务通过隧道（ngrok / cloudflared）暴露到公网，再在 `dong-qiu/agent-lens` 仓库设置里挂 webhook。这一步 SPEC §17 没强制；按需做。
 - **Project 模型**：v0 没有"项目"抽象，session_id 前缀（`claude-code:` / `github-pr:` / `deploy:` ...）已经天然分隔。多项目共用一个 store 时再补 project 维度。
 
-## 模块名
-
-`go.mod` 的 `github.com/dongqiu/agent-lens` 是占位。落定 GitHub 组织后用 `go mod edit -module <new>` 替换。
-
 ## 许可
 
-待定。
+Apache License 2.0。详见 [`LICENSE`](./LICENSE)。

--- a/cmd/agent-lens-hook/audit_report.go
+++ b/cmd/agent-lens-hook/audit_report.go
@@ -12,8 +12,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dongqiu/agent-lens/internal/attest"
-	"github.com/dongqiu/agent-lens/internal/audit"
+	"github.com/dong-qiu/agent-lens/internal/attest"
+	"github.com/dong-qiu/agent-lens/internal/audit"
 )
 
 const auditReportUsage = `agent-lens-hook export audit-report — bundle the

--- a/cmd/agent-lens-hook/audit_report_test.go
+++ b/cmd/agent-lens-hook/audit_report_test.go
@@ -13,12 +13,12 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/dongqiu/agent-lens/internal/attest"
-	"github.com/dongqiu/agent-lens/internal/audit"
-	"github.com/dongqiu/agent-lens/internal/ingest"
-	"github.com/dongqiu/agent-lens/internal/linking"
-	"github.com/dongqiu/agent-lens/internal/query"
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/attest"
+	"github.com/dong-qiu/agent-lens/internal/audit"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/linking"
+	"github.com/dong-qiu/agent-lens/internal/query"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 // startHookTestServer mirrors internal/audit.startTestServer but lives

--- a/cmd/agent-lens-hook/claude.go
+++ b/cmd/agent-lens-hook/claude.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/dongqiu/agent-lens/internal/transcript"
+	"github.com/dong-qiu/agent-lens/internal/transcript"
 )
 
 // claudeHookInput captures the fields we read from a Claude Code hook

--- a/cmd/agent-lens-hook/export.go
+++ b/cmd/agent-lens-hook/export.go
@@ -13,7 +13,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/dongqiu/agent-lens/internal/attest"
+	"github.com/dong-qiu/agent-lens/internal/attest"
 )
 
 const exportUsage = `agent-lens-hook export — export an in-toto / SLSA attestation

--- a/cmd/agent-lens-hook/export_test.go
+++ b/cmd/agent-lens-hook/export_test.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/dongqiu/agent-lens/internal/attest"
-	"github.com/dongqiu/agent-lens/internal/ingest"
-	"github.com/dongqiu/agent-lens/internal/query"
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/attest"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/query"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 // TestExportCodeProvenanceEndToEnd posts realistic AI-side events

--- a/cmd/agent-lens-hook/keygen.go
+++ b/cmd/agent-lens-hook/keygen.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/dongqiu/agent-lens/internal/attest"
+	"github.com/dong-qiu/agent-lens/internal/attest"
 )
 
 const keygenUsage = `agent-lens-hook keygen — generate an ed25519 key pair for

--- a/cmd/agent-lens-hook/verify_attestation.go
+++ b/cmd/agent-lens-hook/verify_attestation.go
@@ -11,7 +11,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/dongqiu/agent-lens/internal/attest"
+	"github.com/dong-qiu/agent-lens/internal/attest"
 )
 
 const verifyAttestationUsage = `agent-lens-hook verify-attestation — verify a

--- a/cmd/agent-lens-hook/verify_attestation_test.go
+++ b/cmd/agent-lens-hook/verify_attestation_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dongqiu/agent-lens/internal/attest"
+	"github.com/dong-qiu/agent-lens/internal/attest"
 )
 
 // writeSignedEnvelope signs a tiny in-toto Statement with priv, dumps

--- a/cmd/agent-lens-hook/verify_test.go
+++ b/cmd/agent-lens-hook/verify_test.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/dongqiu/agent-lens/internal/ingest"
-	"github.com/dongqiu/agent-lens/internal/query"
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/query"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 // fakeGQL is a tiny stand-in that decodes the verify query, looks the

--- a/cmd/agent-lens/main.go
+++ b/cmd/agent-lens/main.go
@@ -14,13 +14,13 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 
-	"github.com/dongqiu/agent-lens/internal/auth"
-	"github.com/dongqiu/agent-lens/internal/ingest"
-	"github.com/dongqiu/agent-lens/internal/linking"
-	"github.com/dongqiu/agent-lens/internal/query"
-	"github.com/dongqiu/agent-lens/internal/store"
-	deploywh "github.com/dongqiu/agent-lens/internal/webhooks/deploy"
-	githubwh "github.com/dongqiu/agent-lens/internal/webhooks/github"
+	"github.com/dong-qiu/agent-lens/internal/auth"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/linking"
+	"github.com/dong-qiu/agent-lens/internal/query"
+	"github.com/dong-qiu/agent-lens/internal/store"
+	deploywh "github.com/dong-qiu/agent-lens/internal/webhooks/deploy"
+	githubwh "github.com/dong-qiu/agent-lens/internal/webhooks/github"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/dongqiu/agent-lens
+module github.com/dong-qiu/agent-lens
 
 go 1.25.0
 

--- a/internal/audit/builder_test.go
+++ b/internal/audit/builder_test.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/dongqiu/agent-lens/internal/ingest"
-	"github.com/dongqiu/agent-lens/internal/linking"
-	"github.com/dongqiu/agent-lens/internal/query"
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/linking"
+	"github.com/dong-qiu/agent-lens/internal/query"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 // startTestServer wires ingest + query + linking against an in-memory

--- a/internal/audit/verify.go
+++ b/internal/audit/verify.go
@@ -9,7 +9,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/dongqiu/agent-lens/internal/attest"
+	"github.com/dong-qiu/agent-lens/internal/attest"
 )
 
 // DecodeReport unmarshals a report file with UseNumber so payload

--- a/internal/audit/verify_test.go
+++ b/internal/audit/verify_test.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/dongqiu/agent-lens/internal/attest"
+	"github.com/dong-qiu/agent-lens/internal/attest"
 )
 
 // makeReport returns a tiny, internally-consistent Report that

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -27,8 +27,8 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/oklog/ulid/v2"
 
-	"github.com/dongqiu/agent-lens/internal/hashchain"
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/hashchain"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 var (

--- a/internal/ingest/handler_test.go
+++ b/internal/ingest/handler_test.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 func TestIngestHappyPath(t *testing.T) {

--- a/internal/linking/linker.go
+++ b/internal/linking/linker.go
@@ -16,8 +16,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/dongqiu/agent-lens/internal/ingest"
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 // DefaultRelation is the fallback when InferRelation has no specific

--- a/internal/linking/linker_test.go
+++ b/internal/linking/linker_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dongqiu/agent-lens/internal/ingest"
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 func appendEvent(t *testing.T, st store.Store, id string, refs []string) {

--- a/internal/pb/artifact.pb.go
+++ b/internal/pb/artifact.pb.go
@@ -173,7 +173,7 @@ const file_artifact_proto_rawDesc = "" +
 	"\x13ARTIFACT_TYPE_IMAGE\x10\x04\x12\x1d\n" +
 	"\x19ARTIFACT_TYPE_TEST_REPORT\x10\x05\x12\x1b\n" +
 	"\x17ARTIFACT_TYPE_BUILD_LOG\x10\x06\x12\x1f\n" +
-	"\x1bARTIFACT_TYPE_DEPLOY_RECORD\x10\aB.Z,github.com/dongqiu/agent-lens/internal/pb;pbb\x06proto3"
+	"\x1bARTIFACT_TYPE_DEPLOY_RECORD\x10\aB/Z-github.com/dong-qiu/agent-lens/internal/pb;pbb\x06proto3"
 
 var (
 	file_artifact_proto_rawDescOnce sync.Once

--- a/internal/pb/event.pb.go
+++ b/internal/pb/event.pb.go
@@ -395,7 +395,7 @@ const file_event_proto_rawDesc = "" +
 	"\x12\x15\n" +
 	"\x11EVENT_KIND_REVIEW\x10\v\x12\x17\n" +
 	"\x13EVENT_KIND_DECISION\x10\f\x12\x13\n" +
-	"\x0fEVENT_KIND_PUSH\x10\rB.Z,github.com/dongqiu/agent-lens/internal/pb;pbb\x06proto3"
+	"\x0fEVENT_KIND_PUSH\x10\rB/Z-github.com/dong-qiu/agent-lens/internal/pb;pbb\x06proto3"
 
 var (
 	file_event_proto_rawDescOnce sync.Once

--- a/internal/pb/link.pb.go
+++ b/internal/pb/link.pb.go
@@ -180,7 +180,7 @@ const file_link_proto_rawDesc = "" +
 	"\x13RELATION_REFERENCES\x10\x02\x12\x14\n" +
 	"\x10RELATION_REVIEWS\x10\x03\x12\x13\n" +
 	"\x0fRELATION_BUILDS\x10\x04\x12\x14\n" +
-	"\x10RELATION_DEPLOYS\x10\x05B.Z,github.com/dongqiu/agent-lens/internal/pb;pbb\x06proto3"
+	"\x10RELATION_DEPLOYS\x10\x05B/Z-github.com/dong-qiu/agent-lens/internal/pb;pbb\x06proto3"
 
 var (
 	file_link_proto_rawDescOnce sync.Once

--- a/internal/query/generated.go
+++ b/internal/query/generated.go
@@ -912,7 +912,7 @@ func (ec *executionContext) _Actor_type(ctx context.Context, field graphql.Colle
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v ActorType) graphql.Marshaler {
-			return ec.marshalNActorType2githubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐActorType(ctx, selections, v)
+			return ec.marshalNActorType2githubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐActorType(ctx, selections, v)
 		},
 		true,
 		true,
@@ -1073,7 +1073,7 @@ func (ec *executionContext) _Event_actor(ctx context.Context, field graphql.Coll
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *Actor) graphql.Marshaler {
-			return ec.marshalNActor2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐActor(ctx, selections, v)
+			return ec.marshalNActor2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐActor(ctx, selections, v)
 		},
 		true,
 		true,
@@ -1105,7 +1105,7 @@ func (ec *executionContext) _Event_kind(ctx context.Context, field graphql.Colle
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v EventKind) graphql.Marshaler {
-			return ec.marshalNEventKind2githubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventKind(ctx, selections, v)
+			return ec.marshalNEventKind2githubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventKind(ctx, selections, v)
 		},
 		true,
 		true,
@@ -1243,7 +1243,7 @@ func (ec *executionContext) _Event_links(ctx context.Context, field graphql.Coll
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v []*Link) graphql.Marshaler {
-			return ec.marshalNLink2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐLinkᚄ(ctx, selections, v)
+			return ec.marshalNLink2ᚕᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐLinkᚄ(ctx, selections, v)
 		},
 		true,
 		true,
@@ -1275,7 +1275,7 @@ func (ec *executionContext) _Event_usage(ctx context.Context, field graphql.Coll
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *TokenUsage) graphql.Marshaler {
-			return ec.marshalOTokenUsage2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐTokenUsage(ctx, selections, v)
+			return ec.marshalOTokenUsage2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐTokenUsage(ctx, selections, v)
 		},
 		true,
 		false,
@@ -1446,7 +1446,7 @@ func (ec *executionContext) _Query_event(ctx context.Context, field graphql.Coll
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *Event) graphql.Marshaler {
-			return ec.marshalOEvent2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐEvent(ctx, selections, v)
+			return ec.marshalOEvent2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐEvent(ctx, selections, v)
 		},
 		true,
 		false,
@@ -1490,7 +1490,7 @@ func (ec *executionContext) _Query_events(ctx context.Context, field graphql.Col
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v []*Event) graphql.Marshaler {
-			return ec.marshalNEvent2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventᚄ(ctx, selections, v)
+			return ec.marshalNEvent2ᚕᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventᚄ(ctx, selections, v)
 		},
 		true,
 		true,
@@ -1578,7 +1578,7 @@ func (ec *executionContext) _Query_sessions(ctx context.Context, field graphql.C
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v []*Session) graphql.Marshaler {
-			return ec.marshalNSession2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐSessionᚄ(ctx, selections, v)
+			return ec.marshalNSession2ᚕᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐSessionᚄ(ctx, selections, v)
 		},
 		true,
 		true,
@@ -1622,7 +1622,7 @@ func (ec *executionContext) _Query_linkedEvents(ctx context.Context, field graph
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v []*Event) graphql.Marshaler {
-			return ec.marshalNEvent2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventᚄ(ctx, selections, v)
+			return ec.marshalNEvent2ᚕᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventᚄ(ctx, selections, v)
 		},
 		true,
 		true,
@@ -1833,7 +1833,7 @@ func (ec *executionContext) _Session_totalUsage(ctx context.Context, field graph
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *TokenUsage) graphql.Marshaler {
-			return ec.marshalOTokenUsage2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐTokenUsage(ctx, selections, v)
+			return ec.marshalOTokenUsage2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐTokenUsage(ctx, selections, v)
 		},
 		true,
 		false,
@@ -4081,7 +4081,7 @@ func (ec *executionContext) ___Type(ctx context.Context, sel ast.SelectionSet, o
 
 // region    ***************************** type.gotpl *****************************
 
-func (ec *executionContext) marshalNActor2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐActor(ctx context.Context, sel ast.SelectionSet, v *Actor) graphql.Marshaler {
+func (ec *executionContext) marshalNActor2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐActor(ctx context.Context, sel ast.SelectionSet, v *Actor) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
@@ -4091,13 +4091,13 @@ func (ec *executionContext) marshalNActor2ᚖgithubᚗcomᚋdongqiuᚋagentᚑle
 	return ec._Actor(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNActorType2githubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐActorType(ctx context.Context, v any) (ActorType, error) {
+func (ec *executionContext) unmarshalNActorType2githubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐActorType(ctx context.Context, v any) (ActorType, error) {
 	var res ActorType
 	err := res.UnmarshalGQL(v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNActorType2githubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐActorType(ctx context.Context, sel ast.SelectionSet, v ActorType) graphql.Marshaler {
+func (ec *executionContext) marshalNActorType2githubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐActorType(ctx context.Context, sel ast.SelectionSet, v ActorType) graphql.Marshaler {
 	return v
 }
 
@@ -4117,11 +4117,11 @@ func (ec *executionContext) marshalNBoolean2bool(ctx context.Context, sel ast.Se
 	return res
 }
 
-func (ec *executionContext) marshalNEvent2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventᚄ(ctx context.Context, sel ast.SelectionSet, v []*Event) graphql.Marshaler {
+func (ec *executionContext) marshalNEvent2ᚕᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventᚄ(ctx context.Context, sel ast.SelectionSet, v []*Event) graphql.Marshaler {
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
 		fc.Result = &v[i]
-		return ec.marshalNEvent2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐEvent(ctx, sel, v[i])
+		return ec.marshalNEvent2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐEvent(ctx, sel, v[i])
 	})
 
 	for _, e := range ret {
@@ -4133,7 +4133,7 @@ func (ec *executionContext) marshalNEvent2ᚕᚖgithubᚗcomᚋdongqiuᚋagent�
 	return ret
 }
 
-func (ec *executionContext) marshalNEvent2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐEvent(ctx context.Context, sel ast.SelectionSet, v *Event) graphql.Marshaler {
+func (ec *executionContext) marshalNEvent2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐEvent(ctx context.Context, sel ast.SelectionSet, v *Event) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
@@ -4143,13 +4143,13 @@ func (ec *executionContext) marshalNEvent2ᚖgithubᚗcomᚋdongqiuᚋagentᚑle
 	return ec._Event(ctx, sel, v)
 }
 
-func (ec *executionContext) unmarshalNEventKind2githubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventKind(ctx context.Context, v any) (EventKind, error) {
+func (ec *executionContext) unmarshalNEventKind2githubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventKind(ctx context.Context, v any) (EventKind, error) {
 	var res EventKind
 	err := res.UnmarshalGQL(v)
 	return res, graphql.ErrorOnPath(ctx, err)
 }
 
-func (ec *executionContext) marshalNEventKind2githubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventKind(ctx context.Context, sel ast.SelectionSet, v EventKind) graphql.Marshaler {
+func (ec *executionContext) marshalNEventKind2githubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐEventKind(ctx context.Context, sel ast.SelectionSet, v EventKind) graphql.Marshaler {
 	return v
 }
 
@@ -4231,11 +4231,11 @@ func (ec *executionContext) marshalNInt2int(ctx context.Context, sel ast.Selecti
 	return res
 }
 
-func (ec *executionContext) marshalNLink2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐLinkᚄ(ctx context.Context, sel ast.SelectionSet, v []*Link) graphql.Marshaler {
+func (ec *executionContext) marshalNLink2ᚕᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐLinkᚄ(ctx context.Context, sel ast.SelectionSet, v []*Link) graphql.Marshaler {
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
 		fc.Result = &v[i]
-		return ec.marshalNLink2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐLink(ctx, sel, v[i])
+		return ec.marshalNLink2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐLink(ctx, sel, v[i])
 	})
 
 	for _, e := range ret {
@@ -4247,7 +4247,7 @@ func (ec *executionContext) marshalNLink2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑ
 	return ret
 }
 
-func (ec *executionContext) marshalNLink2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐLink(ctx context.Context, sel ast.SelectionSet, v *Link) graphql.Marshaler {
+func (ec *executionContext) marshalNLink2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐLink(ctx context.Context, sel ast.SelectionSet, v *Link) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
@@ -4257,11 +4257,11 @@ func (ec *executionContext) marshalNLink2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlen
 	return ec._Link(ctx, sel, v)
 }
 
-func (ec *executionContext) marshalNSession2ᚕᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐSessionᚄ(ctx context.Context, sel ast.SelectionSet, v []*Session) graphql.Marshaler {
+func (ec *executionContext) marshalNSession2ᚕᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐSessionᚄ(ctx context.Context, sel ast.SelectionSet, v []*Session) graphql.Marshaler {
 	ret := graphql.MarshalSliceConcurrently(ctx, len(v), 0, false, func(ctx context.Context, i int) graphql.Marshaler {
 		fc := graphql.GetFieldContext(ctx)
 		fc.Result = &v[i]
-		return ec.marshalNSession2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐSession(ctx, sel, v[i])
+		return ec.marshalNSession2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐSession(ctx, sel, v[i])
 	})
 
 	for _, e := range ret {
@@ -4273,7 +4273,7 @@ func (ec *executionContext) marshalNSession2ᚕᚖgithubᚗcomᚋdongqiuᚋagent
 	return ret
 }
 
-func (ec *executionContext) marshalNSession2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐSession(ctx context.Context, sel ast.SelectionSet, v *Session) graphql.Marshaler {
+func (ec *executionContext) marshalNSession2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐSession(ctx context.Context, sel ast.SelectionSet, v *Session) graphql.Marshaler {
 	if v == nil {
 		if !graphql.HasFieldError(ctx, graphql.GetFieldContext(ctx)) {
 			graphql.AddErrorf(ctx, "the requested element is null which the schema does not allow")
@@ -4486,7 +4486,7 @@ func (ec *executionContext) marshalOBoolean2ᚖbool(ctx context.Context, sel ast
 	return res
 }
 
-func (ec *executionContext) marshalOEvent2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐEvent(ctx context.Context, sel ast.SelectionSet, v *Event) graphql.Marshaler {
+func (ec *executionContext) marshalOEvent2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐEvent(ctx context.Context, sel ast.SelectionSet, v *Event) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}
@@ -4565,7 +4565,7 @@ func (ec *executionContext) marshalOTime2ᚖtimeᚐTime(ctx context.Context, sel
 	return res
 }
 
-func (ec *executionContext) marshalOTokenUsage2ᚖgithubᚗcomᚋdongqiuᚋagentᚑlensᚋinternalᚋqueryᚐTokenUsage(ctx context.Context, sel ast.SelectionSet, v *TokenUsage) graphql.Marshaler {
+func (ec *executionContext) marshalOTokenUsage2ᚖgithubᚗcomᚋdongᚑqiuᚋagentᚑlensᚋinternalᚋqueryᚐTokenUsage(ctx context.Context, sel ast.SelectionSet, v *TokenUsage) graphql.Marshaler {
 	if v == nil {
 		return graphql.Null
 	}

--- a/internal/query/mapper.go
+++ b/internal/query/mapper.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"strings"
 
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 // toGQLEvent converts a storage-layer event into the gqlgen-generated

--- a/internal/query/mapper_test.go
+++ b/internal/query/mapper_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 func TestDecodePayloadUsage_Present(t *testing.T) {

--- a/internal/query/resolver.go
+++ b/internal/query/resolver.go
@@ -1,6 +1,6 @@
 package query
 
-import "github.com/dongqiu/agent-lens/internal/store"
+import "github.com/dong-qiu/agent-lens/internal/store"
 
 // Resolver is the root of the GraphQL resolver tree. Dependencies are
 // injected at construction time and accessed by the per-type resolver

--- a/internal/query/router.go
+++ b/internal/query/router.go
@@ -8,7 +8,7 @@ import (
 	"github.com/99designs/gqlgen/graphql/playground"
 	"github.com/go-chi/chi/v5"
 
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 // RegisterRoutes wires the GraphQL endpoint at /graphql onto r. Mount r

--- a/internal/query/router_test.go
+++ b/internal/query/router_test.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
-	"github.com/dongqiu/agent-lens/internal/ingest"
-	"github.com/dongqiu/agent-lens/internal/query"
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/query"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 // TestVerticalSliceIngestThenQuery is the M1 happy-path acceptance test:

--- a/internal/query/schema.resolvers.go
+++ b/internal/query/schema.resolvers.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 // Links is the resolver for the links field.

--- a/internal/webhooks/deploy/handler.go
+++ b/internal/webhooks/deploy/handler.go
@@ -19,8 +19,8 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/dongqiu/agent-lens/internal/ingest"
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 // Handler is the http.Handler for POST /webhooks/deploy.

--- a/internal/webhooks/deploy/handler_test.go
+++ b/internal/webhooks/deploy/handler_test.go
@@ -8,8 +8,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dongqiu/agent-lens/internal/ingest"
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 const sampleDeploy = `{

--- a/internal/webhooks/deploy/mapper.go
+++ b/internal/webhooks/deploy/mapper.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
 )
 
 // payload is the shape /webhooks/deploy accepts. Most fields are

--- a/internal/webhooks/github/handler.go
+++ b/internal/webhooks/github/handler.go
@@ -14,8 +14,8 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/dongqiu/agent-lens/internal/ingest"
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 // Handler is the http.Handler for POST /webhooks/github.

--- a/internal/webhooks/github/handler_test.go
+++ b/internal/webhooks/github/handler_test.go
@@ -11,8 +11,8 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/dongqiu/agent-lens/internal/ingest"
-	"github.com/dongqiu/agent-lens/internal/store"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/store"
 )
 
 const samplePullRequestOpened = `{

--- a/internal/webhooks/github/mapper.go
+++ b/internal/webhooks/github/mapper.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dongqiu/agent-lens/internal/ingest"
+	"github.com/dong-qiu/agent-lens/internal/ingest"
 )
 
 // pullRequestPayload is the subset of GitHub's `pull_request` webhook

--- a/proto/artifact.proto
+++ b/proto/artifact.proto
@@ -4,7 +4,7 @@ package agentlens.v1;
 
 import "google/protobuf/struct.proto";
 
-option go_package = "github.com/dongqiu/agent-lens/internal/pb;pb";
+option go_package = "github.com/dong-qiu/agent-lens/internal/pb;pb";
 
 // Artifact is content-addressed by id (sha256 of blob_ref content).
 message Artifact {

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -5,7 +5,7 @@ package agentlens.v1;
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
 
-option go_package = "github.com/dongqiu/agent-lens/internal/pb;pb";
+option go_package = "github.com/dong-qiu/agent-lens/internal/pb;pb";
 
 // Event is the canonical record for one observable action in the human-agent
 // coding pipeline. Events are append-only and form a hash chain via prev_hash.

--- a/proto/link.proto
+++ b/proto/link.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package agentlens.v1;
 
-option go_package = "github.com/dongqiu/agent-lens/internal/pb;pb";
+option go_package = "github.com/dong-qiu/agent-lens/internal/pb;pb";
 
 // Link expresses a causal or semantic relation between two events.
 // Stored separately from events so linking can be re-derived without


### PR DESCRIPTION
## Summary

Phase 1 of v0.1.0 release plan per [ADR 0006](https://github.com/dong-qiu/agent-lens/blob/main/docs/ADR/0006-release-and-distribution-v0.1.md). All three foundation items in one atomic commit (they're interdependent — README cites license + module path; module path rename touches 37 files and is naturally atomic).

### What changed

- **License (D2)**: new `LICENSE` (Apache-2.0); `README` "许可:待定" replaced with link.
- **Module path (D3)**: `github.com/dongqiu/agent-lens` → `github.com/dong-qiu/agent-lens` across 37 files (Go imports, `proto/*.proto` `go_package`, regenerated `internal/pb/*.pb.go`, regenerated `internal/query/generated.go` gqlgen marshallers). The unicode-escaped marshaller names like `marshalNActorᚖgithubᚗcomᚋdongᚑqiuᚋ...` were caught by re-running `make gqlgen`.
- **README "状态"**: from "M1 开发中" to current state (M1-M3 shipped, §17 dogfood live, v0.1 personal-mode in prep, explicit "what's NOT in v0.1").
- **README "模块名" section**: removed (no longer needed after D3).

### What's NOT changed

- `docs/ADR/0006-release-and-distribution-v0.1.md` historical references to the old placeholder path are **preserved** — ADRs are append-only and the historical text accurately describes the prior state.

## Verification done locally

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./... -count=1` — all packages pass (skipped integration which needs Docker)
- `(cd web && npx tsc --noEmit)` — clean
- `make proto && make gqlgen` — re-running produces no further drift; the diff is exactly the path rename

## Test plan

- [ ] CI all green (codegen drift, go test 1.23 + 1.26, lint, web build, integration)
- [ ] Confirm no obviously broken `go install github.com/dong-qiu/agent-lens/...` paths post-merge (will only matter once tag cut)

## Out of scope (later phases per ADR 0006)

- Phase 2: `release.yml` workflow, `setup --personal` subcommand, embed `web/dist`, compose auto-migrate, silent-fallback warning (#71), redaction wiring (J1), `replay` subcommand (N1), cosign smoke (N2), sub-agent capture (K per ADR 0007)
- Phase 3: smoke testing, README install rewrite, release notes, tag v0.1.0