### PR TITLE
feat(K1): surface Agent dispatches in EventCard + ADR 0008 fallback

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -179,6 +179,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 - `<synthetic>` 模型标记的消息（Claude Code 自身注入的 stop-sequence 占位，usage 全 0）按已知形态跳过 usage 提取，不报错、不丢消息体。
 - **思考内容（thinking 文本）**：Claude Code 写 transcript 时只保留 `signature` 字段，**原文不持久化**。§10.1 拿不到原文。每条 assistant 消息中被丢弃的 thinking 块**数量**显式记录在派生 DECISION 事件的 `payload.thinking_redacted_by_claude_code`，避免审计报告把"被吞"误读为"无思考"。要拿原文得走 §10.4。
 - 仍**没有**的能力：实时拦截 / token 流式即时反馈 / policy gate。要这些得走 §10.4。
+- **Sub-agent 派发**（Agent 工具）：父侧 tool_call/result 完整捕获（含 `response.agentId` 等元数据，UI 显式 surface）。子 session 在 user-global hook 装好（`agent-lens-hook setup --personal`）的前提下以独立 UUID session 捕获；父→子的自动 `delegates` link 留 v0.2，详见 ADR 0008 与追踪 issue #85。Audit reader 在 v0.1 通过 timestamp + prompt 文本人眼对应。
 
 ### 10.4 代理深模式（M4+，未启用）
 

