### PR TITLE
fix(web): allow esbuild postinstall in pnpm install (v0.1.0 release.yml fix)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -32,5 +32,8 @@
     "tailwindcss": "^3.4.13",
     "typescript": "^5.6.2",
     "vite": "^5.4.8"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }


### PR DESCRIPTION
## Summary

First v0.1.0 tag's release.yml hit a pnpm safety check on the container build's web-build stage:

\`\`\`
[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.21.5
Run "pnpm approve-builds" to pick which dependencies should be allowed to run scripts.
\`\`\`

esbuild's postinstall downloads the platform-specific native binary without which esbuild can't run at build time. pnpm 9+ refuses to run install scripts unless explicitly approved.

## Fix

Add \`pnpm.onlyBuiltDependencies: ["esbuild"]\` to \`web/package.json\`. This is the modern pnpm approval mechanism — declares "we know esbuild's postinstall is needed and we trust it".

## Why this didn't surface in CI before tag-push

CI's \`web build\` job uses pnpm too, but Docker's pnpm version (latest from \`npm install -g pnpm\` inside container) is newer than CI's runner-installed pnpm. The new safety check landed between those versions. Docker container hits it; CI runner happened not to. **First-tag-cut iteration cost** as anticipated in RELEASE_NOTES — workflow yaml is sound, fix is one line.

## Test plan

- [ ] CI green
- [ ] After merge: delete v0.1.0 tag, re-tag at the merge commit, push tag → release.yml should now complete all jobs (4 binary + container + release create)

## Provenance

Discovered in run 25607449107's container build job:
\`\`\`
container image (linux/amd64 + linux/arm64): failure
\`\`\`
Fix verified locally via web/package.json schema (no code change beyond config). Iteration 1 on first-tag-cut feedback loop.