### PR TITLE
feat(hook): add sign-release subcommand (B1)

### DIFF
--- a/cmd/agent-lens-hook/main.go
+++ b/cmd/agent-lens-hook/main.go
@@ -16,6 +16,7 @@ Subcommands:
   verify                 Verify the local hash chain of a session.
   keygen                 Generate an ed25519 key pair for DSSE attestations.
   export                 Export an in-toto / SLSA attestation, or an audit report.
+  sign-release           Sign a release binary and emit a DSSE attestation.
   verify-attestation     Verify a DSSE-wrapped in-toto attestation file.
   verify-audit-report    Verify an audit-report bundle.
 
@@ -40,6 +41,8 @@ func main() {
 		runKeygen(os.Args[2:])
 	case "export":
 		runExport(os.Args[2:])
+	case "sign-release":
+		runSignRelease(os.Args[2:])
 	case "verify-attestation":
 		runVerifyAttestation(os.Args[2:])
 	case "verify-audit-report":
@@ -57,5 +60,6 @@ func main() {
 // runVerify is implemented in verify.go.
 // runKeygen is implemented in keygen.go.
 // runExport is implemented in export.go.
+// runSignRelease is implemented in sign_release.go.
 // runVerifyAttestation is implemented in verify_attestation.go.
 // runVerifyAuditReport is implemented in audit_report.go.

--- a/cmd/agent-lens-hook/sign_release.go
+++ b/cmd/agent-lens-hook/sign_release.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dong-qiu/agent-lens/internal/attest"
+)
+
+// ReleaseArtifactPredicate is the predicateType for the v0.1 release-binary
+// attestation. The subject is the file's sha256 (not gitCommit) so that
+// `cosign verify-blob-attestation` can natively walk the subject linkage —
+// PR #76 found gitCommit subjects break cosign's blob verification.
+const ReleaseArtifactPredicate = "agent-lens.dev/release-artifact/v1"
+
+const signReleaseUsage = `agent-lens-hook sign-release — sign a release binary
+with the project's ed25519 key and emit a DSSE-wrapped in-toto attestation.
+
+Usage:
+  agent-lens-hook sign-release \
+    [--key <path>] --in <binary-path> --out <sig-path>
+
+  --key   ed25519 private key path
+          (default $HOME/.agent-lens/keys/ed25519)
+  --in    path to the binary file to sign (required)
+  --out   path where the .intoto.jsonl DSSE envelope is written (required)
+
+Output is one JSON-encoded DSSE envelope on a single line, suitable for a
+.intoto.jsonl release artifact. The signed payload is an in-toto v1
+Statement whose subject is the binary's sha256 (so cosign verify-blob-
+attestation works) and whose predicate carries the platform parsed from
+the filename (GOOS/GOARCH for darwin|linux × amd64|arm64) and the build
+timestamp. Unrecognized filenames yield an empty platform string rather
+than an error.
+
+Exit codes: 0 success, 2 usage / file errors (missing flag, unreadable
+key, missing --in, unwritable --out, signing error).
+`
+
+func runSignRelease(args []string) {
+	if err := signReleaseCore(args, os.Stdout); err != nil {
+		fmt.Fprintf(os.Stderr, "agent-lens-hook sign-release: %v\n", err)
+		// All failures (including signing) exit 2 per ADR 0006: there's
+		// no "verification failed" vs "couldn't check" split here, only
+		// "we produced a sig" or "we didn't".
+		os.Exit(2)
+	}
+}
+
+// releaseArtifactPredicate is the v1 predicate body. Kept tiny on
+// purpose — anything richer (build env, source commit, builder id)
+// belongs in the SLSA build provenance, not in the release-artifact
+// attestation whose only job is "this is a sha256 + platform that the
+// project signed".
+type releaseArtifactPredicate struct {
+	Platform string `json:"platform"`
+	BuiltAt  string `json:"builtAt"`
+}
+
+func signReleaseCore(args []string, out io.Writer) error {
+	fs := flag.NewFlagSet("sign-release", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	var (
+		keyPath = fs.String("key", "", "ed25519 private key path")
+		inPath  = fs.String("in", "", "binary file to sign (required)")
+		outPath = fs.String("out", "", "path to write the DSSE envelope (required)")
+	)
+	fs.Usage = func() { fmt.Fprint(os.Stderr, signReleaseUsage) }
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *inPath == "" || *outPath == "" {
+		fs.Usage()
+		return fmt.Errorf("--in and --out are both required")
+	}
+
+	kp := *keyPath
+	if kp == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("home dir: %w", err)
+		}
+		kp = filepath.Join(home, ".agent-lens", "keys", "ed25519")
+	}
+	priv, err := attest.LoadPrivateKey(kp)
+	if err != nil {
+		return fmt.Errorf("load private key from %s: %w", kp, err)
+	}
+
+	digest, err := sha256File(*inPath)
+	if err != nil {
+		return fmt.Errorf("hash --in %s: %w", *inPath, err)
+	}
+
+	base := filepath.Base(*inPath)
+	predicate, err := json.Marshal(releaseArtifactPredicate{
+		Platform: detectPlatform(base),
+		BuiltAt:  time.Now().UTC().Format(time.RFC3339),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal predicate: %w", err)
+	}
+
+	stmt := attest.Statement{
+		Type:          attest.InTotoStatementType,
+		PredicateType: ReleaseArtifactPredicate,
+		Subject: []attest.Subject{
+			{Name: base, Digest: map[string]string{"sha256": digest}},
+		},
+		Predicate: predicate,
+	}
+	stmtBytes, err := json.Marshal(stmt)
+	if err != nil {
+		return fmt.Errorf("marshal statement: %w", err)
+	}
+	env, err := attest.Sign(priv, attest.InTotoPayloadType, stmtBytes)
+	if err != nil {
+		return fmt.Errorf("sign: %w", err)
+	}
+	envBytes, err := json.Marshal(env)
+	if err != nil {
+		return fmt.Errorf("marshal envelope: %w", err)
+	}
+	envBytes = append(envBytes, '\n')
+
+	if err := os.WriteFile(*outPath, envBytes, 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", *outPath, err)
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"release attestation written: %s (sha256:%s, %d bytes, key id %s)\n",
+		*outPath, digest, len(envBytes), priv.KeyID,
+	)
+	// out is currently informational — keep stdout silent in success
+	// path so callers can pipe sign-release into a pipeline without
+	// stripping noise. (Stderr keeps the human-readable summary.)
+	_ = out
+	return nil
+}
+
+// sha256File hashes the file at path. Streamed so we don't allocate the
+// whole binary in memory; release binaries can be tens of MB.
+func sha256File(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = f.Close() }()
+	h := sha256.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// recognizedGOOS / recognizedGOARCH are the v0.1 platform matrix per
+// ADR 0006 D5. Anything outside this set yields an empty platform
+// string — unrecognized filenames are not an error, they just don't get
+// platform metadata.
+var (
+	recognizedGOOS   = map[string]bool{"darwin": true, "linux": true}
+	recognizedGOARCH = map[string]bool{"amd64": true, "arm64": true}
+)
+
+// detectPlatform parses GOOS/GOARCH out of release-style binary names
+// like "agent-lens-darwin-arm64" or "agent-lens-hook-linux-amd64.exe".
+// We anchor on the *last* two hyphen-separated segments after stripping
+// any extension; that's robust against the binary name itself containing
+// hyphens (agent-lens-hook), which is exactly our case.
+//
+// Returns "" for anything we don't recognize — including the bare
+// "agent-lens" with no platform suffix, which is intentional: the user
+// can still produce an attestation, it just won't claim a platform it
+// can't prove.
+func detectPlatform(filename string) string {
+	name := filename
+	// Strip a single trailing extension (e.g. ".exe"). Doing this once
+	// rather than via filepath.Ext-in-a-loop matches the spec ("trailing
+	// extensions like .exe or anything after the arch can be ignored")
+	// without accidentally eating a platform segment that contains a dot.
+	if dot := strings.LastIndex(name, "."); dot > 0 && dot > strings.LastIndex(name, "-") {
+		name = name[:dot]
+	}
+	parts := strings.Split(name, "-")
+	if len(parts) < 2 {
+		return ""
+	}
+	arch := parts[len(parts)-1]
+	goos := parts[len(parts)-2]
+	if !recognizedGOOS[goos] || !recognizedGOARCH[arch] {
+		return ""
+	}
+	return goos + "/" + arch
+}

--- a/cmd/agent-lens-hook/sign_release_test.go
+++ b/cmd/agent-lens-hook/sign_release_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dong-qiu/agent-lens/internal/attest"
+)
+
+// TestSignReleaseHappyPath signs a tiny test binary, then walks the
+// envelope back to confirm payloadType, subject digest, predicateType,
+// and that the signature verifies under the matching public key. One
+// test rather than a suite per the v0.1 implementation prompt — this
+// happy path exercises every field that downstream verifiers (cosign,
+// agent-lens-hook verify-attestation) actually read.
+func TestSignReleaseHappyPath(t *testing.T) {
+	dir := t.TempDir()
+
+	// Use the existing test helper from verify_attestation_test.go so
+	// the keypair lives on disk in the same PEM format the real
+	// command will load.
+	priv, pubPath := saveTestKey(t, dir, "ed25519")
+	keyPath := filepath.Join(dir, "ed25519")
+
+	// A platform-bearing filename so we also assert detectPlatform
+	// flows through the predicate. Body is arbitrary — we just need
+	// stable bytes to recompute sha256 over.
+	binPath := filepath.Join(dir, "agent-lens-darwin-arm64")
+	body := []byte("hello\n")
+	if err := os.WriteFile(binPath, body, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	want := sha256.Sum256(body)
+	wantHex := hex.EncodeToString(want[:])
+
+	outPath := filepath.Join(dir, "agent-lens-darwin-arm64.intoto.jsonl")
+	var stdout bytes.Buffer
+	if err := signReleaseCore(
+		[]string{"--key", keyPath, "--in", binPath, "--out", outPath},
+		&stdout,
+	); err != nil {
+		t.Fatalf("signReleaseCore: %v", err)
+	}
+
+	raw, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read envelope: %v", err)
+	}
+	var env attest.Envelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if env.PayloadType != attest.InTotoPayloadType {
+		t.Errorf("payloadType = %q, want %q", env.PayloadType, attest.InTotoPayloadType)
+	}
+
+	pub, err := attest.LoadPublicKey(pubPath)
+	if err != nil {
+		t.Fatalf("load public key: %v", err)
+	}
+	payload, _, err := attest.Verify(pub, &env)
+	if err != nil {
+		t.Fatalf("verify envelope: %v", err)
+	}
+	if env.Signatures[0].KeyID != priv.KeyID {
+		t.Errorf("envelope keyid = %q, want %q", env.Signatures[0].KeyID, priv.KeyID)
+	}
+
+	var stmt attest.Statement
+	if err := json.Unmarshal(payload, &stmt); err != nil {
+		t.Fatalf("unmarshal statement: %v", err)
+	}
+	if stmt.PredicateType != ReleaseArtifactPredicate {
+		t.Errorf("predicateType = %q, want %q", stmt.PredicateType, ReleaseArtifactPredicate)
+	}
+	if len(stmt.Subject) != 1 {
+		t.Fatalf("got %d subjects, want 1", len(stmt.Subject))
+	}
+	if got := stmt.Subject[0].Digest["sha256"]; got != wantHex {
+		t.Errorf("subject sha256 = %q, want %q", got, wantHex)
+	}
+	if stmt.Subject[0].Name != "agent-lens-darwin-arm64" {
+		t.Errorf("subject name = %q, want basename of --in", stmt.Subject[0].Name)
+	}
+
+	var pred releaseArtifactPredicate
+	if err := json.Unmarshal(stmt.Predicate, &pred); err != nil {
+		t.Fatalf("unmarshal predicate: %v", err)
+	}
+	if pred.Platform != "darwin/arm64" {
+		t.Errorf("platform = %q, want darwin/arm64", pred.Platform)
+	}
+	if pred.BuiltAt == "" {
+		t.Error("builtAt is empty; want RFC3339 timestamp")
+	}
+}