--- a/docs/ADR/0008-sub-agent-link-fallback-v0.1.md
+++ b/docs/ADR/0008-sub-agent-link-fallback-v0.1.md
@@ -1,0 +1,88 @@
+# ADR 0008:Sub-agent 自动 link fallback（v0.1 K1 实证记录）
+
+- 状态:草案
+- 日期:2026-05-09
+- 取代:ADR 0007 D3/D4 在 v0.1 范围内的"自动 emit `delegates` link"承诺(D5 已显式预留 fallback,本 ADR 把 fallback 落地)
+- 修订(待 Accepted):SPEC §10.1 已知局限段加一句
+
+## 背景
+
+ADR 0007 D3/D4 锁定了"父会话的 PreToolUse(Agent)→子 sub-agent SessionStart"自动 link 的设计,候选 D3-A(env var 直传)与 D3-C(tool_result payload 回填)留作开放问题等实施 PR 实测。本 ADR 记录实测结果与 v0.1 K1 的取舍。
+
+## 验证
+
+实施 PR(K1)期间在 dogfood session 上跑了实测,结论汇总:
+
+### D3-A:hook 改 env var 直传给 sub-agent —— **不可行**
+
+- agent-lens-hook 是 Claude Code 派生的 short-lived 子进程,其 `os.Setenv` 只影响 hook 自身 + hook 自身派生的子进程
+- Hook 不 fork 派生 sub-agent,sub-agent 是 Claude Code 父进程派生的
+- Claude Code 的 hook 协议(已知)不接受 stdout 里的 env 注入指令——`decision` / `additionalInput` 等控制字段是 tool gating 用,不能改 env
+- 结论:无 Claude Code 内部协议改动的前提下,D3-A 路径在 hook 进程层面**理论不通**
+
+### D3-C:tool_result payload 含 child session_id —— **部分可行**
+
+- 实测 14 条 Agent TOOL_RESULT 事件,`payload.response` 含:
+  - `agentId`(17 字符 hex,如 `a56565bd5a1a9677f`)
+  - `prompt` / `outputFile` / `status` / `description`
+- **但** `agentId` ≠ sub-agent 的 hook session_id
+- Sub-agent 的 hook 事件用 Claude Code 生成的独立 UUID(如 `319dec3d-87b0-47c9-...`)作 session_id
+- agentId 与 session_id 之间**没有任何 surface 出来的映射通路**
+
+### 自动 link 在 v0.1 范围内不可行的核心原因
+
+要从 parent 的 tool_call/result 反查到 child 的 session 事件,需要:
+
+(1) Claude Code 给 sub-agent SessionStart hook payload 加一条 `parent_agent_id`,或
+(2) 沿 outputFile 路径反向解析(脆,需文件系统约定),或
+(3) 时间戳启发式相关(脆,并发派生时坏)
+
+(1) 需上游 Claude Code 改;(2)(3)都是脆策略。v0.1 不引入这类不可靠路径。
+
+## 决定
+
+### D1. v0.1 K1 走 ADR 0007 D5 fallback
+
+Sub-agent 在 audit 中以**独立 session** 出现(cwd 在 worktree 子目录时,经 `agent-lens-hook setup --personal`(C / #82)装的 user-global hook 触发)。**父→子不自动连边**。Audit reader 通过下面 D2 暴露的元数据 + 时间戳 + prompt 文本人眼对应。
+
+### D2. UI 在父侧暴露 sub-agent 派发元数据
+
+EventCard 对 `kind=TOOL_RESULT`、`payload.name="Agent"` 的事件加一个 🤖 chip,显示截断的 agentId + status,tooltip 显示完整 agentId / status / outputFile。
+
+数据已经被 hook 完整捕获(`payload.response.agentId` / `payload.response.prompt` / `payload.response.outputFile` / `payload.response.status`),只是 UI 没显式 surface。本决定让 audit reader 一眼看到"这条 TOOL_RESULT 是 Agent 派发"而非淹没在通用 tool_result 渲染里。
+
+### D3. linker 不加 `delegates` 关系(超出 ADR 0007 D4 的承诺降级)
+
+ADR 0007 D4 承诺加 `delegates` 关系。本 ADR 在 v0.1 范围内**撤回**该承诺:没有 agentId↔session_id 映射,linker 也无可靠规则去 emit。强行加规则只会产生不可靠的边或空边。`intervenes`、`produces` 等既有关系不受影响。
+
+v0.2 加回的路径在 issue #85(linker: auto-link parent→child sub-agent)追踪,候选有 (A) Claude Code 上游改 / (B) 文件系统 marker / (C) 时间相关 / (D) hybrid。
+
+### D4. SPEC §10.1 已知局限段补一句
+
+实施 PR 同 commit 加:"sub-agent 派发(Agent 工具)在 v0.1 中:父侧 tool_call/result 已捕获完整元数据(含 agentId);子 session 在 user-global hook 装好的前提下独立捕获;父→子的自动 link 留 v0.2(详见 ADR 0008 / 追踪 issue #85)。"
+
+### D5. ADR 0007 不修订
+
+ADR 0007 仍保留 D3/D4 原文与 D5 fallback。它记录了**当时的设计意图**与"未实测前的保守路径"。本 ADR 0008 是"实测后的取舍"。两 ADR 配套读完整。0007 进入 Accepted 时,本 ADR 0008 会同步进入草案修订或独立 Accepted(取决于 v0.2 的进展)。
+
+## 后果
+
+- v0.1 ship 时 sub-agent 链路是"父侧完整 + 子侧独立 + 不 link"。Audit 工具核心承诺(transparency)的 90%+ 满足:**所有派发事件都被记录**,只是 link 需手动重建。
+- ADR 0007 D4 的 `delegates` 关系**未引入** linker——不污染 v1 关系词表
+- v0.2 的修复路径需要决定 (A/B/C/D),issue #85 是入口
+- audit-report 在 v0.1 中,如果 root 是 parent commit 而 sub-agent 写了 commit,两条 chain 会作为独立 session 出现在报告里,**通过 git ref 而非 delegates link 串接**——这刚好是既有 linker 的工作模式,无需特殊处理
+
+## 替代方案
+
+- **v0.1 推迟所有 sub-agent transparency 工作**:ADR 0007 已 Accept(草案),C(setup --personal) 已 ship 解锁了子 session 捕获;现在再回退太浪费。否决。
+- **v0.1 引入文件系统 marker 路径**(D3-B):脆策略,引入文件系统约定后未来收回成本高。否决。
+- **v0.1 引入时间相关启发**:并发场景错连边比不连边更坏。否决。
+- **v0.1 等 Claude Code 上游加 parent_agent_id**:无 ETA,阻塞 v0.1。否决。
+
+## 后续工作
+
+1. **本 PR**(K1):D2 的 UI chip + D4 的 SPEC 更新一句话 + 本 ADR 落档
+2. **v0.2 ADR**(待开):基于 issue #85 选 (A/B/C/D) 路径,落 `delegates` link
+3. **撤回 ADR 0007 D4 不需另起 ADR** —— 本 ADR 0008 已显式承担"v0.1 范围内的撤回"角色。0007 D4 在 v0.2 落地时由那个 ADR 重新激活或重新定义
+
+**本 ADR 不带任何代码改动**(实施代码在同 PR 的其它文件)。

--- a/web/src/components/AgentDispatchChip.tsx
+++ b/web/src/components/AgentDispatchChip.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import { createPortal } from "react-dom";
+
+// AgentDispatchChip surfaces sub-agent (Task tool / Agent tool)
+// dispatch metadata on parent-side TOOL_RESULT events. v0.1 ships
+// without automatic parent→child linking (per ADR 0008): audit
+// readers correlate manually via timestamp + prompt text. This chip
+// is the audit reader's "you are looking at an agent dispatch"
+// signal — without it the dispatch hides as a generic TOOL_RESULT.
+//
+// Same fast-tooltip pattern as RedactionChip + TokenUsageChip:
+// React state for cursor position + portal-rendered popup, no native
+// `title` (which has the ~700 ms browser delay flagged in #61 / #67).
+export function AgentDispatchChip({
+  agentId,
+  status,
+  outputFile,
+  prompt,
+}: {
+  agentId: string;
+  status?: string;
+  outputFile?: string;
+  prompt?: string;
+}) {
+  const [hover, setHover] = useState<{ x: number; y: number } | null>(null);
+  const short = agentId.slice(0, 8);
+  const lines = [`agent: ${agentId}`];
+  if (status) lines.push(`status: ${status}`);
+  if (outputFile) lines.push(`output: ${outputFile}`);
+  if (prompt) {
+    const promptPreview =
+      prompt.length > 200 ? prompt.slice(0, 200) + "…" : prompt;
+    lines.push("");
+    lines.push("prompt preview:");
+    lines.push(promptPreview);
+  }
+  lines.push("");
+  lines.push(
+    "v0.1: parent→child auto-link is deferred (ADR 0008). " +
+      "Use timestamp + prompt to correlate with the child session captured under its own UUID.",
+  );
+  const tooltip = lines.join("\n");
+
+  return (
+    <>
+      <span
+        onMouseEnter={(e) => setHover({ x: e.clientX, y: e.clientY })}
+        onMouseMove={(e) => setHover({ x: e.clientX, y: e.clientY })}
+        onMouseLeave={() => setHover(null)}
+        className="inline-flex items-center gap-1 rounded bg-indigo-50 px-1.5 py-0.5 text-[10px] font-medium text-indigo-800 ring-1 ring-indigo-300 font-mono"
+        aria-label={tooltip}
+      >
+        <span aria-hidden>🤖</span>
+        <span>agent {short}</span>
+        {status && status !== "completed" && (
+          <span className="text-indigo-500">· {status}</span>
+        )}
+      </span>
+      {hover &&
+        createPortal(
+          <div
+            className="pointer-events-none fixed z-[9999] max-w-[420px] rounded bg-zinc-900 px-2 py-1.5 text-left text-[11px] text-white shadow-lg ring-1 ring-zinc-700"
+            style={{
+              left: hover.x + 14,
+              top: hover.y + 14,
+              wordBreak: "break-all",
+              whiteSpace: "pre-wrap",
+            }}
+          >
+            {tooltip}
+          </div>,
+          document.body,
+        )}
+    </>
+  );
+}

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useMemo, useState } from "react";
 import type { Event } from "../types";
 import { styleFor, formatTimestamp } from "./kindStyle";
 import { payloadToDiff } from "../lib/payloadToDiff";
+import { AgentDispatchChip } from "./AgentDispatchChip";
 import { RedactionChip } from "./RedactionChip";
 import { TokenUsageChip } from "./TokenUsageChip";
 
@@ -84,6 +85,17 @@ export function EventCard({ event }: { event: Event }) {
                   variant="secret"
                   label={`${n} secret${n === 1 ? "" : "s"} redacted`}
                   tooltip={`The hook's rule-based redactor (SPEC §12) caught ${n} suspected secret${n === 1 ? "" : "s"} in this event's text and replaced ${n === 1 ? "it" : "them"} with [REDACTED:<type>] before forwarding. The original content is NOT recoverable from the audit DB.`}
+                />
+              ) : null;
+            })()}
+            {(() => {
+              const info = agentDispatchInfo(event);
+              return info ? (
+                <AgentDispatchChip
+                  agentId={info.agentId}
+                  status={info.status}
+                  outputFile={info.outputFile}
+                  prompt={info.prompt}
                 />
               ) : null;
             })()}
