### PR TITLE
chore: close out #93 process items 5/6/7 (RC tag pattern + /review policy)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,12 @@ name: Release
 
 on:
   push:
+    # `v*.*.*` matches both stable (`v0.1.0`) and RC (`v0.2.0-rc1`)
+    # tags — GitHub's `*` glob matches any non-`/` character including
+    # `-`, so this single pattern catches everything we want. The
+    # stable-vs-prerelease distinction is enforced downstream by
+    # `prerelease: ${{ contains(github.ref_name, '-rc') }}` in the gh
+    # release step + tag selection in build-image. Per issue #93 Item 5.
     tags: ['v*.*.*']
   # workflow_dispatch (added per issue #93 Item 2 after v0.1.0 iterated
   # 4× on first-tag-cut): manually trigger this pipeline against any
@@ -131,6 +137,33 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Compute image tags
+        id: tags
+        # Dispatch (any kind): single synthetic tag dispatch-<run_id> so
+        # docker/build-push-action accepts the OCI tag format.
+        # Final tag push (no -rc): version tag + :latest (latest follows
+        # final releases only).
+        # RC tag push (e.g. v0.2.0-rc1): version tag only — :latest must
+        # NOT advance to a prerelease (matches the gh release prerelease:
+        # field below; #93 Item 5).
+        run: |
+          set -e
+          IMAGE=ghcr.io/dong-qiu/agent-lens
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            TAGS="$IMAGE:dispatch-${{ github.run_id }}"
+          elif [[ "${{ github.ref_name }}" == *-rc* ]]; then
+            TAGS="$IMAGE:${{ github.ref_name }}"
+          else
+            TAGS="$IMAGE:${{ github.ref_name }}"$'\n'"$IMAGE:latest"
+          fi
+          {
+            echo "tags<<EOF"
+            echo "$TAGS"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "Computed image tags:"
+          echo "$TAGS"
+
       - name: Build + push image
         uses: docker/build-push-action@v5
         with:
@@ -152,16 +185,7 @@ jobs:
           # registry write — lets us validate pipeline changes without
           # polluting :latest.
           push: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.dry_run == false) }}
-          # On tag push: tag the image with the version (e.g. v0.1.0).
-          # On workflow_dispatch: github.ref_name is the branch name, which
-          # commonly contains '/' (e.g. feat/foo) — invalid as an OCI tag, so
-          # docker/build-push-action rejects it even with push:false. Use a
-          # synthetic dispatch-<run_id> tag instead. (This bug was caught by
-          # the very first dry-run we ran on this branch — exactly the class
-          # of failure issue #93 Item 2 exists to surface pre-tag.)
-          tags: |
-            ghcr.io/dong-qiu/agent-lens:${{ github.event_name == 'push' && github.ref_name || format('dispatch-{0}', github.run_id) }}
-            ghcr.io/dong-qiu/agent-lens:latest
+          tags: ${{ steps.tags.outputs.tags }}
           # Container-image cosign signing deferred to v0.2 (different
           # signing path than the release-artifact DSSE attestations
           # signed in build-binaries above).
