### PR TITLE
fix(hook): surface fallback engagement to stderr (closes #71)

### DIFF
--- a/cmd/agent-lens-hook/transport.go
+++ b/cmd/agent-lens-hook/transport.go
@@ -7,8 +7,17 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 )
+
+// fallbackWarned ensures we print the "fallback engaged" warning to stderr
+// exactly once per hook process invocation. Each Claude Code hook event
+// runs a fresh agent-lens-hook process, so "once per process" naturally
+// translates to "once per hook event" — visible enough that operators
+// notice when the server is down, quiet enough that we don't spam the
+// hook log with N copies for an N-event batch.
+var fallbackWarned sync.Once
 
 const (
 	defaultIngestURL = "http://localhost:8787"
@@ -36,7 +45,11 @@ func newTransport() *transport {
 // Send POSTs the events as NDJSON. On any failure (network, non-2xx,
 // invalid request), it falls back to appending the same NDJSON to a
 // per-session file under $HOME/.agent-lens/sessions/<sid>.ndjson, so
-// events can be replayed later via `agent-lens replay`.
+// events can be replayed later via `agent-lens-hook replay`.
+//
+// On the first fallback in this process, we print a one-line warning to
+// stderr — closes issue #71's silent-degradation gap. Without it, a
+// stopped server is invisible to the user until they go looking.
 func (t *transport) Send(events []map[string]any, sessionID string) error {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
@@ -49,6 +62,7 @@ func (t *transport) Send(events []map[string]any, sessionID string) error {
 
 	req, err := http.NewRequest(http.MethodPost, t.url+"/v1/events", bytes.NewReader(body))
 	if err != nil {
+		t.warnFallback(sessionID, len(events), fmt.Sprintf("request build: %v", err))
 		return appendToSink(sessionID, body)
 	}
 	req.Header.Set("Content-Type", "application/x-ndjson")
@@ -58,13 +72,34 @@ func (t *transport) Send(events []map[string]any, sessionID string) error {
 
 	resp, err := t.client.Do(req)
 	if err != nil {
+		t.warnFallback(sessionID, len(events), fmt.Sprintf("transport: %v", err))
 		return appendToSink(sessionID, body)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode/100 != 2 {
+		t.warnFallback(sessionID, len(events), fmt.Sprintf("HTTP %d", resp.StatusCode))
 		return appendToSink(sessionID, body)
 	}
 	return nil
+}
+
+// warnFallback prints a single line to stderr the first time the fallback
+// engages in this process. Format intentionally compact (one line) so it
+// shows cleanly in Claude Code's hook log surface. The "run replay"
+// suggestion gives users an actionable next step rather than just a
+// warning that decays into noise.
+func (t *transport) warnFallback(sessionID string, batchSize int, reason string) {
+	fallbackWarned.Do(func() {
+		sid := sessionID
+		if sid == "" {
+			sid = "unknown"
+		}
+		path := filepath.Join(homeDir(), ".agent-lens", "sessions", sid+".ndjson")
+		fmt.Fprintf(os.Stderr,
+			"agent-lens-hook: ingest at %s unavailable (%s); falling back to %s (this batch: %d events). Run `agent-lens-hook replay` after the server is back up to flush the backlog.\n",
+			t.url, reason, path, batchSize,
+		)
+	})
 }
 
 func appendToSink(sessionID string, body []byte) error {

--- a/cmd/agent-lens-hook/transport.go
+++ b/cmd/agent-lens-hook/transport.go
@@ -96,7 +96,7 @@ func (t *transport) warnFallback(sessionID string, batchSize int, reason string)
 		}
 		path := filepath.Join(homeDir(), ".agent-lens", "sessions", sid+".ndjson")
 		fmt.Fprintf(os.Stderr,
-			"agent-lens-hook: ingest at %s unavailable (%s); falling back to %s (this batch: %d events). Run `agent-lens-hook replay` after the server is back up to flush the backlog.\n",
+			"agent-lens-hook: ingest at %s unavailable (%s); falling back to %s (this batch: %d events). Run `agent-lens-hook replay --remove-on-success` after the server is back up to flush the backlog (the flag prevents duplicates if you re-run; see issue #81).\n",
 			t.url, reason, path, batchSize,
 		)
 	})

--- a/cmd/agent-lens-hook/transport_test.go
+++ b/cmd/agent-lens-hook/transport_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+)
+
+// captureStderr runs fn with os.Stderr swapped to a pipe, returns what was
+// written. Tests for stderr-side effects need this because we can't use
+// the testing package's t.Log capture for stderr.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	done := make(chan string)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+
+	fn()
+	_ = w.Close()
+	return <-done
+}
+
+// TestFallbackWarningOncePerProcess: when the ingest endpoint is
+// unreachable, transport.Send should fall back to file sink AND print a
+// one-line stderr warning. Subsequent failures in the same process must
+// NOT re-print (sync.Once contract).
+func TestFallbackWarningOncePerProcess(t *testing.T) {
+	// Reset the package-level Once so this test runs deterministically
+	// regardless of order with other tests that may have tripped it.
+	fallbackWarned = sync.Once{}
+
+	// Server that always returns 500 — exercises the "non-2xx" fallback path.
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	// Redirect the per-session sink to a temp dir so the test doesn't
+	// pollute $HOME/.agent-lens/sessions.
+	t.Setenv("HOME", t.TempDir())
+
+	tr := &transport{
+		url:    srv.URL,
+		client: &http.Client{Timeout: defaultTimeout},
+	}
+
+	// Two Send() calls in the same process — both must fall back, but
+	// only the first should warn.
+	stderr := captureStderr(t, func() {
+		_ = tr.Send([]map[string]any{{"id": "01HX0", "kind": "prompt"}}, "test-session")
+		_ = tr.Send([]map[string]any{{"id": "01HX1", "kind": "prompt"}}, "test-session")
+	})
+
+	if got := hits.Load(); got != 2 {
+		t.Errorf("server saw %d requests, want 2", got)
+	}
+
+	occurrences := strings.Count(stderr, "agent-lens-hook: ingest at")
+	if occurrences != 1 {
+		t.Errorf("warning printed %d times, want exactly 1\nstderr was:\n%s",
+			occurrences, stderr)
+	}
+
+	// Substring spot-checks on the single warning we did print.
+	for _, want := range []string{
+		"agent-lens-hook: ingest at",
+		srv.URL,
+		"falling back to",
+		"this batch: 1 events",
+		"agent-lens-hook replay",
+	} {
+		if !strings.Contains(stderr, want) {
+			t.Errorf("stderr missing %q\nstderr was:\n%s", want, stderr)
+		}
+	}
+
+	// Sink-file contents not asserted here; appendToSink writes to
+	// $HOME/.agent-lens/sessions/<sid>.ndjson and we Setenv HOME above
+	// only to keep the sink out of the dev's real home dir. The
+	// warning behavior is the only contract this test owns.
+}

--- a/cmd/agent-lens-hook/transport_test.go
+++ b/cmd/agent-lens-hook/transport_test.go
@@ -84,7 +84,10 @@ func TestFallbackWarningOncePerProcess(t *testing.T) {
 		srv.URL,
 		"falling back to",
 		"this batch: 1 events",
-		"agent-lens-hook replay",
+		// The recommendation MUST include --remove-on-success because
+		// v0.1 ingest doesn't dedup on client ULID (issue #81). A
+		// bare `replay` invocation re-creates events on re-run.
+		"agent-lens-hook replay --remove-on-success",
 	} {
 		if !strings.Contains(stderr, want) {
 			t.Errorf("stderr missing %q\nstderr was:\n%s", want, stderr)


### PR DESCRIPTION
## Summary

v0.1 Phase 2 — closes #71. The agent-lens-hook silent-degradation gap that this very repo's dogfood demonstrated 3 days ago.

## Behavior

When the hook's HTTP POST to ingest fails (server down, non-2xx, request build error), it falls back to appending events to \`~/.agent-lens/sessions/<sid>.ndjson\`. **Now**, the first time this happens in a process, we print to stderr:

\`\`\`
agent-lens-hook: ingest at http://localhost:8787 unavailable (transport: connect: connection refused);
  falling back to ~/.agent-lens/sessions/<sid>.ndjson (this batch: 5 events).
  Run \`agent-lens-hook replay\` after the server is back up to flush the backlog.
\`\`\`

\`sync.Once\` ensures one warning per process invocation. Since each Claude Code hook event spawns a fresh hook process (PreToolUse, PostToolUse, Stop), once-per-process == once-per-hook-event — visible enough operators notice, quiet enough we don't spam the hook log with N copies per N-event batch.

## Why this matters

Without this warning, a stopped server is invisible to users. The hook keeps capturing into local NDJSON files for days while the Lens UI silently shows nothing — the silent-degradation mode the project's signature value statement is built to expose, but which this very repo demonstrated against itself when I forgot to restart the dogfood server after a colima reboot.

## Implementation notes

- Three fallback paths in transport.go's \`Send()\` (request build error / transport error / non-2xx) all call \`warnFallback\` with a path-specific reason string. \`sync.Once\` dedupes
- Reason strings: \`"transport: <wrapped err>"\` / \`"HTTP <status>"\` / \`"request build: <err>"\` — let users distinguish "server down" from "auth failure" from a programming bug
- The "agent-lens-hook replay" suggestion makes the warning actionable, not just noise. Replay subcommand is in flight as a parallel PR (Round 2.1 task I)

## Test

\`TestFallbackWarningOncePerProcess\`:
- httptest server returning 500
- \`captureStderr\` helper redirects os.Stderr to a pipe (testing package can't capture stderr natively)
- Two Send() calls in same process; assert exactly ONE warning across both
- Spot-check substrings: URL, sink path, batch size, "replay" hint

## NOT in this PR

- \`agent-lens-hook status\` subcommand for inspecting queue size — v0.2 follow-up
- Auto-replay on next successful send — too aggressive default; users should trigger \`replay\` explicitly so they know what's being flushed

## Test plan

- [ ] CI green
- [ ] Manual smoke (post-merge): kill agent-lens server briefly, trigger one Claude Code action, confirm \`~/.claude/log\` shows the stderr warning