### PR TITLE
ci+release: migrate all GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go: ['1.23', '1.26']
+        go: ['1.25', '1.26']
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache: true
       - uses: golangci/golangci-lint-action@v9
         with:
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache: true
       # Linux runners ship with native Docker, no Colima quirks. Reaper
       # works here, so leave RYUK enabled (the Makefile target disables
@@ -63,7 +63,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.25'
           cache: true
       - uses: bufbuild/buf-action@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       matrix:
         go: ['1.23', '1.26']
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go }}
           cache: true
@@ -31,12 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.23'
           cache: true
-      - uses: golangci/golangci-lint-action@v7
+      - uses: golangci/golangci-lint-action@v9
         with:
           version: latest
 
@@ -45,8 +45,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.23'
           cache: true
@@ -60,8 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.23'
           cache: true
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: bash actions/build/smoke_test.sh
 
   web:
@@ -97,11 +97,11 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: pnpm
@@ -120,10 +120,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
+      - uses: actions/checkout@v5
+      - uses: docker/setup-buildx-action@v4
       - name: Build (no push)
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: deploy/compose/Dockerfile.server

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,18 +59,18 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v5
+      - uses: pnpm/action-setup@v5
         with:
           version: 10
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '24'
           cache: pnpm
           cache-dependency-path: web/pnpm-lock.yaml
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: web-dist
           path: web/dist
@@ -89,15 +89,15 @@ jobs:
           - { goos: linux,  goarch: amd64 }
           - { goos: linux,  goarch: arm64 }
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version: '1.25'
           cache: true
 
       - name: Download web bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: web-dist
           path: internal/webui/dist
@@ -173,7 +173,7 @@ jobs:
           ls -la dist/
 
       - name: Upload binaries + signatures
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: binaries-${{ matrix.goos }}-${{ matrix.goarch }}
           path: dist/
@@ -186,11 +186,11 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -224,7 +224,7 @@ jobs:
           echo "$TAGS"
 
       - name: Build + push image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: deploy/compose/Dockerfile.server
@@ -261,10 +261,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: artifacts/
           # `binaries-darwin-amd64` etc. are separate dirs by default;
@@ -311,7 +311,7 @@ jobs:
           cat artifacts/agent-lens-public.pem
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}


### PR DESCRIPTION
Closes #105.

GitHub forces JS actions onto the **Node.js 24 runtime by default starting 2026-06-02** (Node 20 removed from runners 2026-09-16). This bumps every pinned action to the first major that declares `runs.using: node24`. Each target was verified by reading the repo's `action.yml` at that tag via `gh api` (not release-notes prose).

## Version map

| Action | From | To | Notes |
|---|---|---|---|
| `actions/checkout` | v4 | **v5** | |
| `actions/setup-go` | v5 | **v6** | |
| `actions/setup-node` | v4 | **v5** | |
| `actions/upload-artifact` | v4 | **v6** | v5 still node20 |
| `actions/download-artifact` | v4 | **v7** | v5/v6 still node20 |
| `pnpm/action-setup` | v4 | **v5** | |
| `golangci/golangci-lint-action` | v7 | **v9** | v8 still node20 |
| `softprops/action-gh-release` | v2 | **v3** | |
| `docker/setup-buildx-action` | v3 | **v4** | ⚠️ not in #105 inventory |
| `docker/build-push-action` | v5 | **v7** | v6 still node20; ⚠️ not in #105 inventory |
| `docker/login-action` | v3 | **v4** | ⚠️ not in #105 inventory |
| `bufbuild/buf-action` | v1 | v1 | already node24, unchanged |

## Notes / decisions

- **#105's inventory omitted the three `docker/*` JS actions.** They are node20 too and would also break under the forced switch, so they're included here. (Flagging the inventory gap rather than silently scoping it out.)
- **`golangci-lint-action` v7→v9 crosses no config break:** `.golangci.yml` is already `version: "2"` (golangci-lint v2), which the v7 action already required. v8 was skipped only because it never moved off node20; v9 is the first node24 line.
- **Minimal node24-declaring major per action** to keep the behavioral delta small — this is why `upload-artifact` (v6) and `download-artifact` (v7) land on different majors (each is its own node24 floor). Their interop is exercised end-to-end by the release dry-run below.

## Validation

- `actionlint` clean on both files (the one SC2193 warning at `release.yml:208` is **pre-existing** on `main` — a known false-positive for `${{ }}` expressions in shell comparisons, untouched by this PR).
- CI on this PR re-runs golangci-lint@v9 against the repo, so a v9 incompatibility would fail here.
- Release-pipeline change → `release.yml` dry-run dispatch + `/review` per repo policy (see PR checks / review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-on fix in this PR: go-version matrix alignment (commit 2)

Bumping `setup-go` v5→v6 surfaced a latent CI lie. **v6 sets `GOTOOLCHAIN=local` by default** (v5 left it `auto`), so the `go: '1.23'` matrix legs now fail fast:

```
go: go.mod requires go >= 1.25.0 (running go 1.23.12; GOTOOLCHAIN=local)
```

Under v5, those legs silently auto-downloaded and ran the **1.25.0** toolchain — so `'1.23'` never actually tested Go 1.23. `go.mod`'s real floor is `go 1.25.0`. This PR aligns every pin (matrix + `go-lint` + `integration` + `codegen-drift`) to `'1.25'`, making CI honest and v6-compatible. The `1.26` leg already passes (≥ floor, no switch needed).

This is in-scope: it's a required consequence of the node24 `setup-go` bump — the migration can't be green without it.