@@ -232,6 +256,10 @@ jobs:
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
+          # Tags matching `v*.*.*-rc*` (e.g. v0.2.0-rc1) ship as
+          # prerelease — `releases/latest/...` URLs and ghcr.io :latest
+          # skip them. Stable tags (v*.*.*) ship as latest.
+          prerelease: ${{ contains(github.ref_name, '-rc') }}
           generate_release_notes: true
           fail_on_unmatched_files: true
           files: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,7 @@ Per [#93](https://github.com/dong-qiu/agent-lens/issues/93) Item 5:
 - **Stable release**: tag `vX.Y.Z` (e.g. `v0.1.1`). Marked latest; `/releases/latest/...` redirects, `:latest` ghcr tag advances.
 - **Release candidate**: tag `vX.Y.Z-rcN` (e.g. `v0.2.0-rc1`). Marked **prerelease** automatically; `/releases/latest/...` and `:latest` skip it. Use when the dispatch dry-run path can't cover the test (e.g. asking external testers to install via stable URL pattern, or testing the full `gh release create` codepath end-to-end).
 - **Pre-tag validation**: prefer `gh workflow run release.yml --ref <branch> -f dry_run=true` (cheaper than RC tags; no public artifact). RC tags are for the cases dry-run can't reach.
+- **RC suffix is lowercase `-rc`** (not `-RC`, `-Rc`). The release.yml RC detection uses case-sensitive `contains(github.ref_name, '-rc')` and `[[ ... == *-rc* ]]`. A tag like `v1.0.0-RC1` would be incorrectly published as **stable** and advance `:latest`. Stick to lowercase.
 
 ## Local development with persistence
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,13 +32,34 @@ These were settled during initial scoping and are referenced throughout `SPEC.md
 
 ## Self-review before merge
 
-**Run `/self-review` before submitting any self-review summary or merging a PR.** The skill (in `.claude/skills/self-review/SKILL.md`) runs the mechanical pass automatically (git staging hygiene, codegen drift, tests, typecheck, debug-marker scan), walks the judgment-pass prompts, recommends `/review` or `/ultrareview` escalation when the PR warrants it, and ends with an explicit "what this review didn't cover" disclaimer.
+**Run `/self-review` before submitting any self-review summary or merging a PR.** The skill (in `.claude/skills/self-review/SKILL.md`) runs the mechanical pass automatically (git staging hygiene, codegen drift, tests, typecheck, debug-marker scan, Dockerfile build, actionlint, release.yml dry-run, RELEASE_NOTES quantitative-claim cross-check), walks the judgment-pass prompts, recommends `/review` or `/ultrareview` escalation when the PR warrants it, and ends with an explicit "what this review didn't cover" disclaimer.
 
-The skill exists because passive checklists (this file alone) didn't prevent the failure modes that motivated it — codegen drift, accidental file inclusion, repeated UX misses. Mechanical hygiene is enforced by code that runs, not docs that have to be remembered.
+The skill exists because passive checklists (this file alone) didn't prevent the failure modes that motivated it — codegen drift, accidental file inclusion, repeated UX misses, Dockerfile breakage shipped to tag, release-notes hash overclaims. Mechanical hygiene is enforced by code that runs, not docs that have to be remembered.
 
 **Self-review structurally cannot cover** UX latency, visual rendering, layout shift, or perception. Static analysis won't see a 700 ms tooltip delay or a misaligned chip. The skill surfaces these as explicit "manual smoke needed" handoffs to the user — not as items the review claims to subsume.
 
 **Post-merge calibration**: if CI catches something `/self-review` missed, add a check to the skill's Phase 1. The next contributor (or future-me) inherits the lesson via skill update, not by reading docs.
+
+## Risk-asymmetric files require `/review`
+
+Per [#93](https://github.com/dong-qiu/agent-lens/issues/93) Item 7. Some files have asymmetric blast radius: a missed bug propagates to all users (release pipeline) or breaks the integrity guarantees the project exists to provide (attestation, hash chain). Self-review alone is insufficient for these.
+
+Any PR touching the following **must have `/review` invoked** before merge (the `/self-review` skill's Phase 3 escalates this automatically):
+
+- `.github/workflows/release.yml` — broken release.yml = hours of GHA + tag-rebase friction (v0.1.0 ate 4 iterations / ~6h on this lesson)
+- `deploy/compose/Dockerfile*` — ships in every container image; PR-time CI catches build breakage but not runtime semantics
+- `internal/attest/*` — DSSE envelope / in-toto predicate construction; signing or verifying wrong = silently-broken supply chain
+- `internal/hashchain/*` — chain integrity primitive; bug here invalidates `verify` claims
+
+For these paths, `/review` is project policy, not a soft suggestion.
+
+## Release versioning + RC tag pattern
+
+Per [#93](https://github.com/dong-qiu/agent-lens/issues/93) Item 5:
+
+- **Stable release**: tag `vX.Y.Z` (e.g. `v0.1.1`). Marked latest; `/releases/latest/...` redirects, `:latest` ghcr tag advances.
+- **Release candidate**: tag `vX.Y.Z-rcN` (e.g. `v0.2.0-rc1`). Marked **prerelease** automatically; `/releases/latest/...` and `:latest` skip it. Use when the dispatch dry-run path can't cover the test (e.g. asking external testers to install via stable URL pattern, or testing the full `gh release create` codepath end-to-end).
+- **Pre-tag validation**: prefer `gh workflow run release.yml --ref <branch> -f dry_run=true` (cheaper than RC tags; no public artifact). RC tags are for the cases dry-run can't reach.
 
 ## Local development with persistence
 


### PR DESCRIPTION
## Summary

Three things in one PR — closes the remaining process-discipline parts of [#93](https://github.com/dong-qiu/agent-lens/issues/93) (Items 3+4 stay v0.2 backlog).

### Item 5 — RC tag pattern

\`vX.Y.Z-rcN\` now ships as prerelease automatically:
- \`prerelease: \${{ contains(github.ref_name, '-rc') }}\` on the gh release step
- New "Compute image tags" step splits container tags by event type:
  - `dispatch-<run_id>` for any workflow_dispatch
  - `vX.Y.Z` only for RC tags (no :latest advance)
  - `vX.Y.Z` + `:latest` for stable tags
- Tag filter (\`tags: ['v*.*.*']\`) unchanged — GitHub's \`*\` glob already matches both stable and RC names; semantic split moved downstream.

Decision recorded in CLAUDE.md: dispatch dry-run remains the cheap pre-tag validation; RC tags are for testing the full gh release codepath E2E or shipping candidates without bumping \`:latest\`.

### Item 6 — CLAUDE.md self-review section update

Mechanical-pass description in CLAUDE.md was stale (didn't mention Dockerfile / actionlint / release.yml dry-run / RELEASE_NOTES rows the skill gained in [#96](https://github.com/dong-qiu/agent-lens/pull/96)). Updated.

### Item 7 — `/review` mandatory for risk-asymmetric files

New section in CLAUDE.md codifying project policy: PRs touching `release.yml`, `Dockerfile*`, `internal/attest/*`, or `internal/hashchain/*` MUST have `/review` invoked before merge. The `/self-review` skill (Phase 3) escalates these automatically; this is the human-readable side of the same rule.

## Test plan

- [ ] CI green
- [ ] Run \`gh workflow run release.yml --ref chore/v0.1.1-issue-93-process-items -f dry_run=true\` to validate the new "Compute image tags" step against the workflow_dispatch arm — REQUIRED per the skill's new rule (this PR is touching release.yml)
- [ ] After merge: cut a `v0.1.2-rc1` test tag (no source change required) to E2E-validate RC handling. Verify on the gh release page that it's marked "Pre-release" and ghcr `:latest` did NOT advance to it. Delete the test release after.

## Out of scope

- Item 3: ADR 0009 container platforms (v0.2)
- Item 4: native arm64 runner OR split web-build (v0.2)

## /review

Per the new policy this PR introduces, **this PR itself qualifies for `/review`** (touches release.yml). Self-review per the new skill rules first; user can invoke `/review` before merge.