### PR TITLE
feat(hook): add replay subcommand to drain fallback NDJSON files (N1)

### DIFF
--- a/cmd/agent-lens-hook/main.go
+++ b/cmd/agent-lens-hook/main.go
@@ -14,6 +14,7 @@ Subcommands:
   claude                 Capture a Claude Code hook payload from stdin and forward.
   git-post-commit        Capture a git post-commit event and forward.
   verify                 Verify the local hash chain of a session.
+  replay                 Re-POST fallback NDJSON files to the ingest server.
   keygen                 Generate an ed25519 key pair for DSSE attestations.
   export                 Export an in-toto / SLSA attestation, or an audit report.
   sign-release           Sign a release binary and emit a DSSE attestation.
@@ -37,6 +38,8 @@ func main() {
 		runGitPostCommit(os.Args[2:])
 	case "verify":
 		runVerify(os.Args[2:])
+	case "replay":
+		runReplay(os.Args[2:])
 	case "keygen":
 		runKeygen(os.Args[2:])
 	case "export":
@@ -58,6 +61,7 @@ func main() {
 // runClaude is implemented in claude.go.
 // runGitPostCommit is implemented in git.go.
 // runVerify is implemented in verify.go.
+// runReplay is implemented in replay.go.
 // runKeygen is implemented in keygen.go.
 // runExport is implemented in export.go.
 // runSignRelease is implemented in sign_release.go.

--- a/cmd/agent-lens-hook/replay.go
+++ b/cmd/agent-lens-hook/replay.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"bytes"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+const replayUsage = `agent-lens-hook replay — re-POST fallback NDJSON files
+that the hook wrote when the ingest server was unreachable.
+
+  agent-lens-hook replay [flags]
+
+Flags:
+  --dir <path>          directory containing fallback *.ndjson files
+                        (default $HOME/.agent-lens/sessions)
+  --url <url>           ingest endpoint
+                        (default $AGENT_LENS_URL or http://localhost:8787)
+  --token <token>       bearer token (default $AGENT_LENS_TOKEN)
+  --since <RFC3339>     only replay files with mtime >= this timestamp
+  --dry-run             list files that would be replayed and exit
+  --remove-on-success   delete each file after a successful POST
+
+Files are processed in mtime-ascending order so older sessions land
+before newer ones. A failure on one file is logged to stderr and the
+next file is still attempted.
+
+Exit codes: 0 on success (or --dry-run with at least one match),
+1 if any file failed, 2 on usage / IO errors (e.g. --dir missing).
+
+Example:
+  agent-lens-hook replay --dry-run
+  agent-lens-hook replay --remove-on-success --url http://localhost:8787
+`
+
+func runReplay(args []string) {
+	fs := flag.NewFlagSet("replay", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	var (
+		dirFlag    = fs.String("dir", "", "fallback directory (default $HOME/.agent-lens/sessions)")
+		urlFlag    = fs.String("url", "", "Agent Lens server URL (defaults to AGENT_LENS_URL or http://localhost:8787)")
+		tokenFlag  = fs.String("token", "", "bearer token (defaults to AGENT_LENS_TOKEN)")
+		sinceFlag  = fs.String("since", "", "only replay files with mtime >= this RFC3339 timestamp")
+		dryRun     = fs.Bool("dry-run", false, "list files that would be replayed and exit")
+		removeFlag = fs.Bool("remove-on-success", false, "delete each file after successful POST")
+		timeout    = fs.Duration("timeout", 30*time.Second, "HTTP request timeout per file")
+	)
+	fs.Usage = func() { fmt.Fprint(os.Stderr, replayUsage) }
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+
+	dir := *dirFlag
+	if dir == "" {
+		dir = filepath.Join(homeDir(), ".agent-lens", "sessions")
+	}
+
+	var since time.Time
+	if *sinceFlag != "" {
+		t, err := time.Parse(time.RFC3339, *sinceFlag)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "agent-lens-hook replay: invalid --since: %v\n", err)
+			os.Exit(2)
+		}
+		since = t
+	}
+
+	url := chooseURL(*urlFlag)
+	token := chooseToken(*tokenFlag)
+	client := &http.Client{Timeout: *timeout}
+
+	code := replayCore(dir, url, token, since, *dryRun, *removeFlag, client, os.Stdout, os.Stderr)
+	os.Exit(code)
+}
+
+// replayCore is the testable core of the replay subcommand. It returns
+// the exit code so tests can assert on it without invoking os.Exit.
+func replayCore(dir, url, token string, since time.Time, dryRun, removeOnSuccess bool, client *http.Client, stdout, stderr io.Writer) int {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		fmt.Fprintf(stderr, "agent-lens-hook replay: read dir %s: %v\n", dir, err)
+		return 2
+	}
+
+	type candidate struct {
+		path  string
+		size  int64
+		mtime time.Time
+	}
+	var files []candidate
+	var skipped int
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		if !strings.HasSuffix(name, ".ndjson") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			fmt.Fprintf(stderr, "failed: %s: stat: %v\n", name, err)
+			continue
+		}
+		if !since.IsZero() && info.ModTime().Before(since) {
+			skipped++
+			continue
+		}
+		files = append(files, candidate{
+			path:  filepath.Join(dir, name),
+			size:  info.Size(),
+			mtime: info.ModTime(),
+		})
+	}
+
+	sort.Slice(files, func(i, j int) bool {
+		return files[i].mtime.Before(files[j].mtime)
+	})
+
+	var succeeded, failed int
+	for _, f := range files {
+		if dryRun {
+			fmt.Fprintf(stdout, "would replay: %s (%d bytes, mtime %s)\n",
+				f.path, f.size, f.mtime.UTC().Format(time.RFC3339))
+			succeeded++
+			continue
+		}
+
+		body, err := os.ReadFile(f.path)
+		if err != nil {
+			fmt.Fprintf(stderr, "failed: %s: read: %v\n", f.path, err)
+			failed++
+			continue
+		}
+
+		if err := postNDJSON(client, url, token, body); err != nil {
+			fmt.Fprintf(stderr, "failed: %s: %v\n", f.path, err)
+			failed++
+			continue
+		}
+		fmt.Fprintf(stdout, "replayed: %s (%d bytes)\n", f.path, len(body))
+		succeeded++
+
+		if removeOnSuccess {
+			if err := os.Remove(f.path); err != nil {
+				fmt.Fprintf(stderr, "WARN: removed: failed to remove %s: %v\n", f.path, err)
+			} else {
+				fmt.Fprintf(stdout, "removed: %s\n", f.path)
+			}
+		}
+	}
+
+	fmt.Fprintf(stdout, "replay summary: %d files (%d succeeded, %d failed, %d skipped via --since)\n",
+		len(files), succeeded, failed, skipped)
+
+	if failed > 0 {
+		return 1
+	}
+	return 0
+}
+
+func postNDJSON(client *http.Client, url, token string, body []byte) error {
+	req, err := http.NewRequest(http.MethodPost, url+"/v1/events", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-ndjson")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode/100 != 2 {
+		raw, _ := io.ReadAll(resp.Body)
+		msg := strings.TrimSpace(string(raw))
+		if msg == "" {
+			return fmt.Errorf("HTTP %d", resp.StatusCode)
+		}
+		return fmt.Errorf("HTTP %d: %s", resp.StatusCode, msg)
+	}
+	return nil
+}

