### PR TITLE
feat(hook): add setup subcommand for personal-mode install (C)

### DIFF
--- a/cmd/agent-lens-hook/main.go
+++ b/cmd/agent-lens-hook/main.go
@@ -15,6 +15,7 @@ Subcommands:
   git-post-commit        Capture a git post-commit event and forward.
   verify                 Verify the local hash chain of a session.
   replay                 Re-POST fallback NDJSON files to the ingest server.
+  setup                  Wire hooks into Claude Code (and start docker compose).
   keygen                 Generate an ed25519 key pair for DSSE attestations.
   export                 Export an in-toto / SLSA attestation, or an audit report.
   sign-release           Sign a release binary and emit a DSSE attestation.
@@ -40,6 +41,8 @@ func main() {
 		runVerify(os.Args[2:])
 	case "replay":
 		runReplay(os.Args[2:])
+	case "setup":
+		runSetup(os.Args[2:])
 	case "keygen":
 		runKeygen(os.Args[2:])
 	case "export":
@@ -62,6 +65,7 @@ func main() {
 // runGitPostCommit is implemented in git.go.
 // runVerify is implemented in verify.go.
 // runReplay is implemented in replay.go.
+// runSetup is implemented in setup.go.
 // runKeygen is implemented in keygen.go.
 // runExport is implemented in export.go.
 // runSignRelease is implemented in sign_release.go.

--- a/cmd/agent-lens-hook/setup.go
+++ b/cmd/agent-lens-hook/setup.go
@@ -1,0 +1,475 @@
+package main
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+//go:embed setup_compose.yml
+var setupComposeTemplate string
+
+const setupUsage = `agent-lens-hook setup — wire agent-lens into Claude Code.
+
+Usage:
+  agent-lens-hook setup [--personal | --project-only] [--uninstall]
+                        [--image <ref>] [--skip-compose] [--healthz-timeout <dur>]
+
+Modes (mutually exclusive):
+  --personal       (default) hook config goes to $HOME/.claude/settings.json
+                   so every Claude Code session anywhere on this machine is
+                   captured. Required for sub-agent (Task tool) capture per
+                   ADR 0007 D1.
+  --project-only   hook config goes to .claude/settings.local.json in the
+                   current working directory; only this repo's sessions
+                   are captured. Sub-agents started in worktree-isolated
+                   scopes (under .claude/worktrees/) WILL NOT be captured
+                   under this mode — by design.
+
+Compose orchestration (default: managed):
+  --image <ref>    container image for the server (default
+                   ghcr.io/dong-qiu/agent-lens:latest). Override for
+                   private registry / dev builds.
+  --skip-compose   don't manage docker compose; assume the user runs
+                   the server themselves.
+  --healthz-timeout <dur>
+                   how long to wait for /healthz to return 200 after
+                   compose up (default 60s).
+
+Reverse:
+  --uninstall      remove agent-lens hook entries from settings (leaves
+                   other tools' entries untouched) and run
+                   ` + "`docker compose down`" + ` if compose was managed.
+
+The hook command path written into settings.json is the absolute path
+of the running agent-lens-hook binary (os.Executable). So if you move
+the binary or upgrade via ` + "`go install`" + `, just re-run setup.
+
+Exit codes: 0 success, 2 usage / IO / docker errors.
+`
+
+// Hook event types we register for. The set MUST stay in sync with
+// the events claude.go's Send() handles, otherwise some interactions
+// stop being captured silently.
+var setupHookEvents = []string{
+	"SessionStart",
+	"UserPromptSubmit",
+	"PreToolUse",
+	"PostToolUse",
+	"Stop",
+}
+
+func runSetup(args []string) {
+	fs := flag.NewFlagSet("setup", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+	var (
+		personal       = fs.Bool("personal", false, "user-global hook install (default)")
+		projectOnly    = fs.Bool("project-only", false, "scope hooks to current repo")
+		uninstall      = fs.Bool("uninstall", false, "remove hook entries (and docker compose down)")
+		image          = fs.String("image", "ghcr.io/dong-qiu/agent-lens:latest", "container image for the server")
+		skipCompose    = fs.Bool("skip-compose", false, "don't manage docker compose")
+		healthzTimeout = fs.Duration("healthz-timeout", 60*time.Second, "how long to wait for /healthz")
+	)
+	fs.Usage = func() { fmt.Fprint(os.Stderr, setupUsage) }
+	if err := fs.Parse(args); err != nil {
+		os.Exit(2)
+	}
+
+	if *personal && *projectOnly {
+		fmt.Fprintln(os.Stderr, "agent-lens-hook setup: --personal and --project-only are mutually exclusive")
+		os.Exit(2)
+	}
+	scope := scopePersonal
+	if *projectOnly {
+		scope = scopeProjectOnly
+	}
+
+	if err := doSetup(setupOpts{
+		uninstall:      *uninstall,
+		scope:          scope,
+		image:          *image,
+		skipCompose:    *skipCompose,
+		healthzTimeout: *healthzTimeout,
+		stdout:         os.Stdout,
+		stderr:         os.Stderr,
+	}); err != nil {
+		fmt.Fprintf(os.Stderr, "agent-lens-hook setup: %v\n", err)
+		os.Exit(2)
+	}
+}
+
+type setupScope int
+
+const (
+	scopePersonal setupScope = iota
+	scopeProjectOnly
+)
+
+type setupOpts struct {
+	uninstall      bool
+	scope          setupScope
+	image          string
+	skipCompose    bool
+	healthzTimeout time.Duration
+	// I/O writers — injected for testability
+	stdout, stderr interface{ Write([]byte) (int, error) }
+}
+
+func doSetup(o setupOpts) error {
+	binPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("locate self: %w", err)
+	}
+	settingsPath, err := resolveSettingsPath(o.scope)
+	if err != nil {
+		return err
+	}
+
+	if o.uninstall {
+		if err := unmergeAgentLensHooks(settingsPath); err != nil {
+			return fmt.Errorf("unmerge hooks: %w", err)
+		}
+		_, _ = fmt.Fprintf(o.stdout, "removed agent-lens hook entries from %s\n", settingsPath)
+		if !o.skipCompose && o.scope == scopePersonal {
+			if err := composeDown(); err != nil {
+				_, _ = fmt.Fprintf(o.stderr, "WARN: compose down failed: %v\n", err)
+			} else {
+				_, _ = fmt.Fprintf(o.stdout, "stopped docker compose stack\n")
+			}
+		}
+		return nil
+	}
+
+	if err := mergeAgentLensHooks(settingsPath, binPath); err != nil {
+		return fmt.Errorf("merge hooks: %w", err)
+	}
+	_, _ = fmt.Fprintf(o.stdout, "wired agent-lens hooks into %s\n", settingsPath)
+
+	if o.scope == scopePersonal && !o.skipCompose {
+		if err := checkDocker(); err != nil {
+			return fmt.Errorf("docker check: %w", err)
+		}
+		composePath, err := writeComposeFile(o.image)
+		if err != nil {
+			return fmt.Errorf("write compose: %w", err)
+		}
+		_, _ = fmt.Fprintf(o.stdout, "wrote compose file to %s\n", composePath)
+
+		if err := composeUp(composePath); err != nil {
+			return fmt.Errorf("compose up: %w", err)
+		}
+		_, _ = fmt.Fprintf(o.stdout, "compose stack starting (postgres + minio + agent-lens)\n")
+
+		if err := waitHealthz("http://localhost:8787/healthz", o.healthzTimeout); err != nil {
+			return fmt.Errorf("healthz wait: %w (run `docker compose -f %s logs agent-lens` to debug)", err, composePath)
+		}
+		_, _ = fmt.Fprintf(o.stdout, "agent-lens healthy at http://localhost:8787\n")
+	}
+
+	_, _ = fmt.Fprintf(o.stdout, "\nSetup complete. Open http://localhost:8787 in a browser for the Lens UI.\n")
+	return nil
+}
+
+// resolveSettingsPath returns the absolute path the hook config should
+// live in for the chosen scope. The personal path is created if it
+// doesn't exist; the project-only path requires .claude/ to already exist
+// (since that signals the user has set up Claude Code for this repo).
+func resolveSettingsPath(scope setupScope) (string, error) {
+	if scope == scopeProjectOnly {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(cwd, ".claude", "settings.local.json"), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "settings.json"), nil
+}
+
+// mergeAgentLensHooks reads settings (or starts fresh if missing),
+// inserts an agent-lens-hook entry under each event in setupHookEvents
+// IF that event doesn't already have one for our binary, and writes the
+// result back atomically. Other tools' hook entries are preserved
+// verbatim — only-add semantics, never delete or reorder.
+func mergeAgentLensHooks(settingsPath, binPath string) error {
+	settings, err := readSettings(settingsPath)
+	if err != nil {
+		return err
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		hooks = map[string]any{}
+		settings["hooks"] = hooks
+	}
+
+	for _, event := range setupHookEvents {
+		matchers, _ := hooks[event].([]any)
+		// Walk existing matchers; if any already has an agent-lens-hook
+		// command, we're done with this event (idempotent).
+		if alreadyOurs(matchers) {
+			continue
+		}
+		matchers = append(matchers, map[string]any{
+			"matcher": "*",
+			"hooks": []any{
+				map[string]any{
+					"type":    "command",
+					"command": binPath + " claude",
+					"timeout": 5,
+				},
+			},
+		})
+		hooks[event] = matchers
+	}
+
+	return writeSettings(settingsPath, settings)
+}
+
+// unmergeAgentLensHooks is the inverse of mergeAgentLensHooks. For each
+// event, drop matchers whose first hook command is ours, leaving the
+// rest untouched. If an event ends up with no matchers, the key is
+// removed (so we don't leave empty arrays scattered).
+func unmergeAgentLensHooks(settingsPath string) error {
+	settings, err := readSettings(settingsPath)
+	if err != nil {
+		// Missing settings = nothing to remove; success.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil
+		}
+		return err
+	}
+	hooks, _ := settings["hooks"].(map[string]any)
+	if hooks == nil {
+		return nil
+	}
+
+	for _, event := range setupHookEvents {
+		matchers, _ := hooks[event].([]any)
+		filtered := matchers[:0]
+		for _, m := range matchers {
+			mm, _ := m.(map[string]any)
+			if !matcherIsOurs(mm) {
+				filtered = append(filtered, m)
+			}
+		}
+		if len(filtered) == 0 {
+			delete(hooks, event)
+		} else {
+			hooks[event] = filtered
+		}
+	}
+	if len(hooks) == 0 {
+		delete(settings, "hooks")
+	}
+
+	return writeSettings(settingsPath, settings)
+}
+
+// alreadyOurs reports whether any matcher in the slice has at least one
+// hook entry whose command points at agent-lens-hook.
+func alreadyOurs(matchers []any) bool {
+	for _, m := range matchers {
+		if matcherIsOurs(m) {
+			return true
+		}
+	}
+	return false
+}
+
+// matcherIsOurs reports whether `m` (a single matcher object) has at
+// least one hook entry that's ours. Used by both alreadyOurs (for
+// idempotency) and unmergeAgentLensHooks (for removal).
+func matcherIsOurs(m any) bool {
+	mm, _ := m.(map[string]any)
+	if mm == nil {
+		return false
+	}
+	hooks, _ := mm["hooks"].([]any)
+	for _, h := range hooks {
+		hh, _ := h.(map[string]any)
+		if hh == nil {
+			continue
+		}
+		cmd, _ := hh["command"].(string)
+		if commandIsAgentLensHook(cmd) {
+			return true
+		}
+	}
+	return false
+}
+
+// commandIsAgentLensHook matches a hook command line if its first
+// space-separated token's basename equals "agent-lens-hook". Catches
+// our binary regardless of installation path (go install / brew /
+// release tarball) without false-positives on tools whose names happen
+// to contain "agent-lens-hook" as a substring.
+func commandIsAgentLensHook(cmd string) bool {
+	if cmd == "" {
+		return false
+	}
+	fields := strings.Fields(cmd)
+	if len(fields) == 0 {
+		return false
+	}
+	return filepath.Base(fields[0]) == "agent-lens-hook"
+}
+
+// readSettings reads + parses the JSON settings file. A missing file
+// (typical for fresh installs) returns an empty map, NOT an error.
+func readSettings(path string) (map[string]any, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return map[string]any{}, nil
+		}
+		return nil, err
+	}
+	if len(raw) == 0 {
+		return map[string]any{}, nil
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(raw, &settings); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if settings == nil {
+		settings = map[string]any{}
+	}
+	return settings, nil
+}
+
+// writeSettings serializes settings as pretty JSON and writes it to
+// path atomically (write to <path>.tmp + rename) so a crash mid-write
+// can't corrupt the user's settings.json.
+func writeSettings(path string, settings map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	out, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return err
+	}
+	out = append(out, '\n')
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// checkDocker returns an error with an actionable hint if `docker` is
+// missing or the daemon isn't reachable. We don't try to install or
+// start docker — that's a setup step the user owns.
+func checkDocker() error {
+	if _, err := exec.LookPath("docker"); err != nil {
+		return errors.New("`docker` not found on PATH; install Docker Desktop / colima / orbstack first, then re-run setup")
+	}
+	cmd := exec.Command("docker", "info")
+	cmd.Stderr = nil
+	cmd.Stdout = nil
+	if err := cmd.Run(); err != nil {
+		return errors.New("`docker info` failed; the docker daemon may not be running. Start Docker Desktop / `colima start` / `orbstack start` and re-run setup")
+	}
+	return nil
+}
+
+// writeComposeFile materializes the embedded compose template at
+// $HOME/.agent-lens/compose.yml with the {{IMAGE}} placeholder
+// substituted. Returns the absolute path so callers can pass it to
+// `docker compose -f ...`.
+func writeComposeFile(image string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".agent-lens")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return "", err
+	}
+	contents := strings.ReplaceAll(setupComposeTemplate, "{{IMAGE}}", image)
+	path := filepath.Join(dir, "compose.yml")
+	if err := os.WriteFile(path, []byte(contents), 0o644); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func composeUp(path string) error {
+	cmd := exec.Command("docker", "compose", "-f", path, "up", "-d")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func composeDown() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(home, ".agent-lens", "compose.yml")
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	cmd := exec.Command("docker", "compose", "-f", path, "down")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// waitHealthz polls the URL with exponential-ish backoff until 200 or
+// timeout. Returns the wrapped error from the LAST attempt so the
+// user sees a representative failure mode rather than the very first
+// "connection refused" before the server has bound its port.
+func waitHealthz(url string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	var lastErr error
+	delay := 500 * time.Millisecond
+	for {
+		select {
+		case <-ctx.Done():
+			if lastErr != nil {
+				return fmt.Errorf("timed out after %s: last error: %w", timeout, lastErr)
+			}
+			return fmt.Errorf("timed out after %s", timeout)
+		default:
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			return err
+		}
+		client := &http.Client{Timeout: 2 * time.Second}
+		resp, err := client.Do(req)
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+			lastErr = fmt.Errorf("HTTP %d", resp.StatusCode)
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("timed out after %s: last error: %w", timeout, lastErr)
+		case <-time.After(delay):
+		}
+		if delay < 4*time.Second {
+			delay *= 2
+		}
+	}
+}

