### PR TITLE
fix(release): drop linux/arm64 container, ship amd64 only (v0.1.0 iter 3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
           retention-days: 7
 
   build-image:
-    name: container image (linux/amd64 + linux/arm64)
+    name: container image (linux/amd64)
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -112,7 +112,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: docker/setup-qemu-action@v3
       - uses: docker/setup-buildx-action@v3
 
       - uses: docker/login-action@v3
@@ -126,19 +125,24 @@ jobs:
         with:
           context: .
           file: deploy/compose/Dockerfile.server
-          # Multi-arch via QEMU. Linux only — darwin/windows aren't a v0.1
-          # container target (per ADR 0006 D5 the BINARIES are darwin/linux,
-          # but the CONTAINER ships only linux because nobody runs Docker
-          # natively on macOS arm64 without colima/Docker Desktop).
-          platforms: linux/amd64,linux/arm64
+          # v0.1: linux/amd64 only. linux/arm64 via QEMU emulation
+          # exhausted GitHub Actions' 6-hour job timeout on the web-build
+          # stage (vite + Monaco's 3.8 MB chunk in emulated arm64 = many
+          # hours). arm64 Mac users run amd64 images via Docker Desktop /
+          # colima at ~2x perf penalty — acceptable for v0.1; v0.1.x can
+          # split web-build into a separate amd64 job + multi-arch
+          # docker build using the artifact, OR move to native arm64
+          # runners (ubuntu-24.04-arm).
+          # Binaries are still cross-built for darwin/linux × amd64/arm64
+          # in build-binaries; arm64 users have a native binary path.
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/dong-qiu/agent-lens:${{ github.ref_name }}
             ghcr.io/dong-qiu/agent-lens:latest
-          # Enable provenance + SBOM via buildkit defaults; cosign of the
-          # image itself is a v0.2 follow-up (cosign sign vs DSSE-attest of
-          # the manifest is a different signing path than the release-artifact
-          # attestations we sign here).
+          # Container-image cosign signing deferred to v0.2 (different
+          # signing path than the release-artifact DSSE attestations
+          # signed in build-binaries above).
 
   release:
     name: gh release


### PR DESCRIPTION
## Summary

Iter 2 (#91)'s container build job was **cancelled at 6 hours** — GitHub Actions' max single-job timeout. Multi-arch buildx with QEMU-emulated arm64 hit the wall on the vite web-build stage.

## Cause analysis

\`linux/arm64\` via \`docker/setup-qemu-action\` runs the entire web-build stage under x86→arm64 emulation:
- vite + Monaco's 3.8 MB chunk + esbuild + ~10 npm deps
- Emulation slowdown: ~5-10x on JIT-heavy node workloads
- Combined with arm64 Go compile + multi-arch buildx merge: job runs >6h

## Fix

- v0.1 ships \`linux/amd64\` container only
- Binaries remain cross-built for darwin/linux × amd64/arm64 (build-binaries job; that's Go cross-compile, fast)
- arm64 Mac users either: (a) run native binary (b) run amd64 container via Docker Desktop/colima at ~2x runtime penalty

## v0.1.x revisit options

1. \`runs-on: ubuntu-24.04-arm\` for native arm64 (no QEMU)
2. Split web-build into amd64-only job, upload dist artifact, multi-arch docker build downloads artifact
3. Both

## Test plan

- [ ] CI green
- [ ] After merge: re-tag v0.1.0 → release.yml completes in <10 min instead of timing out