@@ -263,6 +275,37 @@ function redactedThinkingCount(event: Event): number {
   if (p.marker !== "assistant_message") return 0;
   const v = p.thinking_redacted_by_claude_code;
   return typeof v === "number" && v > 0 ? v : 0;
+}
+
+// agentDispatchInfo extracts sub-agent dispatch metadata from a parent-
+// side TOOL_RESULT event whose tool name is "Agent" (Claude Code's
+// internal name for the Task-tool dispatch). Returns null on any other
+// event so the chip only shows where it's meaningful.
+//
+// Per ADR 0008: v0.1 surfaces this metadata so audit readers can see
+// "this is an agent dispatch, here's the agentId". The actual child
+// session is captured under a separate UUID (post-`setup --personal`)
+// but no automatic delegates link is emitted yet (issue #85, v0.2).
+function agentDispatchInfo(event: Event): {
+  agentId: string;
+  status?: string;
+  outputFile?: string;
+  prompt?: string;
+} | null {
+  if (event.kind !== "TOOL_RESULT") return null;
+  const p = (event.payload ?? {}) as Record<string, unknown>;
+  if (p.name !== "Agent") return null;
+  const resp = p.response;
+  if (!resp || typeof resp !== "object") return null;
+  const r = resp as Record<string, unknown>;
+  const agentId = r.agentId;
+  if (typeof agentId !== "string" || !agentId) return null;
+  return {
+    agentId,
+    status: typeof r.status === "string" ? r.status : undefined,
+    outputFile: typeof r.outputFile === "string" ? r.outputFile : undefined,
+    prompt: typeof r.prompt === "string" ? r.prompt : undefined,
+  };
 }
 
 // redactedSecretCount reads the count of secrets the hook's rule-based


