### PR TITLE
fix(web): allow esbuild postinstall script in pnpm install (release.y…

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -32,5 +32,8 @@
     "tailwindcss": "^3.4.13",
     "typescript": "^5.6.2",
     "vite": "^5.4.8"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }


### PR DESCRIPTION
…ml fix)

First v0.1.0 tag failed because the release.yml container build job's web-build stage hit:
  ERR_PNPM_IGNORED_BUILDS: Ignored build scripts: esbuild@0.21.5
  Run "pnpm approve-builds" to pick which dependencies should be allowed
  to run scripts.

esbuild's postinstall downloads the platform-specific native binary without which esbuild can't run. pnpm 9+ requires explicit approval of build scripts. Approve esbuild via package.json's pnpm.onlyBuilt Dependencies field.

This fix is iteration 1 on the first-tag-cut feedback loop documented in PR #87 / RELEASE_NOTES — workflow yaml is sound, web-build stage hits the modern pnpm safety check.