### PR TITLE
docs(v0.1): cosign partial-compat — soften claim + document recipe (J)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,11 @@ agent-lens-hook keygen
 - `agent-lens-hook export slsa-build` → 标准 SLSA Build Track v1
 - `agent-lens-hook export deploy-evidence` → predicateType `agent-lens.dev/deploy-evidence/v1`
 
-每条命令产出一个 DSSE 信封 `.intoto.jsonl`，cosign 兼容。Predicate 里只放 thinking / prompt 的 sha256 + 200 字预览 + token 数；全文留 agent-lens 存储里——签了就难撤回，敏感内容上链得万分谨慎。
+每条命令产出一个 DSSE 信封 `.intoto.jsonl`，签名格式标准（in-toto v1 Statement，DSSE envelope，ed25519）。**官方校验路径用 `agent-lens-hook verify-attestation`**——验签 + predicateType 检查 + subject 显示一气呵成。
+
+cosign 兼容性**部分**：DSSE envelope 与签名本身 cosign 能识别，但 `cosign verify-blob-attestation` 不能直接跑，因为本工具的 in-toto subject 用 `gitCommit` digest 类型（in-toto v1.1 标准给 git commit 的算法），而 cosign 假设 subject 是 sha256 over a blob。如果一定要走 cosign，先抽出 raw 签名 + 构造 DSSE PAE blob，再 `cosign verify-blob --signature <sig> --insecure-ignore-tlog <pae-blob>` —— 详见 [§ Cosign 兼容性](#cosign-兼容性) 段。v0.2 路线考虑加 sha256 alias 或 `cosign-format` 助手，让一键命令工作。
+
+Predicate 里只放 thinking / prompt 的 sha256 + 200 字预览 + token 数；全文留 agent-lens 存储里——签了就难撤回，敏感内容上链得万分谨慎。
 
 ### 导出 code-provenance（commit 边界）
 
@@ -202,7 +206,43 @@ agent-lens-hook verify-attestation deploy.intoto.jsonl \
 
 `--pub` 默认 `$HOME/.agent-lens/keys/ed25519.pub`。
 
-DSSE envelope 是标准格式，cosign / sigstore-go 都能识别——agent-lens 用同一份 ed25519 公钥（PEM/PKIX）签 + 验。把 `.intoto.jsonl` 的 payload (base64) 解出来再喂给第三方工具即可；后续若启用 Sigstore 网络模式（Fulcio + Rekor），`verify-attestation` 会扩展 `--rekor-url` 等 flag，envelope 格式不变。
+DSSE envelope 是标准 in-toto v1 + DSSE v1，结构（`payloadType` / `payload` / `signatures[].sig`）兼容 sigstore 工具栈。agent-lens 用同一份 ed25519 公钥（PEM/PKIX）签 + 验，所以下游脚本也可以读 `.intoto.jsonl` 解 payload (base64) 自己处理。后续若启用 Sigstore 网络模式（Fulcio + Rekor），`verify-attestation` 会扩展 `--rekor-url` 等 flag，envelope 格式不变。
+
+## Cosign 兼容性
+
+v0.1 与 cosign 的关系是**部分兼容**：
+
+| 路径 | 状态 | 备注 |
+|---|---|---|
+| `agent-lens-hook verify-attestation` | ✅ 推荐 | 验签 + predicateType 校验 + subject 显示 一气呵成 |
+| `cosign verify-blob-attestation` (code-provenance / deploy-evidence) | ❌ | subject digest 用 `gitCommit` 或 image，cosign 假设 sha256 over blob，subject linkage 失败 |
+| `cosign verify-blob-attestation` (slsa-build) | ⏳ 未测 | SLSA Build subject 用 sha256 artifact digests，理论上 cosign 应能跑；v0.1 没在 CI 验证，留给 v0.2 |
+| `cosign verify-blob` 抽 raw 签名 + DSSE PAE blob | ✅ workaround | 见下方 recipe；`Verified OK` 已实测过 |
+
+**手动 cosign 校验 recipe**（如果你 audit pipeline 已经在用 cosign）：
+
+```bash
+ATT=path/to/code-prov.intoto.jsonl
+PUB=$HOME/.agent-lens/keys/ed25519.pub
+
+# 1. 抽出 raw 签名（base64）
+python3 -c "import json; print(json.load(open('$ATT'))['signatures'][0]['sig'])" > sig.b64
+
+# 2. 构造 DSSE PAE blob（cosign 这一步只验签，不做 subject linkage）
+python3 -c "
+import json, base64, sys
+e = json.load(open('$ATT'))
+pt = e['payloadType']
+p = base64.b64decode(e['payload'])
+sys.stdout.buffer.write(f'DSSEv1 {len(pt)} {pt} {len(p)} '.encode() + p)
+" > pae.bin
+
+# 3. cosign verify-blob
+cosign verify-blob --key "$PUB" --signature sig.b64 --insecure-ignore-tlog pae.bin
+# Verified OK
+```
+
+**v0.2 路线**（[#75](https://github.com/dong-qiu/agent-lens/issues/75)）：考虑给 subject 加 sha256 alias 或新增 `agent-lens-hook cosign-format` 助手，让 `cosign verify-blob-attestation` 一键能跑。
 
 ## 校验哈希链
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -202,7 +202,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
   - **build**：predicate = `slsa.dev/provenance/v1`（标准 SLSA build provenance）。
   - **deploy**：predicate = `agent-lens.dev/deploy-evidence/v1`（关联上游 trace 根 ID）。
 - 签名使用 Sigstore（cosign / Fulcio / Rekor）或本地 KMS；自托管模式两者皆可。
-- 对外定位：**把 SLSA / in-toto 的可信链路向 AI 协作上游延伸**，envelope 与签名按标准 DSSE + in-toto v1，**官方校验路径用 `agent-lens-hook verify-attestation`**。cosign 的 `verify-blob-attestation` 在 commit / deploy attestation 上不直接通（subject 用 `gitCommit` / image digest，cosign 期望 sha256 over blob）；cosign `verify-blob` 走手动 PAE 路径可校验签名（README 有 recipe）。Kyverno / Conftest 等基于 OPA 的策略工具消费 in-toto Statement 内部，不依赖 cosign 那条 verify 路径，独立可用。SLSA build 路径理论可走 cosign（subject 是 sha256 artifact digest）但 v0.1 未端到端验证，列 v0.2 路线。
+- 对外定位：**把 SLSA / in-toto 的可信链路向 AI 协作上游延伸**，envelope 与签名按标准 DSSE + in-toto v1，**官方校验路径用 `agent-lens-hook verify-attestation`**。cosign 的 `verify-blob-attestation` 在 commit / deploy attestation 上不直接通（subject 用 `gitCommit` / image digest，cosign 期望 sha256 over blob）；cosign `verify-blob` 走手动 PAE 路径可校验签名（README 有 recipe，已实测）。SLSA build 路径理论可走 cosign（subject 是 sha256 artifact digest）但 v0.1 未端到端验证，列 v0.2 路线。其它下游工具（Kyverno / Conftest 等）的集成 v0.1 范围外，留待具体 use case 出现时单独验证。
 
 ## 12. 安全与合规
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -202,7 +202,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
   - **build**：predicate = `slsa.dev/provenance/v1`（标准 SLSA build provenance）。
   - **deploy**：predicate = `agent-lens.dev/deploy-evidence/v1`（关联上游 trace 根 ID）。
 - 签名使用 Sigstore（cosign / Fulcio / Rekor）或本地 KMS；自托管模式两者皆可。
-- 对外定位：**把 SLSA / in-toto 的可信链路向 AI 协作上游延伸**，输出可被 cosign verify / Kyverno / Conftest 等现有工具直接消费的 attestation。
+- 对外定位：**把 SLSA / in-toto 的可信链路向 AI 协作上游延伸**，envelope 与签名按标准 DSSE + in-toto v1，**官方校验路径用 `agent-lens-hook verify-attestation`**。cosign 的 `verify-blob-attestation` 在 commit / deploy attestation 上不直接通（subject 用 `gitCommit` / image digest，cosign 期望 sha256 over blob）；cosign `verify-blob` 走手动 PAE 路径可校验签名（README 有 recipe）。Kyverno / Conftest 等基于 OPA 的策略工具消费 in-toto Statement 内部，不依赖 cosign 那条 verify 路径，独立可用。SLSA build 路径理论可走 cosign（subject 是 sha256 artifact digest）但 v0.1 未端到端验证，列 v0.2 路线。
 
 ## 12. 安全与合规
 


### PR DESCRIPTION
## Summary

v0.1 J task: empirically validate cosign cross-tool compatibility, then document/fix.

**Path taken: (c) — softening + concrete workaround recipe.**

## Smoke results (real cosign v3.0.6)

Reproduced locally with a real attestation (\`agent-lens-hook export code-provenance\` against this session's c24e170 commit):

| Verification path | Outcome |
|---|---|
| \`agent-lens-hook verify-attestation\` | ✅ Works (signature + predicateType + subject) — **the recommended path** |
| \`cosign verify-blob-attestation --type ... --signature env.intoto.jsonl blob\` | ❌ \`Error: no matching subject digest found\` — our subject uses \`gitCommit\` (in-toto v1.1 standard), cosign expects sha256 over blob |
| \`cosign verify-blob --signature <raw_sig> --insecure-ignore-tlog <pae_blob>\` | ✅ \`Verified OK\` after extracting raw sig + computing DSSE PAE manually |

The DSSE envelope **structure** and ed25519 signature **are** cosign-compatible. The mismatch is in cosign's subject-linkage assumption (sha256 only), not in our envelope shape.

## Changes

### README (sections \"Attestation 签名密钥\" + new \"Cosign 兼容性\")

- \"DSSE 信封 cosign 兼容\" → \"签名格式标准；cosign 兼容性**部分**\"
- New §Cosign 兼容性 with verification matrix (verify-attestation ✅ / verify-blob-attestation ❌ / verify-blob+PAE ✅)
- Concrete 3-step recipe for users with cosign-based audit pipelines

### SPEC.md §11

- Line 205 \"输出可被 cosign verify / Kyverno / Conftest 等现有工具直接消费的 attestation\" reworded to reflect partial cosign compat + Kyverno/Conftest still independently work (they consume in-toto Statement, not cosign-verified) + SLSA build path noted as untested in v0.1

### Issue #75 opened

Tracks the v0.2 fix:
- Path A: add sha256 alias to subject digest
- Path B: \`agent-lens-hook cosign-format\` helper subcommand
- Path C: both

## NOT in this PR

- CI cosign step — existing \`internal/attest\` unit tests cover sign/verify roundtrip via project's primitives. Adding cosign install to CI is overhead (~30s job, depends on flaky external download) for marginal value. Deferred to #75 if/when cosign UX gets fixed
- SLSA build path validation against cosign — needs a session with build events + artifacts; deferred to a future SLSA-build-specific test

## Test plan

- [ ] CI green (no behavior change, just docs)
- [ ] Manual: read README §Cosign 兼容性, verify recipe steps make sense