--- a/cmd/agent-lens-hook/setup.go
+++ b/cmd/agent-lens-hook/setup.go
@@ -208,6 +208,9 @@ func mergeAgentLensHooks(settingsPath, binPath string) error {
 	if err != nil {
 		return err
 	}
+	if err := validateHooksShape(settings); err != nil {
+		return fmt.Errorf("%s: %w (please fix manually before re-running setup)", settingsPath, err)
+	}
 	hooks, _ := settings["hooks"].(map[string]any)
 	if hooks == nil {
 		hooks = map[string]any{}
@@ -249,6 +252,9 @@ func unmergeAgentLensHooks(settingsPath string) error {
 			return nil
 		}
 		return err
+	}
+	if err := validateHooksShape(settings); err != nil {
+		return fmt.Errorf("%s: %w (please fix manually before re-running setup --uninstall)", settingsPath, err)
 	}
 	hooks, _ := settings["hooks"].(map[string]any)
 	if hooks == nil {
@@ -324,6 +330,40 @@ func commandIsAgentLensHook(cmd string) bool {
 		return false
 	}
 	return filepath.Base(fields[0]) == "agent-lens-hook"
+}
+
+// validateHooksShape rejects settings whose 'hooks' tree isn't the
+// shape Claude Code's settings.json schema requires. Without this
+// check, a hand-edited settings.json with `"hooks": "string"` would
+// be silently overwritten — the exact silent-degradation pattern this
+// project's signature value statement is built to prevent. Caller
+// surfaces the location to the user with a "fix manually" hint.
+//
+// We validate the outer shape (object → array → object) but NOT the
+// per-hook fields (type / command / timeout); those are Claude Code's
+// schema, not ours, and our merge only inspects `command` via
+// commandIsAgentLensHook which itself fails closed on missing fields.
+func validateHooksShape(settings map[string]any) error {
+	raw, present := settings["hooks"]
+	if !present {
+		return nil
+	}
+	hooks, ok := raw.(map[string]any)
+	if !ok {
+		return fmt.Errorf("'hooks' is %T, want a JSON object", raw)
+	}
+	for event, eventValue := range hooks {
+		matchers, ok := eventValue.([]any)
+		if !ok {
+			return fmt.Errorf("'hooks.%s' is %T, want a JSON array", event, eventValue)
+		}
+		for i, matcherValue := range matchers {
+			if _, ok := matcherValue.(map[string]any); !ok {
+				return fmt.Errorf("'hooks.%s[%d]' is %T, want a JSON object", event, i, matcherValue)
+			}
+		}
+	}
+	return nil
 }
 
 // readSettings reads + parses the JSON settings file. A missing file

--- a/cmd/agent-lens-hook/setup_compose.yml
+++ b/cmd/agent-lens-hook/setup_compose.yml
@@ -1,0 +1,46 @@
+# Personal-mode docker compose template — written by `agent-lens-hook setup
+# --personal` to $HOME/.agent-lens/compose.yml. Differs from
+# deploy/compose/docker-compose.yml in two ways: (1) references the
+# published GHCR image instead of building from source, (2) data volumes
+# live under $HOME/.agent-lens/data/ so the user owns them outside any
+# repo checkout. The {{IMAGE}} placeholder is substituted at write time
+# from the --image flag (default ghcr.io/dong-qiu/agent-lens:latest).
+services:
+  postgres:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_USER: agentlens
+      POSTGRES_PASSWORD: agentlens
+      POSTGRES_DB: agentlens
+    ports:
+      - "5432:5432"
+    volumes:
+      - ./data/pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U agentlens"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: agentlens
+      MINIO_ROOT_PASSWORD: agentlens-secret
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - ./data/minio:/data
+
+  agent-lens:
+    image: {{IMAGE}}
+    environment:
+      AGENT_LENS_ADDR: ":8787"
+      AGENT_LENS_PG_DSN: "postgres://agentlens:agentlens@postgres:5432/agentlens?sslmode=disable"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8787:8787"

--- a/cmd/agent-lens-hook/setup_test.go
+++ b/cmd/agent-lens-hook/setup_test.go
@@ -209,6 +209,67 @@ func TestUnmergeKeepsOthers(t *testing.T) {
 	}
 }
 
