### PR TITLE
feat(redact): wire rule-based redactor into hook content paths (H1)

### DIFF
--- a/cmd/agent-lens-hook/claude.go
+++ b/cmd/agent-lens-hook/claude.go
@@ -8,8 +8,19 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/dong-qiu/agent-lens/internal/redact"
 	"github.com/dong-qiu/agent-lens/internal/transcript"
 )
+
+// redactText runs the v0.1 rule-based redactor over free-text content
+// (prompts / thinking / assistant decisions) before it lands in the
+// event payload. Tool-call payloads are NOT redacted because the
+// canonical command (e.g. "curl -H 'Authorization: ...'") is part of
+// what audit needs to see verbatim — redacting commands would break
+// reproducibility checks and replay scenarios.
+func redactText(s string) (string, int) {
+	return redact.Redact(s)
+}
 
 // claudeHookInput captures the fields we read from a Claude Code hook
 // payload on stdin. Other fields are ignored; the original payload is not
@@ -84,10 +95,15 @@ func buildEvents(in *claudeHookInput) (events []map[string]any, commit func() er
 }
 
 func makePrompt(in *claudeHookInput) map[string]any {
-	return baseEvent(in, map[string]any{"type": "human", "id": "user"}, "prompt", map[string]any{
-		"text": in.Prompt,
+	text, n := redactText(in.Prompt)
+	payload := map[string]any{
+		"text": text,
 		"cwd":  in.CWD,
-	})
+	}
+	if n > 0 {
+		payload["redacted_count"] = n
+	}
+	return baseEvent(in, map[string]any{"type": "human", "id": "user"}, "prompt", payload)
 }
 
 func makeToolCall(in *claudeHookInput) map[string]any {
@@ -190,18 +206,26 @@ func makeStopEvents(in *claudeHookInput) ([]map[string]any, func() error) {
 	for _, b := range blocks {
 		switch b.Kind {
 		case "thinking":
+			text, n := redactText(b.Content)
 			payload := map[string]any{
-				"text":       b.Content, // TODO: redact per SPEC §12 before forwarding
+				"text":       text,
 				"message_id": b.MessageID,
 				"source":     "transcript",
+			}
+			if n > 0 {
+				payload["redacted_count"] = n
 			}
 			attachUsageMetadata(payload, &b)
 			events = append(events, baseEvent(in, agentActorWithModel(b.Model), "thought", payload))
 		case "text":
+			text, n := redactText(b.Content)
 			payload := map[string]any{
 				"marker":     "assistant_message",
-				"text":       b.Content,
+				"text":       text,
 				"message_id": b.MessageID,
+			}
+			if n > 0 {
+				payload["redacted_count"] = n
 			}
 			// Surface Claude-Code-side redaction of `thinking` content
 			// so audit readers don't mistake "transcript field empty"

--- a/cmd/agent-lens-hook/claude_test.go
+++ b/cmd/agent-lens-hook/claude_test.go
@@ -29,6 +29,35 @@ func TestBuildEventsUserPrompt(t *testing.T) {
 	}
 }
 
+// TestBuildEventsUserPromptRedacts: the v0.1 redactor must run on
+// prompt content before the event hits ingest. Without this, a user
+// pasting a secret into a Claude prompt sees it land verbatim in the
+// audit DB — exactly the failure mode SPEC §12 promises to prevent.
+func TestBuildEventsUserPromptRedacts(t *testing.T) {
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "UserPromptSubmit",
+		SessionID:     "s1",
+		Prompt:        "Help me debug: AKIAIOSFODNN7EXAMPLE",
+	})
+	if len(evs) != 1 {
+		t.Fatalf("got %d events, want 1", len(evs))
+	}
+	payload, _ := evs[0]["payload"].(map[string]any)
+	if payload == nil {
+		t.Fatalf("event has no payload: %+v", evs[0])
+	}
+	text, _ := payload["text"].(string)
+	if strings.Contains(text, "AKIAIOSFODNN7") {
+		t.Errorf("AWS access key leaked through redaction: %q", text)
+	}
+	if !strings.Contains(text, "[REDACTED:aws-access-key-id]") {
+		t.Errorf("expected [REDACTED:aws-access-key-id] marker in payload.text, got %q", text)
+	}
+	if n, _ := payload["redacted_count"].(int); n != 1 {
+		t.Errorf("redacted_count = %v, want 1", payload["redacted_count"])
+	}
+}
+
 func TestBuildEventsPreToolUse(t *testing.T) {
 	evs, _ := buildEvents(&claudeHookInput{
 		HookEventName: "PreToolUse",

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -48,6 +48,14 @@ var patterns = []pattern{
 		name: "github-token",
 		re:   regexp.MustCompile(`\bgh[oprsu]_[A-Za-z0-9]{36,}\b`),
 	},
+	// Anthropic API keys: sk-ant-api{version}- or sk-ant-admin{version}-
+	// followed by ≥40 chars of the body alphabet. The project's first-
+	// party agent IS Claude Code, so a user pasting their own Anthropic
+	// key into a prompt to debug an SDK call is a likely scenario.
+	{
+		name: "anthropic-api-key",
+		re:   regexp.MustCompile(`\bsk-ant-(?:api|admin)\d{2}-[A-Za-z0-9_\-]{40,}\b`),
+	},
 	// Slack bot/user tokens. Format xoxb-/xoxp-/xoxa-/xoxr-/xoxs-
 	// followed by digit-dash-segments.
 	{

--- a/internal/redact/redact.go
+++ b/internal/redact/redact.go
@@ -1,0 +1,95 @@
+// Package redact applies pattern-based redaction to free-text fields
+// (prompts, thinking content, assistant decisions) before they reach
+// the ingest server. Per SPEC §12: "rule-based first, model-assisted
+// later". This implements the rule-based half.
+//
+// v0.1 patterns cover the highest-confidence catastrophic-leak cases:
+// PEM private keys, AWS access keys, GitHub tokens, Slack tokens, and
+// generic high-entropy secrets next to common keyword identifiers.
+// PII (emails, phone numbers, SSN-like patterns) is INTENTIONALLY out
+// of scope — the false-positive rate at v0.1 doesn't justify the noise
+// it would add to audit reports.
+//
+// Replacement strategy: substitute with `[REDACTED:type]` so audit
+// readers can see something WAS there of that kind, without the
+// content. Preserves byte-count signal but hides material.
+package redact
+
+import (
+	"regexp"
+)
+
+// Pattern is a named regex + label. Order in the patterns slice
+// determines apply order; longer / more specific patterns first to
+// avoid generic-keyword catching content already wrapped by a more
+// specific match.
+type pattern struct {
+	name string
+	re   *regexp.Regexp
+}
+
+var patterns = []pattern{
+	// PEM-encoded private keys. Catches RSA / EC / ED25519 / generic.
+	// Multi-line; (?s) flag makes `.` match newlines for the body.
+	{
+		name: "pem-private-key",
+		re:   regexp.MustCompile(`(?s)-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----.*?-----END [A-Z0-9 ]*PRIVATE KEY-----`),
+	},
+	// AWS access key IDs. The 4-letter prefix set is documented by
+	// AWS; the 16-char body is base32 alphabet.
+	{
+		name: "aws-access-key-id",
+		re:   regexp.MustCompile(`\b(?:AKIA|AGPA|AROA|AIDA|ANPA|ANVA|ASIA)[0-9A-Z]{16}\b`),
+	},
+	// GitHub personal-access tokens (ghp_), OAuth (gho_), server
+	// tokens (ghs_), user-to-server (ghu_), refresh (ghr_). v2 PATs
+	// are at least 36 chars after the prefix.
+	{
+		name: "github-token",
+		re:   regexp.MustCompile(`\bgh[oprsu]_[A-Za-z0-9]{36,}\b`),
+	},
+	// Slack bot/user tokens. Format xoxb-/xoxp-/xoxa-/xoxr-/xoxs-
+	// followed by digit-dash-segments.
+	{
+		name: "slack-token",
+		re:   regexp.MustCompile(`\bxox[abprs]-[0-9]+-[0-9]+-[0-9]+-[a-fA-F0-9]+\b`),
+	},
+	// HTTP Authorization header values: "Bearer <token>" /
+	// "Basic <base64>". Separate from keyword-secret because the
+	// separator is whitespace, not `:` or `=`.
+	{
+		name: "auth-header",
+		re:   regexp.MustCompile(`(?i)\b(?:Bearer|Basic)\s+[A-Za-z0-9_\-/.+=]{16,}\b`),
+	},
+	// Generic secret-with-keyword: "api_key": "...", password=...,
+	// token: ... . Requires the right-hand side be ≥16 chars of
+	// secret-shaped alphabet (alphanumeric + a few symbols) AND a
+	// keyword on the left. Higher false-positive risk than the
+	// vendor-specific patterns above, so kept conservative.
+	{
+		name: "keyword-secret",
+		re:   regexp.MustCompile(`(?i)\b(?:api[_-]?key|secret|password|passwd|access[_-]?token|x-api-key)\s*[:=]\s*["']?[A-Za-z0-9_\-/+=]{16,}["']?`),
+	},
+}
+
+// Redact applies the v0.1 rule set. Returns the redacted text and the
+// number of pattern matches replaced. Caller may surface the count to
+// audit readers (e.g. "X secrets redacted" badge) so users know this
+// happened — silent redaction would be the wrong default for an audit
+// tool.
+func Redact(text string) (string, int) {
+	if text == "" {
+		return text, 0
+	}
+	var total int
+	out := text
+	for _, p := range patterns {
+		matches := p.re.FindAllStringIndex(out, -1)
+		if len(matches) == 0 {
+			continue
+		}
+		total += len(matches)
+		out = p.re.ReplaceAllString(out, "[REDACTED:"+p.name+"]")
+	}
+	return out, total
+}

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -41,6 +41,18 @@ hope that helps`,
 			wantCount:   1,
 		},
 		{
+			name:        "anthropic-api-key",
+			in:          "ANTHROPIC_API_KEY=sk-ant-api03-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789AbCdEfGhIjKlMn",
+			wantPattern: "[REDACTED:anthropic-api-key]",
+			wantCount:   1,
+		},
+		{
+			name:        "anthropic-admin-key",
+			in:          "use sk-ant-admin01-XYZxyz0123456789_-abcdefghijklmnopqrstuvwxyzABCDEFGHIJ for org admin",
+			wantPattern: "[REDACTED:anthropic-api-key]",
+			wantCount:   1,
+		},
+		{
 			name:        "slack-bot",
 			in:          "use xoxb-12345-67890-12345-abcdef0123456789abcdef",
 			wantPattern: "[REDACTED:slack-token]",
@@ -137,6 +149,10 @@ func TestRedactNoFalsePositives(t *testing.T) {
 		"see the BEGIN PRIVATE KEY format docs",
 		// Code with bearer keyword but no value following
 		"// bearer tokens are in the header",
+		// Anthropic-prefix-only chatter without an actual key body
+		"the sk-ant prefix family is documented in their docs",
+		// sk-ant-* but with too-short body (under 40 chars)
+		"placeholder sk-ant-api03-tooshort here",
 	}
 	for _, in := range cases {
 		t.Run(in, func(t *testing.T) {

--- a/internal/redact/redact_test.go
+++ b/internal/redact/redact_test.go
@@ -1,0 +1,158 @@
+package redact
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRedactPatterns(t *testing.T) {
+	cases := []struct {
+		name        string
+		in          string
+		wantPattern string // substring that should appear in output
+		wantCount   int
+	}{
+		{
+			name: "pem-rsa-private",
+			in: `Here's the key:
+-----BEGIN RSA PRIVATE KEY-----
+MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQ
+-----END RSA PRIVATE KEY-----
+hope that helps`,
+			wantPattern: "[REDACTED:pem-private-key]",
+			wantCount:   1,
+		},
+		{
+			name:        "pem-ed25519-private",
+			in:          "Key: -----BEGIN ED25519 PRIVATE KEY-----\nABCD\n-----END ED25519 PRIVATE KEY-----",
+			wantPattern: "[REDACTED:pem-private-key]",
+			wantCount:   1,
+		},
+		{
+			name:        "aws-access-key",
+			in:          "use AKIAIOSFODNN7EXAMPLE for s3",
+			wantPattern: "[REDACTED:aws-access-key-id]",
+			wantCount:   1,
+		},
+		{
+			name:        "github-pat",
+			in:          "set token=ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789Ab",
+			wantPattern: "[REDACTED:github-token]",
+			wantCount:   1,
+		},
+		{
+			name:        "slack-bot",
+			in:          "use xoxb-12345-67890-12345-abcdef0123456789abcdef",
+			wantPattern: "[REDACTED:slack-token]",
+			wantCount:   1,
+		},
+		{
+			name:        "keyword-api-key",
+			in:          `config: api_key: "abcdefghij1234567890_-"`,
+			wantPattern: "[REDACTED:keyword-secret]",
+			wantCount:   1,
+		},
+		{
+			name:        "keyword-password-equals",
+			in:          `password=Sup3rSecret_Pa55w0rd!Long`,
+			wantPattern: "[REDACTED:keyword-secret]",
+			wantCount:   1,
+		},
+		{
+			name:        "auth-header-bearer",
+			in:          "Authorization: Bearer abcdef1234567890ghijkl0987654321",
+			wantPattern: "[REDACTED:auth-header]",
+			wantCount:   1,
+		},
+		{
+			name:        "auth-header-basic",
+			in:          "Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmRfd2l0aF9lbm91Z2hfYnl0ZXM=",
+			wantPattern: "[REDACTED:auth-header]",
+			wantCount:   1,
+		},
+		{
+			name: "multiple-patterns-coexist",
+			in: `key1: ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789Ab
+also AKIAIOSFODNN7EXAMPLE`,
+			wantPattern: "[REDACTED:",
+			wantCount:   2,
+		},
+		// Edge: an AWS-shaped string inside a PEM block should be
+		// redacted ONCE (pem catches the whole block). Verifies pattern
+		// ordering avoids double-redacting.
+		{
+			name: "pem-wraps-other-secret",
+			in: `-----BEGIN RSA PRIVATE KEY-----
+content with AKIAIOSFODNN7EXAMPLE inside
+-----END RSA PRIVATE KEY-----`,
+			wantPattern: "[REDACTED:pem-private-key]",
+			wantCount:   1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, count := Redact(tc.in)
+			if !strings.Contains(got, tc.wantPattern) {
+				t.Errorf("output missing %q\nin:  %s\nout: %s", tc.wantPattern, tc.in, got)
+			}
+			if count != tc.wantCount {
+				t.Errorf("count = %d, want %d\nin:  %s\nout: %s", count, tc.wantCount, tc.in, got)
+			}
+			// The original secret bytes must not survive in the output
+			// (this is the whole point — easy to forget if a future
+			// change uses a non-replacing transform).
+			for _, leaked := range []string{
+				"MIIEvQIBAD",                 // PEM body
+				"AKIAIOSFODNN7",              // AWS prefix
+				"ghp_aBcDeFgHi",              // GH PAT prefix
+				"xoxb-12345-67890",           // Slack prefix
+			} {
+				if strings.Contains(got, leaked) && !strings.Contains(tc.in, leaked) == false {
+					// Only flag if the secret appeared in input AND survived in output
+					if strings.Contains(tc.in, leaked) && strings.Contains(got, leaked) {
+						t.Errorf("secret %q leaked through redaction\nout: %s", leaked, got)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestRedactNoFalsePositives ensures the v0.1 patterns don't redact
+// content that happens to look key-shaped. False positives in audit
+// reports erode user trust in the redactor — they assume things were
+// secrets that weren't.
+func TestRedactNoFalsePositives(t *testing.T) {
+	cases := []string{
+		// Plain English with a keyword but no secret-shaped value
+		"the password is in the manual",
+		"please set your api_key when you're ready",
+		// Short strings under min length
+		`token: "short"`,
+		// AWS-prefix chars in a sentence (4-letter prefix only counts
+		// when followed by 16 base32 chars)
+		"the AKIA service is available",
+		// PEM-like text with no actual key body (no full BEGIN/END pair)
+		"see the BEGIN PRIVATE KEY format docs",
+		// Code with bearer keyword but no value following
+		"// bearer tokens are in the header",
+	}
+	for _, in := range cases {
+		t.Run(in, func(t *testing.T) {
+			got, count := Redact(in)
+			if count != 0 {
+				t.Errorf("got %d redactions on benign input\nin:  %s\nout: %s", count, in, got)
+			}
+		})
+	}
+}
+
+// TestRedactEmptyInput: edge case — empty string should pass through
+// without any allocation overhead or pattern walking.
+func TestRedactEmptyInput(t *testing.T) {
+	got, count := Redact("")
+	if got != "" || count != 0 {
+		t.Errorf("Redact(\"\") = (%q, %d), want (\"\", 0)", got, count)
+	}
+}


### PR DESCRIPTION
## Summary

Round 2.2.2 — implements **H1**, the v0.1 rule-based redactor per SPEC §12, and wires it into all three free-text content paths in the Claude Code hook. Closes the long-standing TODO at \`claude.go:194\`.

## Why this exists

SPEC §12: "prompt / thinking 可能含密钥、PII、专有代码。**入库前 redaction**（先规则式，后续可加模型辅助）". M1-M3 shipped without ever wiring redaction. Personal-mode users run \`agent-lens-hook setup --personal\`, paste a token into Claude — it lands in the audit DB verbatim. Catastrophic for v0.1's main user-facing promise.

## Scope

- New \`internal/redact\` package (was empty dir): Redact() + 6 regex patterns
- Wired into \`makePrompt\` + thinking branch + text branch in \`claude.go\`
- Adds \`redacted_count\` field to event payloads when count > 0 (audit transparency — silent redaction would defeat the purpose of an audit tool)
- 12 sub-tests on the redactor (5 happy + 6 no-false-positive + 1 empty)
- 1 integration test through buildEvents

## Patterns (v0.1 minimum, high-confidence only)

| Pattern | Catches |
|---|---|
| pem-private-key | \`-----BEGIN/END *PRIVATE KEY-----\` block (multi-line) |
| aws-access-key-id | AKIA / AGPA / AROA / AIDA / ANPA / ANVA / ASIA + 16 base32 |
| github-token | \`gh[oprsu]_<36+>\` |
| slack-token | \`xox[abprs]-…\` |
| auth-header | \`Bearer <16+>\` / \`Basic <16+>\` |
| keyword-secret | api_key / secret / password / token + colon-or-equals + ≥16-char value |

**Out of scope intentionally**: PII (emails, SSN, phone). False-positive cost too high for v0.1 without empirical signal. Will revisit in v0.2 with real dogfood data.

## Why tool-call payloads are NOT redacted

Bash tool args / Edit tool file paths are needed verbatim for audit replay and reproduction. \`curl -H "Authorization: ..."\` IS the canonical command — replacing it would break what audit consumers need. Documented in \`redactText\`'s comment.

## Live smoke through dogfood server

\`\`\`bash
$ echo '{"hook_event_name":"UserPromptSubmit","session_id":"smoke","prompt":"Use this token: ghp_aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789Ab to push"}' \\
  | bin/agent-lens-hook claude

$ curl -X POST http://localhost:8787/v1/graphql -d '{"query":"{ events(sessionId: \\"smoke\\") { payload } }"}'
{"data":{"events":[{
  "payload":{
    "text":"Use this token: [REDACTED:github-token] to push",
    "redacted_count":1
}}]}}
\`\`\`

## NOT in this PR (H2 — separate scope)

- \`thinking_redacted_by_claude_code\` field projection through GraphQL + Lens UI chip — Claude-Code-side redaction metadata transparency. Existing in payload but not surfaced to audit reader

## Test plan

- [ ] CI green
- [ ] Reviewer can re-run the live smoke command above