### PR TITLE
docs(v0.1): release notes + README 60s install + SPEC overclaim softening (Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,42 +6,74 @@
 
 ## 状态
 
-M1–M3 已交付，§17 dogfood 已激活——本仓库自身就是首个使用者。v0.1.0 personal-mode 发布筹备中（详见 [`docs/ADR/0006-release-and-distribution-v0.1.md`](./docs/ADR/0006-release-and-distribution-v0.1.md)）；当前安装路径仍是 build-from-source（见 §"一次跑通"）。Team mode、Helm chart、Windows、PR Review Bot outbound 等不在 v0.1 范围。
+**v0.1.0 personal-mode** 发布——单机单人 audit。完整 release notes：[`docs/RELEASE_NOTES_v0.1.0.md`](./docs/RELEASE_NOTES_v0.1.0.md)（含已知限制 + v0.2 路线）。Team mode、Helm chart、Windows、PR Review Bot outbound、跨 AI CLI（OpenCode 等）不在 v0.1 范围。
 
-## 一次跑通
+## 60 秒试用（v0.1.0 +）
+
+发布后用预编译二进制 + GHCR 镜像，最小依赖：
 
 ```bash
-# 1. 装工具链（macOS）
-brew install go pnpm buf node
-# golang-migrate 不再需要——server 启动时自动应用嵌入的 migrations
-# （如需外部迁移：AGENT_LENS_SKIP_MIGRATE=1 + brew install golang-migrate）
+# 1. 拉镜像 + 起 Postgres / MinIO / agent-lens（端口 8787）
+docker compose -f https://raw.githubusercontent.com/dong-qiu/agent-lens/v0.1.0/deploy/compose/docker-compose.yml up -d
 
-# 2. 启 Postgres + MinIO
-make compose-up
+# 2. 装 hook 二进制（macOS arm64 示例）
+curl -fsSL https://github.com/dong-qiu/agent-lens/releases/download/v0.1.0/agent-lens-hook-darwin-arm64 \
+  -o /usr/local/bin/agent-lens-hook
+chmod +x /usr/local/bin/agent-lens-hook
 
-# 3a. 开发模式：起后端（terminal 1）+ Vite 前端（terminal 2）
-make build && ./bin/agent-lens
-# 启动时自动 migrate up；监听 :8787 提供 /healthz, /v1/events (POST), /v1/graphql
-# /v1/playground 仅在 AGENT_LENS_PLAYGROUND=true 时挂载
-make web-install   # 首次
-make web-dev       # http://localhost:5173 (Vite，proxies /v1 到 :8787)
+# 3. 一行配 Claude Code hook（写到 ~/.claude/settings.json，幂等合并；保留你既有 hooks）
+agent-lens-hook setup --personal --skip-compose
+# 不带 --skip-compose 它会自动启 docker compose 给你；这里因为上面手动起了
 
-# 3b. 生产模式：UI 嵌入二进制由 / 直接服务
-make build-prod && ./bin/agent-lens
-# 浏览 http://localhost:8787 看 Lens UI；同端口走 GraphQL 与 API
-
-# 4. 装 Claude Code hook
-# 编辑 ~/.claude/settings.json，加入 hooks 指向 ./bin/agent-lens-hook claude
-# 详见下方 "接入 Claude Code"
-
-# 5. 装 git post-commit hook（在被观测的仓库里）
-ln -s "$(pwd)/bin/agent-lens-hook" .git/hooks/agent-lens-hook
+# 4. 装 git post-commit hook（在被观测的仓库里）
+ln -s "$(which agent-lens-hook)" .git/hooks/agent-lens-hook
 cat > .git/hooks/post-commit <<'EOF'
 #!/bin/sh
 exec .git/hooks/agent-lens-hook git-post-commit
 EOF
 chmod +x .git/hooks/post-commit
+
+# 5. 浏览 http://localhost:8787 看 Lens UI
 ```
+
+要卸：`agent-lens-hook setup --uninstall`（精确移除 hook 条目，留下你为其它工具写的部分）。
+
+### 验证下载（可选）
+
+v0.1.0 二进制由项目自有 ed25519 签名，公钥随 release 发出。**用 v0.1 工具校验 v0.1 二进制**——dogfood 的最强信号：
+
+```bash
+curl -fsSL https://github.com/dong-qiu/agent-lens/releases/download/v0.1.0/agent-lens-public.pem -o pubkey.pem
+agent-lens-hook verify-attestation \
+  --pub pubkey.pem \
+  --require-type "agent-lens.dev/release-artifact/v1" \
+  agent-lens-hook-darwin-arm64.sig
+# OK · payloadType application/vnd.in-toto+json · keyid <id>
+```
+
+`cosign` 用户走 [§ Cosign 兼容性](#cosign-兼容性) 段的 recipe（已实测）。
+
+## 改源码 / 贡献
+
+```bash
+# 1. 装开发工具链
+brew install go pnpm buf node            # golang-migrate 不需要：server 启动自迁移
+
+# 2. 起 Postgres + MinIO（开发期持久存）
+make compose-up
+
+# 3. 跑 server（dev 模式 = UI 走 vite dev server）
+make build && ./bin/agent-lens
+make web-install                         # 首次
+make web-dev                             # http://localhost:5173，proxies /v1 到 :8787
+
+# 3'. 或 prod 模式（UI 嵌入二进制）
+make build-prod && ./bin/agent-lens      # http://localhost:8787 直接看 UI
+
+# 4. 设置 hook（同上 60 秒段）
+```
+
+源码安装也通过 `setup --personal`（subcommand 来自 cmd/agent-lens-hook，build 出来跟二进制行为一致）。`go install ./cmd/agent-lens-hook` 后即可在任何目录调用。
 
 ## 测试
 
@@ -52,6 +84,8 @@ make web-build         # TS 类型检查 + Vite 打包
 ```
 
 ## 接入 Claude Code
+
+> **推荐用 `agent-lens-hook setup --personal`**（见上方"60 秒试用"段，幂等、保留你既有 hook 条目）。下面是 setup 命令的等价手动配置——如果你只想知道写了什么，或要做特殊定制（比如改 hook command 路径、加自定义 `matcher`），按这里写：
 
 在 `~/.claude/settings.json`（或仓库级 `.claude/settings.json`）添加：
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -16,7 +16,7 @@ Agent Lens 是面向 Coding Agent 的**可观测、可追溯、可审计**系统
 - **G1 全程捕获**：覆盖 Prompt → Agent Thinking → Tool Calls → Code Change → Test → Build → Deploy 的每一类事件。
 - **G2 因果串联**：把跨阶段、跨工具、跨 Agent 的事件按因果与时序拼成可查询的 trace。
 - **G3 防篡改**：事件 append-only，哈希链 + 可选签名，可校验、可重放。
-- **G4 可审计**：支持按时间、人、Agent、需求 ID、commit、PR、build、deploy 任意维度回溯。
+- **G4 可审计**：以多维度回溯证据链为目标。v0.1 实际范围：按 session / event id / 跨 session linker 关联（`linkedEvents`）回溯，外加按 git ref / image digest 自动串接 commit / PR / build / deploy 阶段；按时间窗 / actor / agent / 文件 / 需求 ID 等 fine-grained 检索是 v0.2+ 路线（详见 v0.1.0 release notes 的"已知限制"段）。
 - **G5 低侵入接入**：通过 hook / SDK / Git hook / CI 插件接入，不要求改造既有工作流。
 - **G6 供应链兼容**：在阶段边界输出符合 in-toto / SLSA 规范的 attestation，可被 cosign / policy controller 直接消费。
 
@@ -54,7 +54,7 @@ Agent Lens 是面向 Coding Agent 的**可观测、可追溯、可审计**系统
 2. **Ingest**：标准化事件 schema（参考 OpenTelemetry，扩展 AI 字段）。
 3. **Link**：基于 commit SHA、PR ID、session ID、需求 ID 跨阶段拼接。
 4. **Store**：append-only 事件流 + 内容寻址的 artifact 存储。
-5. **Query**：按 trace / 时间 / 人 / Agent / 文件 / 需求 ID 检索。
+5. **Query**：v0.1 提供 by-session / by-event-id / 跨 session linker 关联（depth 0-3，可达 sessions BFS）+ Sessions 列表（按 lastEventAt 排序，可选 `since` 时间过滤）。GraphQL 查询接口在 `internal/query/schema.graphql`。按时间窗 / actor / agent / 文件 / 需求 ID 等 fine-grained 检索是 v0.2+ 路线。
 6. **Visualize**：时间线 + 因果图 + 代码 diff 关联视图（"Lens UI"）。
 7. **Verify**：哈希链 + 签名 + replay。
 8. **Export**：阶段边界输出 in-toto attestation（含 SLSA provenance predicate）。
@@ -145,7 +145,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 ### 9.2 评审
 1. PR 创建时 GitHub App 上报 pr event。
 2. Linking worker 用 commit SHA 把 PR 关联到上游所有 turn。
-3. PR Bot 在 PR 上评论一段"Evidence Summary"链接到 Lens UI。
+3. PR Bot 在 PR 上评论一段"Evidence Summary"链接到 Lens UI。**v0.1 未交付**——见 §14 M2 注记，需先开 ADR 决定 outbound 形态（评论 vs status check vs LLM 自动审）+ 与 §13 self-hosted 调性的兼容路径。
 
 ### 9.3 构建与部署
 1. CI 插件上报 build event；产物 hash 写入 artifact store。

--- a/docs/RELEASE_NOTES_v0.1.0.md
+++ b/docs/RELEASE_NOTES_v0.1.0.md
@@ -1,0 +1,131 @@
+# Agent Lens v0.1.0 — 个人模式首发
+
+第一次对外发布。Personal mode only —— 一个开发者在自己笔记本上跑、自己看自己的数据。
+
+把你和 Claude Code 的每一次对话——prompt / thinking / tool call / tool result / 最后落地的 commit / PR / build / deploy——串成一条 hash-linked、可签名校验、可整条打包导出的事件链，存在你自己的笔记本上。多数 Coding Agent 都是黑盒；这是给那个黑盒装一面镜子。
+
+## v0.1 你能做什么
+
+- **Claude Code 全链路捕获**（`agent-lens-hook setup --personal` 一行装好）
+  - prompt / thinking（含 `🚫 N thinking redacted` 占位指示器，标识 Claude Code 端丢弃的思考块）
+  - tool call / tool result（Bash / Edit / Write / Read 等 + Agent 派发标识 `🤖 agent <id>`）
+  - per-message token usage（input / output / cache_read / cache_write_5m / cache_write_1h，带 vendor 字段，跨厂商可比）
+  - Claude Code 子 agent（Task tool）独立 session 捕获
+- **Hook 端规则脱敏**（SPEC §12 路线第一步）
+  - 7 类高置信度模式：PEM 私钥 / AWS / GitHub / Anthropic / Slack / HTTP Authorization / keyword=value secret
+  - UI `🔒 N secrets redacted` chip，落库前替换为 `[REDACTED:<type>]`
+- **GitHub webhook 接 PR / push / workflow_run**（可选；本机服务暴露公网才能用）
+- **Lens Web UI**（embed 在 server binary 里，访问 server 同端口 :8787 即可）
+  - Timeline 视图（最多 5000 事件 / session）
+  - 因果图（ReactFlow + Monaco diff，单 session 上限 200 节点）
+  - Sessions list + 每 session token 总用量
+- **签名 attestation 三件套**（in-toto / SLSA / 自定义 predicate）
+  - `code-provenance / slsa-build / deploy-evidence`
+  - DSSE 信封 + 项目自有 ed25519 签名
+- **审计报告导出**：以 deploy / commit / PR 为根，BFS 打包整条证据链 + 嵌入 attestation，单文件 JSON 自鉴
+- **CLI 校验**：
+  - `agent-lens-hook verify`（哈希链）
+  - `agent-lens-hook verify-attestation`（DSSE 签名）
+  - `agent-lens-hook verify-audit-report`（整包重 hash）
+- **silent-degradation 自报**：hook HTTP 失败回落 NDJSON 时，stderr 一行可见警告 + `agent-lens-hook replay` 命令把 backlog 推回 server
+
+## 安装
+
+（实际下载链接在 GitHub Releases 上线后填具体 URL，下面是 ship 后的 README 引导格式）
+
+### 60 秒快速试用
+
+```bash
+# 1. 拉镜像 + 起 PG + MinIO + agent-lens
+docker run -d -p 8787:8787 ghcr.io/dong-qiu/agent-lens:v0.1.0
+# 注：完整 stack（含 Postgres / MinIO 持久存储）走下面 docker compose 路径
+
+# 2. 装 hook 二进制（Mac arm64 示例）
+curl -fsSL https://github.com/dong-qiu/agent-lens/releases/download/v0.1.0/agent-lens-hook-darwin-arm64 \
+  -o /usr/local/bin/agent-lens-hook
+chmod +x /usr/local/bin/agent-lens-hook
+
+# 3. 一键配 Claude Code hook + 起持久 stack
+agent-lens-hook setup --personal
+
+# 4. 浏览 http://localhost:8787 看 Lens UI
+```
+
+### 验证下载（可选）
+
+v0.1.0 的二进制由项目自己的 ed25519 签发。下载下来可以用 v0.1 的 verify 工具校验 v0.1 的二进制：
+
+```bash
+curl -fsSL https://github.com/dong-qiu/agent-lens/releases/download/v0.1.0/agent-lens-public.pem -o pubkey.pem
+agent-lens-hook verify-attestation \
+  --pub pubkey.pem \
+  --require-type "agent-lens.dev/release-artifact/v1" \
+  agent-lens-hook-darwin-arm64.sig
+# OK · payloadType application/vnd.in-toto+json · keyid <id>
+```
+
+`cosign` 用户走 README §Cosign 兼容性 段的 recipe（已实测）。
+
+### 改源码 / 贡献
+
+```bash
+brew install go pnpm node              # 不再需要 golang-migrate（server 自迁移）
+git clone https://github.com/dong-qiu/agent-lens
+cd agent-lens
+make compose-up                        # 起 PG + MinIO
+make build-prod && ./bin/agent-lens    # build + 嵌入 UI 跑
+```
+
+详细见 README 主文档。
+
+## v0.1 故意没做什么
+
+透明工具该自己交代 scope。v0.1 不做：
+
+- **团队多用户 / 数据隔离**：单机单人；多人共享 server 看得到彼此 prompt——这不是设计目标。Team mode 在 v0.2 路线，需要先有 ADR 决定"谁能看到谁"的 isolation 模型。
+- **PR Review Bot outbound**：架构图里画了，§14 M2 注记里也明说"未交付"。需要先单开 ADR 决定 LLM 自动审 vs 规则引擎 vs 仅附 audit-report 链接 vs 与 §13 self-hosted 兼容方式。
+- **采集器自身的 capture-time attestation**：当前能 verify "事件序完整"，不能 verify "事件源没被静默篡改"。ADR 0003 在补这个。
+- **OpenCode / Cursor / 其他 AI CLI 接入**：v0.1 only Claude Code（SPEC §10.1）。OpenCode 在 §10.2 路线（v0.2）。
+- **成本估算**：只记 token 数，不算 USD（vendor pricing volatile，写死容易过时；ADR 0002 D1 决定）。
+- **Sub-agent 父→子自动 link**：父侧完整捕获、子 session 独立捕获，但父→子 `delegates` 自动连边留 v0.2（详见 ADR 0008 + 追踪 issue #85）。
+- **Windows 二进制**：darwin / linux only。
+- **Helm chart**：`deploy/helm/` 留空。v0.1 仅 Docker Compose。
+
+## §17 自审 / Dogfood 故事
+
+v0.1.0 的二进制由项目自己的 ed25519 签发；签发用的工具就是 v0.1 提供给你的 `agent-lens-hook export` + `verify-attestation`。**用 v0.1 校验 v0.1**——见上方"验证下载"段。
+
+v0.1 的开发本身也是 dogfood：本仓库的开发循环全程跑在 agent-lens 上，从 v0.1.0 任何一次 commit 都能反向 trace 到触发它的 prompt 和 thinking。这是 §17 自观测从激活日（M3 收尾）一直跑到 v0.1.0 cut 的产物——这次发布的 release notes 自身的撰写过程也在 audit chain 里。
+
+## 已知限制（装之前应该知道）
+
+- **Hook 失败时落本地 NDJSON 文件**：`~/.agent-lens/sessions/<sid>.ndjson`。即便没起 server，hooks 仍会在 home dir 累积事件文件。stderr 一行警告会提示。彻底停活：删 `.claude/settings.local.json` + `~/.claude/settings.json` 的 hook 段（`agent-lens-hook setup --uninstall`）+ `rm -rf ~/.agent-lens`。
+- **不回填**：`setup --personal` 之后的 session 才入库；之前的 Claude Code 历史不导。
+- **Thinking 文本可能含敏感片段**：默认 redaction 抓 7 类高置信度密钥，**不抓 PII** / 不抓 entropy-based 通用秘密 / 不抓 Stripe / OpenAI / GCP / Discord / JWT 等其他 vendor。导出 audit-report 前自己 review。
+- **`agent-lens verify` v1 弱**：只校验 `prev_hash → hash` 链路完整性，不重算 hash。敌手能直接写库就能伪造自洽链。强校验在 v0.2 路线。
+- **Graph 视图最多 200 节点**：超过会卡（dagre + ReactFlow 渲染上限）；Timeline 视图无此限制（最多 5000）。Graph 是高层 summary 视图，深 drill-down 用 Timeline。
+- **Sub-agent（Task tool）父→子手动关联**：v0.1 父侧捕获含 agentId、子 session 独立捕获，但**没自动连边**。审计时通过 timestamp + prompt 文本人眼对应。详见 ADR 0008。
+- **Cosign 部分兼容**：`cosign verify-blob-attestation` 在 release-artifact 上原生工作（sha256 subject）；在 code-provenance / deploy-evidence 上需走手动 PAE recipe（README §Cosign 兼容性 有完整命令）。SLSA build 路径理论可走但 v0.1 未端到端验证。
+
+## 下一步（v0.2 重点 / 无 ETA）
+
+按当前 issue 跟踪：
+
+- **Sub-agent 父→子自动 link**（[#85](https://github.com/dong-qiu/agent-lens/issues/85)）：候选 4 条路径（Claude Code 上游改 / FS marker / 时间相关启发 / hybrid）
+- **Server-side ULID dedup**（[#81](https://github.com/dong-qiu/agent-lens/issues/81)）：让 replay 重跑安全
+- **Cosign 兼容性升级**（[#75](https://github.com/dong-qiu/agent-lens/issues/75)）：sha256 alias 或 cosign-format 助手
+- **Agent-lens-hook status 子命令**（隐式 #71 follow-up）：检查 fallback 队列大小
+- **Web 测试基础设施**（[#62](https://github.com/dong-qiu/agent-lens/issues/62)）：vitest setup
+- **Session.totalUsage N+1 + 全量 load 性能**（[#65](https://github.com/dong-qiu/agent-lens/issues/65)）
+- **GraphQL TokenUsage 集成测试**（[#66](https://github.com/dong-qiu/agent-lens/issues/66)）
+- **Agent transparency follow-ups**（[#58](https://github.com/dong-qiu/agent-lens/issues/58)）
+
+更广 v0.2 主题：team mode / capture-time attestation（ADR 0003）/ human-intervention events（ADR 0004）/ context transform events（ADR 0005）/ Helm chart / OpenCode 接入 / §10.4 proxy 深模式（实时拦截 + 流式 thinking）。
+
+## 反馈
+
+GitHub Issues。dogfood 自己用 v0.1 抓自己的开发证据，发现 patterns 后开 issue 是最直接的路径。
+
+---
+
+**v0.1.0 release engineering note**：本 release 的 8 个 binary（agent-lens × agent-lens-hook × darwin/linux × amd64/arm64） + container image（multi-arch GHCR）+ checksums 都由 release.yml 在 tag push 时自动产出 + 签名（ADR 0006 D6 / D7）。第一次 tag 失败的迭代成本是删 tag / 修 / 重 tag，不毁灭性——所以你也许会看到 v0.1.1 出现得比较早。


### PR DESCRIPTION
## Summary

v0.1 Phase 3 — final docs prep before tag v0.1.0.

Three artifacts in one PR (all docs, no code):

### 1. \`docs/RELEASE_NOTES_v0.1.0.md\` (new)

Full release notes. Structure:
- One-line opener + concrete value statement
- "v0.1 你能做什么" — 7 capability bullets with feature names + flags
- 60-second install + verify-download (cosign-via-PAE)
- "v0.1 故意没做什么" — 8 explicit deferrals, each owned (issue or ADR ref)
- §17 dogfood story: v0.1 self-audits the v0.1 release
- Known limitations: 7 sharp edges spelled out (5000-event Timeline cap, 200-event Graph cap, redactor pattern gaps, sub-agent manual correlation, cosign partial, etc.)
- v0.2 follow-ups: links to 8 issues opened during v0.1 (#58 / #62 / #65 / #66 / #71 / #75 / #81 / #85)

Honest tone, no marketing inflation. Audit users care about explicit scope > glossy claims.

### 2. README rewrite

- "状态" section: v0.1.0 released, points at RELEASE_NOTES
- New "60 秒试用" section: docker compose + \`setup --personal\` (replaces dev-only build-from-source)
- "改源码 / 贡献" section preserved, recommends \`setup --personal\` for hook config
- "接入 Claude Code" manual-config section kept but prefaced with "推荐用 setup --personal"

### 3. SPEC overclaim softening (closes PR #76 review's 3rd leg)

- §2 G4: query-dimension claim softened to v0.1 actual scope
- §6.5: same, with reference to schema.graphql
- §9.2: PR Bot bullet annotated "v0.1 未交付"

## NOT in this PR

- **G phase**: clean-machine smoke (a fresh box runs setup --personal end-to-end including docker compose pull from GHCR — needs to wait until v0.1.0 tag is cut and binaries exist)
- **Tag v0.1.0 itself**: separate action; this PR describes v0.1.0 for readers landing post-tag

## Test plan

- [ ] CI green (docs-only, no functional change)
- [ ] Reviewer skims RELEASE_NOTES_v0.1.0.md for:
  - Tone (honest vs marketing)
  - Length (overlong vs adequate)
  - Anything overclaimed (caught the §6.5 type 3 weeks ago — don't recommit the same sin in release notes)
  - All 8 v0.2 issues referenced exist (they were opened during PRs in this v0.1 cycle)