+// TestMergeRefusesMalformedHooks: when the user has hand-edited
+// settings.json into a shape that doesn't match Claude Code's schema
+// (e.g. "hooks" set to a string), merge MUST refuse rather than
+// silently overwrite. Silent overwrite would discard whatever the user
+// was trying to express — exactly the silent-degradation pattern this
+// project is built to surface.
+func TestMergeRefusesMalformedHooks(t *testing.T) {
+	cases := []struct {
+		name string
+		in   map[string]any
+		want string
+	}{
+		{
+			name: "hooks-is-string",
+			in:   map[string]any{"hooks": "this-should-be-an-object"},
+			want: "'hooks' is string, want a JSON object",
+		},
+		{
+			name: "event-is-string",
+			in:   map[string]any{"hooks": map[string]any{"PreToolUse": "not-an-array"}},
+			want: "'hooks.PreToolUse' is string, want a JSON array",
+		},
+		{
+			name: "matcher-is-number",
+			in: map[string]any{"hooks": map[string]any{
+				"PreToolUse": []any{42},
+			}},
+			want: "'hooks.PreToolUse[0]' is float64, want a JSON object",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "settings.json")
+			writeJSON(t, path, tc.in)
+			origBytes, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = mergeAgentLensHooks(path, "/usr/local/bin/agent-lens-hook")
+			if err == nil {
+				t.Fatalf("expected error, got nil; file mutated to:\n%s", readBytes(t, path))
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error %q missing %q", err.Error(), tc.want)
+			}
+
+			// File must NOT have been modified — error means refuse,
+			// not "ate the data and complained on the way out".
+			postBytes, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(origBytes) != string(postBytes) {
+				t.Errorf("file mutated despite error:\nbefore:\n%s\nafter:\n%s", origBytes, postBytes)
+			}
+		})
+	}
+}
+
 func TestCommandIsAgentLensHook(t *testing.T) {
 	cases := []struct {
 		cmd  string
@@ -257,6 +318,17 @@ func writeJSON(t *testing.T, path string, m map[string]any) {
 
 func debugJSON(v any) string {
 	b, _ := json.MarshalIndent(v, "", "  ")
+	return string(b)
+}
+
+// readBytes is a fatal-on-error file reader used in error-path tests
+// where we need to display the file's post-error state in a t.Errorf.
+func readBytes(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
 	return string(b)
 }
 

--- a/cmd/agent-lens-hook/setup_test.go
+++ b/cmd/agent-lens-hook/setup_test.go
@@ -1,0 +1,297 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// TestMergeAgentLensHooksFreshFile: empty / missing settings.json → all
+// 5 events get our hook entry, no other keys appear.
+func TestMergeAgentLensHooksFreshFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+
+	if err := mergeAgentLensHooks(path, "/usr/local/bin/agent-lens-hook"); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+
+	got := readJSON(t, path)
+	hooks, _ := got["hooks"].(map[string]any)
+	if hooks == nil {
+		t.Fatalf("settings missing hooks key:\n%s", debugJSON(got))
+	}
+	for _, ev := range setupHookEvents {
+		matchers, _ := hooks[ev].([]any)
+		if len(matchers) != 1 {
+			t.Errorf("event %q: got %d matchers, want 1", ev, len(matchers))
+			continue
+		}
+		if !alreadyOurs(matchers) {
+			t.Errorf("event %q: alreadyOurs returned false on freshly-written entry", ev)
+		}
+	}
+}
+
+// TestMergeIdempotent: re-running merge twice produces a settings file
+// byte-equal to running it once. Critical UX promise: users can re-run
+// `setup --personal` to recover from a botched manual edit without
+// duplicating entries.
+func TestMergeIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	bin := "/usr/local/bin/agent-lens-hook"
+
+	if err := mergeAgentLensHooks(path, bin); err != nil {
+		t.Fatalf("first merge: %v", err)
+	}
+	first, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeAgentLensHooks(path, bin); err != nil {
+		t.Fatalf("second merge: %v", err)
+	}
+	second, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(first) != string(second) {
+		t.Errorf("re-running merge changed settings (not idempotent)\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}
+
+// TestMergePreservesOtherKeys: the user's settings.json with unrelated
+// top-level keys (theme, plugins, permissions, OTHER tools' hooks)
+// must come back unchanged except for the hooks we add. This is THE
+// promise that justifies setup over a manual sed.
+func TestMergePreservesOtherKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	// Pre-populate with the kind of stuff a real user has — including
+	// another tool's hook entry and a non-overlapping permissions block.
+	pre := map[string]any{
+		"theme": "dark",
+		"enabledPlugins": map[string]any{
+			"some-plugin@marketplace": true,
+		},
+		"permissions": map[string]any{
+			"allow": []any{"Bash(npm test)"},
+		},
+		"hooks": map[string]any{
+			"PreToolUse": []any{
+				map[string]any{
+					"matcher": "*",
+					"hooks": []any{
+						map[string]any{
+							"type":    "command",
+							"command": "/some/other/tool/their-hook record",
+							"timeout": 10,
+						},
+					},
+				},
+			},
+		},
+	}
+	writeJSON(t, path, pre)
+
+	if err := mergeAgentLensHooks(path, "/usr/local/bin/agent-lens-hook"); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+
+	got := readJSON(t, path)
+
+	if got["theme"] != "dark" {
+		t.Errorf("theme not preserved: %v", got["theme"])
+	}
+	if !reflect.DeepEqual(got["enabledPlugins"], pre["enabledPlugins"]) {
+		t.Errorf("enabledPlugins clobbered:\nwant %v\ngot  %v", pre["enabledPlugins"], got["enabledPlugins"])
+	}
+	if !reflect.DeepEqual(got["permissions"], pre["permissions"]) {
+		t.Errorf("permissions clobbered:\nwant %v\ngot  %v", pre["permissions"], got["permissions"])
+	}
+
+	hooks, _ := got["hooks"].(map[string]any)
+	preToolMatchers, _ := hooks["PreToolUse"].([]any)
+	if len(preToolMatchers) != 2 {
+		t.Errorf("PreToolUse: got %d matchers, want 2 (one ours, one preserved)\n%s",
+			len(preToolMatchers), debugJSON(hooks))
+	}
+	// First matcher must be the user's existing one (not reordered).
+	first, _ := preToolMatchers[0].(map[string]any)
+	firstHooks, _ := first["hooks"].([]any)
+	firstHook, _ := firstHooks[0].(map[string]any)
+	if cmd, _ := firstHook["command"].(string); !strings.Contains(cmd, "their-hook") {
+		t.Errorf("user's existing PreToolUse hook was reordered; first command = %q", cmd)
+	}
+}
+
+// TestUnmergeRoundTrip: merge then unmerge yields settings semantically
+// equal to the pre-state. Closes the install/uninstall promise:
+// --uninstall reverts to the user's pre-install state. We compare by
+// re-parsing both sides through encoding/json so trailing-newline /
+// indentation / number-type (int vs float64) noise from the JSON round
+// trip doesn't cause false failures.
+func TestUnmergeRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	pre := map[string]any{
+		"theme": "dark",
+	}
+	// Use writeSettings (the production writer) so the pre-state's
+	// formatting matches the post-state's, isolating the test from
+	// trailing-newline noise.
+	if err := writeSettings(path, pre); err != nil {
+		t.Fatal(err)
+	}
+	preCanon := canonicalJSON(t, path)
+
+	if err := mergeAgentLensHooks(path, "/path/to/agent-lens-hook"); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if err := unmergeAgentLensHooks(path); err != nil {
+		t.Fatalf("unmerge: %v", err)
+	}
+	postCanon := canonicalJSON(t, path)
+
+	if preCanon != postCanon {
+		t.Errorf("round-trip changed semantic content:\npre:\n%s\npost:\n%s", preCanon, postCanon)
+	}
+}
+
+// TestUnmergeKeepsOthers: when a user has multiple tools' hooks
+// registered, unmerge removes only ours, leaving the rest exact-shape.
+func TestUnmergeKeepsOthers(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "settings.json")
+	otherTool := map[string]any{
+		"matcher": "*",
+		"hooks": []any{
+			map[string]any{
+				"type":    "command",
+				"command": "/some/other/tool/their-hook record",
+				"timeout": 10,
+			},
+		},
+	}
+	writeJSON(t, path, map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []any{otherTool},
+		},
+	})
+
+	if err := mergeAgentLensHooks(path, "/path/to/agent-lens-hook"); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if err := unmergeAgentLensHooks(path); err != nil {
+		t.Fatalf("unmerge: %v", err)
+	}
+
+	got := readJSON(t, path)
+	hooks, _ := got["hooks"].(map[string]any)
+	preToolMatchers, _ := hooks["PreToolUse"].([]any)
+	if len(preToolMatchers) != 1 {
+		t.Errorf("got %d PreToolUse matchers post-unmerge, want 1 (the other tool)\n%s",
+			len(preToolMatchers), debugJSON(hooks))
+	}
+	// Compare via JSON to avoid int-vs-float64 noise from the unmarshal
+	// path (Go literal int 10 in `otherTool` becomes float64 after JSON
+	// round trip; reflect.DeepEqual would say not-equal even though
+	// the JSON is byte-equal).
+	if jsonEqual(t, preToolMatchers[0], otherTool) == false {
+		t.Errorf("other tool's matcher was modified during round trip\nwant: %s\ngot:  %s",
+			debugJSON(otherTool), debugJSON(preToolMatchers[0]))
+	}
+}
+
+func TestCommandIsAgentLensHook(t *testing.T) {
+	cases := []struct {
+		cmd  string
+		want bool
+	}{
+		{"/usr/local/bin/agent-lens-hook claude", true},
+		{"/Users/dongqiu/go/bin/agent-lens-hook claude", true},
+		{"agent-lens-hook claude", true}, // PATH-relative still our binary
+		{"/usr/bin/agent-lens-hook-extra report", false},
+		{"/usr/bin/their-tool record", false},
+		{"", false},
+		{"  ", false},
+	}
+	for _, tc := range cases {
+		if got := commandIsAgentLensHook(tc.cmd); got != tc.want {
+			t.Errorf("commandIsAgentLensHook(%q) = %v, want %v", tc.cmd, got, tc.want)
+		}
+	}
+}
+
+// helpers --------------------------------------------------------------
+
+func readJSON(t *testing.T, path string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		t.Fatalf("unmarshal %s: %v\n%s", path, err, raw)
+	}
+	return m
+}
+
+func writeJSON(t *testing.T, path string, m map[string]any) {
+	t.Helper()
+	raw, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func debugJSON(v any) string {
+	b, _ := json.MarshalIndent(v, "", "  ")
+	return string(b)
+}
+
+// canonicalJSON re-parses a settings file and re-serializes it with
+// fixed indentation. Used to compare semantic content without being
+// fooled by whitespace or number-type round-trip artifacts.
+func canonicalJSON(t *testing.T, path string) string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var v any
+	if err := json.Unmarshal(raw, &v); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(out)
+}
+
+// jsonEqual reports whether two values produce identical JSON when
+// marshaled. More forgiving than reflect.DeepEqual for maps with
+// numeric values that crossed an Unmarshal/Marshal boundary.
+func jsonEqual(t *testing.T, a, b any) bool {
+	t.Helper()
+	aj, err := json.Marshal(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	bj, err := json.Marshal(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(aj) == string(bj)
+}


### PR DESCRIPTION
## Summary

Round 2.2.1 — implements **C**, the v0.1 canonical install UX. Combines ADR 0006 D8 (setup --personal subcommand) with ADR 0007 D1 (default user-global hook config so sub-agents are captured).

## What \`agent-lens-hook setup --personal\` does (default)

1. Resolves self-binary path via \`os.Executable()\` — survives moves / reinstalls automatically
2. Idempotent merge into \`~/.claude/settings.json\` for all 5 hook events (SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / Stop)
3. Preserves theme / plugins / permissions / **other tools' hooks** untouched. Only-add semantics
4. Writes \`~/.agent-lens/compose.yml\` from embedded template (image ref overridable via \`--image\`)
5. Runs \`docker compose up -d\`
6. Polls \`/healthz\` until 200 (\`--healthz-timeout\`, default 60s)

## Other modes

- \`--project-only\`: writes to \`.claude/settings.local.json\` in cwd. Escape hatch with explicit warning that sub-agent capture won't work
- \`--uninstall\`: reverses both halves (settings + compose down). Round-trip is canonical-JSON byte-equal
- \`--skip-compose\`: just touch settings, don't manage docker (for users running their own server)
- \`--image <ref>\`: override container image (private registry / dev builds)

## Tests (6 happy-path + edge cases on JSON merge)

| Test | Asserts |
|---|---|
| \`TestMergeAgentLensHooksFreshFile\` | empty file → all 5 events wired |
| \`TestMergeIdempotent\` | re-running merge byte-equal output |
| \`TestMergePreservesOtherKeys\` | theme + plugins + permissions + another tool's PreToolUse intact |
| \`TestUnmergeRoundTrip\` | pre-state ≡ post-uninstall canonical JSON |
| \`TestUnmergeKeepsOthers\` | uninstall surgical, only our entries removed |
| \`TestCommandIsAgentLensHook\` | marker logic catches binary by basename |

## Live smoke (project-only mode, fresh /tmp dir + \`{"theme":"dark"}\`)

\`\`\`
$ agent-lens-hook setup --project-only --skip-compose
wired agent-lens hooks into /tmp/setup-smoke/.claude/settings.local.json
Setup complete. ...

$ agent-lens-hook setup --uninstall --project-only --skip-compose
removed agent-lens hook entries from /tmp/setup-smoke/.claude/settings.local.json

$ cat .claude/settings.local.json
{"theme": "dark"}    # exact pre-state restored

$ agent-lens-hook setup --project-only --skip-compose  # ×2
size after 1st: 1362
size after 2nd: 1362    # ✅ idempotent on disk
\`\`\`

## NOT in this PR (deferred to G — clean-environment smoke)

- Full \`--personal\` flow end-to-end (docker compose up + GHCR pull + healthz wait) on a CLEAN machine. The current dogfood server holds port :8787 so a meaningful test would conflict. Defer to fresh-machine smoke before v0.1.0 tag

## Why subcommand named \`setup\` not \`setup --personal\` literal

The \`--personal\` flag exists for explicit invocation but is the default; \`agent-lens-hook setup\` alone behaves the same. Naming the subcommand \`setup\` rather than \`install\` matches Claude Code ecosystem convention (people \`brew install\` or \`go install\` the BINARY; they \`setup\` the integration).

## Test plan

- [ ] CI green
- [ ] Manual smoke (post-merge) on a clean dir / clean settings.json — verify default \`--personal\` flow against \`ghcr.io/dong-qiu/agent-lens:latest\` after the v0.1.0 tag exists