### PR TITLE
fix(server): answer HEAD /healthz with 200 (#99)

### DIFF
--- a/cmd/agent-lens/main.go
+++ b/cmd/agent-lens/main.go
@@ -25,6 +25,19 @@ import (
 	githubwh "github.com/dong-qiu/agent-lens/internal/webhooks/github"
 )
 
+// registerHealthz wires the liveness probe for both GET and HEAD. HEAD
+// support matters for uptime checkers / load balancers that probe with
+// HEAD (issue #99): chi's r.Get matches GET only, so HEAD fell through to
+// the catch-all UI handler and 404'd. The handler only sets the status —
+// net/http suppresses the body for HEAD responses automatically.
+func registerHealthz(r chi.Router) {
+	h := func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}
+	r.Get("/healthz", h)
+	r.Head("/healthz", h)
+}
+
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
 	slog.SetDefault(logger)
@@ -79,9 +92,7 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(30 * time.Second))
 
-	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+	registerHealthz(r)
 
 	token := os.Getenv("AGENT_LENS_TOKEN")
 	if token == "" {

--- a/cmd/agent-lens/main_test.go
+++ b/cmd/agent-lens/main_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// TestRegisterHealthz guards issue #99: /healthz must answer 200 to both
+// GET and HEAD. Before the fix, only GET was registered, so HEAD probes
+// (uptime checkers, load balancers) fell through to the catch-all and 404'd.
+func TestRegisterHealthz(t *testing.T) {
+	r := chi.NewRouter()
+	registerHealthz(r)
+
+	for _, method := range []string{http.MethodGet, http.MethodHead} {
+		t.Run(method, func(t *testing.T) {
+			rec := httptest.NewRecorder()
+			r.ServeHTTP(rec, httptest.NewRequest(method, "/healthz", nil))
+			if rec.Code != http.StatusOK {
+				t.Errorf("%s /healthz = %d, want %d", method, rec.Code, http.StatusOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #99 — `/healthz` returned **404 on HEAD** but 200 on GET.

`chi`'s `r.Get("/healthz", …)` matches GET only, so HEAD probes fell through to the catch-all UI handler (`r.Mount("/", …)`) and 404'd. Uptime checkers and load balancers commonly probe with HEAD.

## Change

- Extract the probe into `registerHealthz(r chi.Router)` and register it for **both GET and HEAD**. The handler only sets the status — `net/http` suppresses the body for HEAD responses automatically, so the same handler is correct for both.
- Add `cmd/agent-lens/main_test.go` → `TestRegisterHealthz` asserts 200 for GET **and** HEAD against the exact `registerHealthz` that `main()` calls (real regression coverage, not a re-implemented router).

## Test

```
go test ./cmd/agent-lens/... -run TestRegisterHealthz -v   # GET + HEAD both 200 ✓
go vet ./...                                                # ✓
go build ./...                                              # ✓
```

(Full suite incl. PG integration tests deferred to CI — change is isolated to one route + a new test.)

## Note on /review

Path touches `cmd/agent-lens/main.go`, which the `/self-review` skill flags for a `/review` recommendation (CLI-surface). This change is a trivial internal route fix, **not** a CLI-surface change, and touches none of the mandatory-`/review` paths (release.yml / Dockerfile / attest / hashchain). Flagging for your call; I'd say self-review suffices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)