### PR DESCRIPTION
## Summary

Round 2.2.4 — v0.1 K (sub-agent transparency) per **ADR 0008 fallback path**. Both ADR 0007 D3 mechanisms turned out incomplete after empirical probing during this PR:

| Path | Status | Why |
|---|---|---|
| D3-A: env injection via hook | ❌ not viable | hook stdout protocol doesn't surface env-injection; \`os.Setenv\` in hook process doesn't reach Claude Code's spawn |
| D3-C: tool_result agentId | partial | response.agentId IS captured but ≠ sub-agent's hook session_id. No surfaced agentId↔session_id mapping |

So v0.1 K ships ADR 0007 D5's documented fallback: sub-agent appears as a standalone session, no auto-link. Audit reader correlates manually via timestamp + prompt text.

## What this PR delivers

1. **ADR 0008** (\`docs/ADR/0008-sub-agent-link-fallback-v0.1.md\`): empirical findings + descope decision + v0.2 candidate paths (Claude Code upstream / FS marker / time correlation / hybrid)
2. **SPEC §10.1 known-limitations**: one new bullet pointing at ADR 0008 / issue #85
3. **AgentDispatchChip** (\`web/src/components/AgentDispatchChip.tsx\`): 🤖 indigo chip on parent-side TOOL_RESULT events with name=\"Agent\". Shows truncated agentId + status; tooltip has full agentId / status / outputFile / prompt preview + v0.2 caveat. Same fast-tooltip pattern as RedactionChip
4. **EventCard.tsx**: wires the chip via \`agentDispatchInfo(event)\` helper
5. **Issue #85** opened: tracks v0.2 auto-linking design (4 candidate paths)

## What this PR does NOT deliver (per ADR 0008)

- ❌ \`delegates\` linker relation — without agentId↔session_id mapping, any rule produces unreliable/empty edges. v0.2 with proper design.
- ❌ Nested timeline UI for sub-agent — v0.2.

## Empirical evidence

\`\`\`
$ # query parent session for Agent tool events
$ curl ... -d '{ events(sessionId:\"c3e32521-...\", limit: 5000) ... }'
  Agent tool events: 14
  TOOL_RESULT example:
    payload top-level keys: [input, name, response]
    response keys: [agentId, canReadOutputFile, description, isAsync, outputFile, prompt, status]
      agentId: \"a56565bd5a1a9677f\"        ← captured ✓
      status: \"async_launched\"
      outputFile: \"/private/tmp/.../tasks/a56565bd5a1a9677f.output\"

$ # check if agentId exists as a session_id
$ for aid in a56565... ae33cc...; query sessions(id=$aid).eventCount
  → all 0 (agentId is NOT used as session_id)

$ # sub-agent UUID-style session_ids found in DB (separate from main)
  319dec3d-87b0-...   ← these are independent sessions, no parent link
  bbb79d40-12d2-...
\`\`\`

## Audit reader workflow in v0.1

1. Open parent session in Lens UI
2. Find a TOOL_RESULT event with 🤖 agent chip
3. Note agentId + timestamp + prompt
4. Open SessionList, find a session with timestamp matching shortly after the agent dispatch + matching prompt text
5. That's the child sub-agent session

v0.2 (issue #85) automates step 4-5.

## Test plan

- [ ] CI green
- [ ] Manual smoke: open Lens UI, find any Agent TOOL_RESULT event in this session (14 already exist), confirm 🤖 chip renders + tooltip readable

## Pre-merge note

Browser smoke recommended before merge — this is the third user-facing chip in 3 PRs, and the previous two PRs each surfaced a UX issue only browser testing caught (#83's slow tooltip, etc).