### PR TITLE
docs(claude): note gh pr merge --delete-branch footgun in worktree layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,12 @@ releasable — there is no long-lived `develop` branch.
   refactor branch; it would conflict with every other in-flight stream.
 - After a squash-merge, delete the local branch with `git branch -D` (`-d`
   refuses because squash leaves the branch looking unmerged).
+- Merge with `gh pr merge <n> --squash` — **without** `--delete-branch`. In
+  this layout gh's post-merge local cleanup tries to check out / delete the
+  branch and aborts with a misleading `fatal: 'main' is already used by
+  worktree …`; the remote merge has *already* succeeded, so do not re-run or
+  assume failure. Then fast-forward `main/` (`git -C main pull --ff-only`) and
+  remove the branch + worktree yourself (`wt-rm <branch>`).
 
 ## Self-review before merge
 


### PR DESCRIPTION
## Summary

Adds one bullet to CLAUDE.md "Repository layout & branching" recording a merge-workflow footgun specific to the bare-repo + worktree layout.

## Why

Hit while merging #103: `gh pr merge <n> --squash --delete-branch` aborts its **post-merge local cleanup** with

```
fatal: 'main' is already used by worktree at '…/main'
```

because `main` is pinned to the `main/` worktree, so gh can't check out / delete the branch locally. The **remote merge has already succeeded** — but the non-zero exit + `fatal:` makes it look like the merge failed, inviting a needless re-run or rollback.

The new bullet documents the safe form: plain `gh pr merge <n> --squash`, then fast-forward `main/` and clean up with `wt-rm <branch>`.

## Context

Follows the bare+worktree layout audit this session. The on-disk `worktrees/*` fixed-slot drift (which contradicted the documented per-task `wt-new` model) was removed separately; the doc already described the per-task model correctly, so this PR only adds the missing merge-workflow lesson.

## Scope

- One bullet, CLAUDE.md only. No code, no version-relevant change.
- First PR through the cleaned-up per-task worktree flow (branch `docs/worktree-merge-note` at container root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)