--- a/cmd/agent-lens-hook/replay.go
+++ b/cmd/agent-lens-hook/replay.go
@@ -27,6 +27,7 @@ Flags:
   --since <RFC3339>     only replay files with mtime >= this timestamp
   --dry-run             list files that would be replayed and exit
   --remove-on-success   delete each file after a successful POST
+                        (strongly recommended; see "Important" below)
 
 Files are processed in mtime-ascending order so older sessions land
 before newer ones. A failure on one file is logged to stderr and the
@@ -38,6 +39,17 @@ Exit codes: 0 on success (or --dry-run with at least one match),
 Example:
   agent-lens-hook replay --dry-run
   agent-lens-hook replay --remove-on-success --url http://localhost:8787
+
+Important — re-running creates duplicates in v0.1:
+
+  v0.1 ingest does not dedup on event ULID; the server overrides the
+  client-supplied id with a fresh server-side ULID on every POST. So
+  re-running replay over a file that was already accepted will insert
+  duplicate events into the database (visible as doubled event counts
+  in Lens UI / GraphQL).
+
+  Always use --remove-on-success unless you have an independent
+  idempotency control. Tracking issue: #81.
 `
 
 func runReplay(args []string) {

--- a/cmd/agent-lens-hook/replay.go
+++ b/cmd/agent-lens-hook/replay.go
@@ -85,7 +85,7 @@ func runReplay(args []string) {
 func replayCore(dir, url, token string, since time.Time, dryRun, removeOnSuccess bool, client *http.Client, stdout, stderr io.Writer) int {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
-		fmt.Fprintf(stderr, "agent-lens-hook replay: read dir %s: %v\n", dir, err)
+		_, _ = fmt.Fprintf(stderr, "agent-lens-hook replay: read dir %s: %v\n", dir, err)
 		return 2
 	}
 
@@ -109,7 +109,7 @@ func replayCore(dir, url, token string, since time.Time, dryRun, removeOnSuccess
 		}
 		info, err := e.Info()
 		if err != nil {
-			fmt.Fprintf(stderr, "failed: %s: stat: %v\n", name, err)
+			_, _ = fmt.Fprintf(stderr, "failed: %s: stat: %v\n", name, err)
 			continue
 		}
 		if !since.IsZero() && info.ModTime().Before(since) {
@@ -130,7 +130,7 @@ func replayCore(dir, url, token string, since time.Time, dryRun, removeOnSuccess
 	var succeeded, failed int
 	for _, f := range files {
 		if dryRun {
-			fmt.Fprintf(stdout, "would replay: %s (%d bytes, mtime %s)\n",
+			_, _ = fmt.Fprintf(stdout, "would replay: %s (%d bytes, mtime %s)\n",
 				f.path, f.size, f.mtime.UTC().Format(time.RFC3339))
 			succeeded++
 			continue
@@ -138,29 +138,29 @@ func replayCore(dir, url, token string, since time.Time, dryRun, removeOnSuccess
 
 		body, err := os.ReadFile(f.path)
 		if err != nil {
-			fmt.Fprintf(stderr, "failed: %s: read: %v\n", f.path, err)
+			_, _ = fmt.Fprintf(stderr, "failed: %s: read: %v\n", f.path, err)
 			failed++
 			continue
 		}
 
 		if err := postNDJSON(client, url, token, body); err != nil {
-			fmt.Fprintf(stderr, "failed: %s: %v\n", f.path, err)
+			_, _ = fmt.Fprintf(stderr, "failed: %s: %v\n", f.path, err)
 			failed++
 			continue
 		}
-		fmt.Fprintf(stdout, "replayed: %s (%d bytes)\n", f.path, len(body))
+		_, _ = fmt.Fprintf(stdout, "replayed: %s (%d bytes)\n", f.path, len(body))
 		succeeded++
 
 		if removeOnSuccess {
 			if err := os.Remove(f.path); err != nil {
-				fmt.Fprintf(stderr, "WARN: removed: failed to remove %s: %v\n", f.path, err)
+				_, _ = fmt.Fprintf(stderr, "WARN: removed: failed to remove %s: %v\n", f.path, err)
 			} else {
-				fmt.Fprintf(stdout, "removed: %s\n", f.path)
+				_, _ = fmt.Fprintf(stdout, "removed: %s\n", f.path)
 			}
 		}
 	}
 
-	fmt.Fprintf(stdout, "replay summary: %d files (%d succeeded, %d failed, %d skipped via --since)\n",
+	_, _ = fmt.Fprintf(stdout, "replay summary: %d files (%d succeeded, %d failed, %d skipped via --since)\n",
 		len(files), succeeded, failed, skipped)
 
 	if failed > 0 {

--- a/cmd/agent-lens-hook/replay_test.go
+++ b/cmd/agent-lens-hook/replay_test.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestReplay(t *testing.T) {
+	t.Run("HappyPath", func(t *testing.T) {
+		dir := t.TempDir()
+
+		// Two files with distinct mtimes; older first in ascending order.
+		oldPath := filepath.Join(dir, "session-old.ndjson")
+		newPath := filepath.Join(dir, "session-new.ndjson")
+		oldBody := []byte(`{"id":"e1","kind":"prompt"}` + "\n")
+		newBody := []byte(`{"id":"e2","kind":"prompt"}` + "\n")
+		if err := os.WriteFile(oldPath, oldBody, 0o600); err != nil {
+			t.Fatalf("write old: %v", err)
+		}
+		if err := os.WriteFile(newPath, newBody, 0o600); err != nil {
+			t.Fatalf("write new: %v", err)
+		}
+		// Force a clear mtime ordering: old = 2h ago, new = 1h ago.
+		old := time.Now().Add(-2 * time.Hour)
+		newer := time.Now().Add(-1 * time.Hour)
+		if err := os.Chtimes(oldPath, old, old); err != nil {
+			t.Fatalf("chtimes old: %v", err)
+		}
+		if err := os.Chtimes(newPath, newer, newer); err != nil {
+			t.Fatalf("chtimes new: %v", err)
+		}
+
+		// Also drop a dot-file and a non-.ndjson file to verify they are
+		// skipped without showing up in the summary.
+		if err := os.WriteFile(filepath.Join(dir, ".hidden.ndjson"), []byte("{}\n"), 0o600); err != nil {
+			t.Fatalf("write hidden: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("ignore me"), 0o600); err != nil {
+			t.Fatalf("write txt: %v", err)
+		}
+
+		var (
+			mu       sync.Mutex
+			gotPaths []string
+			gotCT    []string
+		)
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/v1/events" {
+				http.NotFound(w, r)
+				return
+			}
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			gotPaths = append(gotPaths, string(body))
+			gotCT = append(gotCT, r.Header.Get("Content-Type"))
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"accepted":1}`))
+		}))
+		defer srv.Close()
+
+		var stdout, stderr bytes.Buffer
+		code := replayCore(dir, srv.URL, "", time.Time{}, false, false,
+			&http.Client{Timeout: 5 * time.Second}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0; stderr=%s", code, stderr.String())
+		}
+
+		mu.Lock()
+		defer mu.Unlock()
+		if len(gotPaths) != 2 {
+			t.Fatalf("server saw %d POSTs, want 2 (stderr=%s)", len(gotPaths), stderr.String())
+		}
+		// mtime ascending → old before new
+		if string(gotPaths[0]) != string(oldBody) {
+			t.Errorf("first POST body = %q, want old %q", gotPaths[0], oldBody)
+		}
+		if string(gotPaths[1]) != string(newBody) {
+			t.Errorf("second POST body = %q, want new %q", gotPaths[1], newBody)
+		}
+		for i, ct := range gotCT {
+			if ct != "application/x-ndjson" {
+				t.Errorf("POST[%d] Content-Type = %q, want application/x-ndjson", i, ct)
+			}
+		}
+
+		out := stdout.String()
+		if !strings.Contains(out, "replay summary: 2 files (2 succeeded, 0 failed, 0 skipped") {
+			t.Errorf("summary line missing in stdout:\n%s", out)
+		}
+	})
+
+	t.Run("DryRun", func(t *testing.T) {
+		dir := t.TempDir()
+
+		a := filepath.Join(dir, "a.ndjson")
+		b := filepath.Join(dir, "b.ndjson")
+		if err := os.WriteFile(a, []byte(`{"id":"x","kind":"prompt"}`+"\n"), 0o600); err != nil {
+			t.Fatalf("write a: %v", err)
+		}
+		if err := os.WriteFile(b, []byte(`{"id":"y","kind":"prompt"}`+"\n"), 0o600); err != nil {
+			t.Fatalf("write b: %v", err)
+		}
+
+		var hits int
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			hits++
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer srv.Close()
+
+		var stdout, stderr bytes.Buffer
+		code := replayCore(dir, srv.URL, "", time.Time{}, true, false,
+			&http.Client{Timeout: 5 * time.Second}, &stdout, &stderr)
+		if code != 0 {
+			t.Fatalf("exit code = %d, want 0; stderr=%s", code, stderr.String())
+		}
+		if hits != 0 {
+			t.Errorf("server saw %d POSTs in --dry-run, want 0", hits)
+		}
+
+		out := stdout.String()
+		if !strings.Contains(out, "would replay: "+a) {
+			t.Errorf("missing 'would replay' line for %s in:\n%s", a, out)
+		}
+		if !strings.Contains(out, "would replay: "+b) {
+			t.Errorf("missing 'would replay' line for %s in:\n%s", b, out)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `agent-lens-hook replay` (closes ADR 0006 N1, the v0.1 hard blocker). Lists `*.ndjson` files under `--dir` (default `$HOME/.agent-lens/sessions`), filters by `--since`, sorts by mtime ascending so older sessions replay first, and POSTs each to `<url>/v1/events` with the same `Content-Type: application/x-ndjson` and optional `Authorization: Bearer` header that `transport.go` uses on the live path.
- `--dry-run` lists matching files without sending; `--remove-on-success` deletes a file after a 2xx response. A failure on one file is logged to stderr and the next file is still attempted; exit code 1 surfaces the partial failure, 2 covers usage / IO errors.
- Wires the subcommand into `cmd/agent-lens-hook/main.go` (one new `case` plus help-text line); no other subcommand or `transport.go` is touched. No new dependencies.

## Why now

`SPEC.md` §10.1, the README, and three code comments reference an `agent-lens-hook replay` command — but the command never existed. PR #76's overclaim scan caught this; ADR 0006 N1 promoted it to a v0.1 hard blocker.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./cmd/agent-lens-hook/ -count=1` all pass
- [x] `replay_test.go` covers the happy path (two files replayed in mtime order, correct `Content-Type`, summary line, dot-files and non-`.ndjson` skipped) and `--dry-run` (zero POSTs, `would replay:` lines for both files)
- [x] Manual smoke: `agent-lens-hook replay --dry-run --dir <tmp>` against a hand-written `.ndjson` prints `would replay: <path> (49 bytes, mtime 2026-05-06T03:11:28Z)` and a summary line
- [ ] Future follow-up if needed: end-to-end smoke with the real ingest server and `--remove-on-success`

## What this PR does NOT cover

- Per-event retry on partial NDJSON ingest failure — replay is whole-file POST today; if the server rejects a single bad line in a fallback file, the entire file is marked failed. v0.1 trade-off; revisit if dogfood surfaces a bad-line in the wild.
- No README / SPEC update in this PR (per scope guidance, per-subcommand `--help` is enough for v0.1; Phase 3 docs sweep can pick it up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)