### PR TITLE
ci+release: Dockerfile build CI + workflow_dispatch dry-run (#93 items 1+2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,3 +108,26 @@ jobs:
           cache-dependency-path: web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
+
+  # Catches Dockerfile breakage on every PR — added per issue #93 Item 1
+  # after v0.1.0 first-tag-cut iterated 3 times on Dockerfile issues
+  # (pnpm safety check + QEMU arm64 timeout) that all would have surfaced
+  # locally but didn't because we only built it via the release pipeline.
+  # Single-arch (linux/amd64, native runner) keeps the job fast (~2 min
+  # cached); multi-arch is release.yml's job.
+  dockerfile-build:
+    name: Dockerfile build (linux/amd64)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - name: Build (no push)
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: deploy/compose/Dockerfile.server
+          push: false
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,17 @@ name: Release
 on:
   push:
     tags: ['v*.*.*']
+  # workflow_dispatch (added per issue #93 Item 2 after v0.1.0 iterated
+  # 4× on first-tag-cut): manually trigger this pipeline against any
+  # branch BEFORE tagging, with --dry-run skipping GHCR push and the
+  # GitHub Release create step. Lets us validate end-to-end pipeline
+  # changes without burning a real tag-rebase cycle.
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run — skip GHCR push + GitHub Release create (default true)'
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -136,7 +147,11 @@ jobs:
           # Binaries are still cross-built for darwin/linux × amd64/arm64
           # in build-binaries; arm64 users have a native binary path.
           platforms: linux/amd64
-          push: true
+          # push only on real tag push, OR explicit non-dry-run
+          # workflow_dispatch. Dry-run builds the image but skips
+          # registry write — lets us validate pipeline changes without
+          # polluting :latest.
+          push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
           tags: |
             ghcr.io/dong-qiu/agent-lens:${{ github.ref_name }}
             ghcr.io/dong-qiu/agent-lens:latest
@@ -147,6 +162,11 @@ jobs:
   release:
     name: gh release
     needs: [build-binaries, build-image]
+    # Skip on dry-run workflow_dispatch — binaries + signatures are
+    # still uploaded as workflow run artifacts (build-binaries job),
+    # so reviewers can pull them for verify; we just don't create a
+    # public GitHub Release.
+    if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false)
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,8 +152,15 @@ jobs:
           # registry write — lets us validate pipeline changes without
           # polluting :latest.
           push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
+          # On tag push: tag the image with the version (e.g. v0.1.0).
+          # On workflow_dispatch: github.ref_name is the branch name, which
+          # commonly contains '/' (e.g. feat/foo) — invalid as an OCI tag, so
+          # docker/build-push-action rejects it even with push:false. Use a
+          # synthetic dispatch-<run_id> tag instead. (This bug was caught by
+          # the very first dry-run we ran on this branch — exactly the class
+          # of failure issue #93 Item 2 exists to surface pre-tag.)
           tags: |
-            ghcr.io/dong-qiu/agent-lens:${{ github.ref_name }}
+            ghcr.io/dong-qiu/agent-lens:${{ github.event_name == 'push' && github.ref_name || format('dispatch-{0}', github.run_id) }}
             ghcr.io/dong-qiu/agent-lens:latest
           # Container-image cosign signing deferred to v0.2 (different
           # signing path than the release-artifact DSSE attestations


### PR DESCRIPTION
## Summary

Two release-engineering hardenings from issue #93 retrospective. Together they prevent the v0.1.0 first-tag-cut class of failures — the 3 iterations that cost ~6h of GitHub Actions runtime and 4 PRs.

## Item 1: \`dockerfile-build\` CI job

New job in \`ci.yml\` builds \`deploy/compose/Dockerfile.server\` (linux/amd64, no push) on every PR. Would have caught:
- pnpm safety check on esbuild postinstall (PR #90 root cause)
- Multi-stage build invariants (web-build → Go → distroless)
- Dependency install issues (any package manager / Go module change)

Doesn't catch:
- linux/arm64-specific issues (QEMU; v0.1.x scope)
- GHCR auth (real push, requires real secret)
- Runtime semantics (only build, no run)

Cost: ~2-3 min/PR cached via \`type=gha\`.

## Item 2: \`workflow_dispatch\` with \`dry_run\` input

New manual trigger on \`release.yml\`:
\`\`\`bash
gh workflow run release.yml -f dry_run=true
\`\`\`
or via the GitHub Actions UI tab.

Validates the entire pipeline against any branch BEFORE tagging:
- 4 binary builds + DSSE signing run normally → uploaded as workflow run artifacts
- Container builds locally but does NOT push to GHCR
- \`gh release\` job is skipped (no public Release created)

\`dry_run\` defaults to \`true\` (safe-by-default for manual triggers). Tag-push behavior unchanged.

## What this PR does NOT do (issue #93 items 3-8)

- ADR 0009 for container platforms
- Native arm64 runner OR split web-build job
- \`/review\` policy for release-engineering files
- \`/self-review\` skill update
- RC tag pattern

Each tracked separately as v0.2 or process work.

## Test plan

- [ ] CI green (the new dockerfile-build job runs on this very PR — eat your own dogfood)
- [ ] After merge: trigger \`gh workflow run release.yml -f dry_run=true\` on main, verify all jobs except gh release run; verify image NOT pushed to GHCR