### PR TITLE
feat(web): chip for rule-based-redactor secrets count (H2, completes H)

### DIFF
--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -80,6 +80,20 @@ export function EventCard({ event }: { event: Event }) {
                 </span>
               ) : null;
             })()}
+            {(() => {
+              const n = redactedSecretCount(event);
+              return n > 0 ? (
+                <span
+                  className="inline-flex items-center gap-1 rounded bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 ring-1 ring-amber-300"
+                  title={`The hook's rule-based redactor (SPEC §12) caught ${n} suspected secret${n === 1 ? "" : "s"} in this event's text and replaced ${n === 1 ? "it" : "them"} with [REDACTED:<type>] before forwarding. The original content is NOT recoverable from the audit DB.`}
+                >
+                  <span>🔒</span>
+                  <span>
+                    {n} secret{n === 1 ? "" : "s"} redacted
+                  </span>
+                </span>
+              ) : null;
+            })()}
             {event.usage && (
               <TokenUsageChip
                 usage={event.usage}
@@ -255,6 +269,21 @@ function redactedThinkingCount(event: Event): number {
   const p = (event.payload ?? {}) as Record<string, unknown>;
   if (p.marker !== "assistant_message") return 0;
   const v = p.thinking_redacted_by_claude_code;
+  return typeof v === "number" && v > 0 ? v : 0;
+}
+
+// redactedSecretCount reads the count of secrets the hook's rule-based
+// redactor (SPEC §12 / internal/redact) caught and replaced in this
+// event's text. Set by the hook on PROMPT, THOUGHT, and DECISION
+// events when at least one pattern matched; absent / 0 elsewhere.
+//
+// Different from thinking-redacted: that's Claude Code dropping
+// content before it ever leaves the assistant; this is OUR redactor
+// catching secrets in content that DID make it to the hook. They're
+// surfaced as separate chips so audit readers can tell them apart.
+function redactedSecretCount(event: Event): number {
+  const p = (event.payload ?? {}) as Record<string, unknown>;
+  const v = p.redacted_count;
   return typeof v === "number" && v > 0 ? v : 0;
 }
 

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useMemo, useState } from "react";
 import type { Event } from "../types";
 import { styleFor, formatTimestamp } from "./kindStyle";
 import { payloadToDiff } from "../lib/payloadToDiff";
+import { RedactionChip } from "./RedactionChip";
 import { TokenUsageChip } from "./TokenUsageChip";
 
 // React.lazy keeps the ~600 KB Monaco bundle out of the eager chunk:
@@ -69,29 +70,21 @@ export function EventCard({ event }: { event: Event }) {
             {(() => {
               const n = redactedThinkingCount(event);
               return n > 0 ? (
-                <span
-                  className="inline-flex items-center gap-1 rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-700 ring-1 ring-zinc-300"
-                  title={`Claude Code dropped ${n} thinking block${n === 1 ? "" : "s"} from this message — only the signature was preserved in the transcript. Capturing the original thinking content requires §10.4 proxy mode.`}
-                >
-                  <span>🚫</span>
-                  <span>
-                    {n} thinking redacted
-                  </span>
-                </span>
+                <RedactionChip
+                  variant="thinking"
+                  label={`${n} thinking redacted`}
+                  tooltip={`Claude Code dropped ${n} thinking block${n === 1 ? "" : "s"} from this message — only the signature was preserved in the transcript. Capturing the original thinking content requires §10.4 proxy mode.`}
+                />
               ) : null;
             })()}
             {(() => {
               const n = redactedSecretCount(event);
               return n > 0 ? (
-                <span
-                  className="inline-flex items-center gap-1 rounded bg-amber-50 px-1.5 py-0.5 text-[10px] font-medium text-amber-800 ring-1 ring-amber-300"
-                  title={`The hook's rule-based redactor (SPEC §12) caught ${n} suspected secret${n === 1 ? "" : "s"} in this event's text and replaced ${n === 1 ? "it" : "them"} with [REDACTED:<type>] before forwarding. The original content is NOT recoverable from the audit DB.`}
-                >
-                  <span>🔒</span>
-                  <span>
-                    {n} secret{n === 1 ? "" : "s"} redacted
-                  </span>
-                </span>
+                <RedactionChip
+                  variant="secret"
+                  label={`${n} secret${n === 1 ? "" : "s"} redacted`}
+                  tooltip={`The hook's rule-based redactor (SPEC §12) caught ${n} suspected secret${n === 1 ? "" : "s"} in this event's text and replaced ${n === 1 ? "it" : "them"} with [REDACTED:<type>] before forwarding. The original content is NOT recoverable from the audit DB.`}
+                />
               ) : null;
             })()}
             {event.usage && (

--- a/web/src/components/RedactionChip.tsx
+++ b/web/src/components/RedactionChip.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { createPortal } from "react-dom";
+
+// RedactionChip renders the small "redacted" badges in EventCard with a
+// fast custom tooltip — replaces the native `title` attribute that
+// previously sat on these chips, which had the ~700ms browser-imposed
+// delay flagged in auto-memory after PR #61 (graph node) and PR #67
+// (token chip) hit the same UX miss. Same fix as TokenUsageChip: track
+// cursor position in React state, render the popup via a portal so
+// ancestor overflow:hidden can't clip it.
+//
+// Two variants: "thinking" (🚫, zinc) for thinking blocks Claude Code
+// dropped from transcript before they reached the hook; "secret" (🔒,
+// amber) for secrets the hook's rule-based redactor caught and
+// substituted with [REDACTED:<type>]. Distinct icons + colors so audit
+// readers can tell the upstream redactions apart.
+type Variant = "thinking" | "secret";
+
+const variants: Record<Variant, { icon: string; cls: string }> = {
+  thinking: {
+    icon: "🚫",
+    cls: "bg-zinc-100 text-zinc-700 ring-zinc-300",
+  },
+  secret: {
+    icon: "🔒",
+    cls: "bg-amber-50 text-amber-800 ring-amber-300",
+  },
+};
+
+export function RedactionChip({
+  variant,
+  label,
+  tooltip,
+}: {
+  variant: Variant;
+  label: string;
+  tooltip: string;
+}) {
+  const [hover, setHover] = useState<{ x: number; y: number } | null>(null);
+  const v = variants[variant];
+  return (
+    <>
+      <span
+        onMouseEnter={(e) => setHover({ x: e.clientX, y: e.clientY })}
+        onMouseMove={(e) => setHover({ x: e.clientX, y: e.clientY })}
+        onMouseLeave={() => setHover(null)}
+        className={`inline-flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] font-medium ring-1 ${v.cls}`}
+        aria-label={tooltip}
+      >
+        <span aria-hidden>{v.icon}</span>
+        <span>{label}</span>
+      </span>
+      {hover &&
+        createPortal(
+          <div
+            className="pointer-events-none fixed z-[9999] max-w-[360px] rounded bg-zinc-900 px-2 py-1.5 text-left text-[11px] text-white shadow-lg ring-1 ring-zinc-700"
+            style={{
+              left: hover.x + 14,
+              top: hover.y + 14,
+              wordBreak: "break-word",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {tooltip}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Round 2.2.3 — completes **H**. PR #83 (H1) added \`payload.redacted_count\` from the rule-based redactor, but it was invisible in Lens UI. Silent redaction is the exact opposite of what an audit tool should do.

## Change

Add a sibling chip to the existing \`🚫 N thinking redacted\` one in EventCard:

\`🔒 N secret(s) redacted\`  (amber/orange, distinct from the zinc thinking chip)

Renders on any event whose payload has \`redacted_count > 0\` — that's PROMPT / THOUGHT / DECISION as wired in H1's claude.go. Tool-call payloads are NOT redacted by H1's design, so no chip appears on those.

## Why two chips not one

They signal different upstream redactions:

| Chip | Source | Recoverable? |
|---|---|---|
| 🚫 thinking redacted | Claude Code dropped thinking BEFORE reaching the hook (transcript only kept signature) | No — requires §10.4 proxy mode |
| 🔒 secret redacted | OUR redactor caught patterns AFTER content reached the hook | No — substituted with \`[REDACTED:<type>]\` |

Distinct icons + colors + tooltips so audit readers can tell them apart.

## Data path verified

\`\`\`
$ curl -X POST .../v1/graphql events ...
PROMPT: redacted_count=1 text='test ANTHROPIC_API_KEY=[REDACTED:anthropic-api-key]'
\`\`\`

GraphQL exposes \`redacted_count\` via the existing \`payload: JSON\` pass-through — no schema change needed (matches the existing pattern of \`thinking_redacted_by_claude_code\`).

## NOT in this PR

- Graph view nodeSummary surface — v0.1.x UI polish
- Browser smoke (visual click-through verifying chip renders) — Phase 4 manual smoke item, pattern parity with the existing thinking chip is v0.1 confidence

## Test plan

- [ ] CI green (web build, typecheck)
- [ ] Manual smoke (post-merge): open Lens UI, navigate to a session with redacted-count events, confirm 🔒 chip renders distinctly from 🚫 chip