### PR DESCRIPTION
## Summary

v0.1 Phase 2 — implements ADR 0006 D6 + D7. New \`agent-lens-hook sign-release\` subcommand produces a DSSE-wrapped in-toto Statement for a release binary, signed with the project's ed25519 key.

This is the building block release.yml (B2) will invoke once per cross-built binary.

## Key design choice: sha256 subject (not gitCommit)

PR #76 empirically found that \`cosign verify-blob-attestation\` breaks for code-provenance / deploy-evidence attestations because their subject uses \`gitCommit\` / image digest, but cosign expects sha256-over-blob. By making the **release-artifact** predicate's subject the binary file's sha256, cosign can natively verify subject linkage. **Bonus**: validated locally — see smoke results below.

## Scope (atomic)

- \`cmd/agent-lens-hook/sign_release.go\` (~200 LOC): subcommand + sha256 streaming hasher + detectPlatform parser
- \`cmd/agent-lens-hook/sign_release_test.go\`: one happy-path test exercising every field
- \`cmd/agent-lens-hook/main.go\`: one-line dispatch in switch

## Smoke results (local, pre-push)

\`\`\`
$ ./bin/agent-lens-hook sign-release --key /tmp/key --in /tmp/test-bin --out /tmp/test-bin.sig
release attestation written: /tmp/test-bin.sig (sha256:077dde..., 569 bytes, key id 1188245188d837b3)

$ ./bin/agent-lens-hook verify-attestation --pub /tmp/key.pub \\
    --require-type "agent-lens.dev/release-artifact/v1" /tmp/test-bin.sig
OK · payloadType application/vnd.in-toto+json · predicateType agent-lens.dev/release-artifact/v1 · keyid 1188245188d837b3
  subject: test-bin (sha256:077dde...)

$ cosign verify-blob-attestation --key /tmp/key.pub \\
    --type "agent-lens.dev/release-artifact/v1" --insecure-ignore-tlog \\
    --signature /tmp/test-bin.sig /tmp/test-bin
Verified OK
\`\`\`

The third one — cosign natively verifying — closes the gap PR #76 documented for code-provenance subjects. Release-artifact attestations are now first-class citizens for cosign-based audit pipelines, no PAE-blob workaround needed.

## NOT in this PR (B2 + later)

- \`.github/workflows/release.yml\` invoking sign-release in matrix build (B2)
- README docs for the subcommand (B2 or follow-up)
- detectPlatform edge-case unit tests (deferred unless B2 surfaces a regression)

## Test plan

- [ ] CI green
- [ ] Reviewer can re-run the smoke commands above on a fresh clone

## Provenance note

Initial implementation was scaffolded by an isolated worktree agent that stalled on commit; main session verified all files, ran build/vet/test/smoke, and committed. The implementation matches the prompt spec verbatim.