### PR TITLE
feat(capture): mark skill invocations with a payload.skill discriminator

### DIFF
--- a/cmd/agent-lens-hook/claude.go
+++ b/cmd/agent-lens-hook/claude.go
@@ -136,7 +136,40 @@ func makeToolCall(in *claudeHookInput) map[string]any {
 		}
 	}
 	payload["authorization"] = auth
+	if skill := skillInvocation(in.ToolName, in.ToolInput); skill != nil {
+		payload["skill"] = skill
+	}
 	return baseEvent(in, agentActor(), "tool_call", payload)
+}
+
+// skillInvocation extracts a normalized skill discriminator from a Skill
+// tool_call's input. Returns nil for non-Skill tools or unparseable input
+// (fail-soft: a missing discriminator just leaves a plain tool_call). This is
+// gap 1 of issue #101 — a queryable marker that "a skill ran" and which one,
+// without downstream having to special-case the Skill tool's input shape.
+//
+// Deliberately neutral: it records name+args only, not whether the skill was
+// human-typed (/cmd) vs model-invoked — the hook can't tell them apart, and
+// the "human-initiated workflow" semantics are the open design question #101
+// leaves for a possible human_intervention sub_kind (ADR 0004). The injected
+// instruction *body* (gap 2) isn't reachable here — the PostToolUse response
+// carries only {success, commandName}; tracked in #110.
+func skillInvocation(toolName string, toolInput json.RawMessage) map[string]any {
+	if toolName != "Skill" {
+		return nil
+	}
+	var s struct {
+		Skill string `json:"skill"`
+		Args  string `json:"args"`
+	}
+	if err := json.Unmarshal(toolInput, &s); err != nil || s.Skill == "" {
+		return nil
+	}
+	out := map[string]any{"name": s.Skill}
+	if s.Args != "" {
+		out["args"] = s.Args
+	}
+	return out
 }
 
 // detectRiskSignalsOrEmpty wraps detectRiskSignals so the authorization

--- a/cmd/agent-lens-hook/claude_test.go
+++ b/cmd/agent-lens-hook/claude_test.go
@@ -70,6 +70,75 @@ func TestBuildEventsPreToolUse(t *testing.T) {
 	}
 }
 
+func TestBuildEventsSkillInvocation(t *testing.T) {
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "PreToolUse",
+		SessionID:     "s1",
+		ToolName:      "Skill",
+		ToolInput:     json.RawMessage(`{"skill":"review","args":"100"}`),
+	})
+	if len(evs) != 1 || evs[0]["kind"] != "tool_call" {
+		t.Fatalf("got %+v, want one tool_call event", evs)
+	}
+	payload, ok := evs[0]["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload not a map: %T", evs[0]["payload"])
+	}
+	skill, ok := payload["skill"].(map[string]any)
+	if !ok {
+		t.Fatalf("payload.skill missing or not a map: %+v", payload)
+	}
+	if skill["name"] != "review" {
+		t.Errorf("skill.name = %v, want review", skill["name"])
+	}
+	if skill["args"] != "100" {
+		t.Errorf("skill.args = %v, want 100", skill["args"])
+	}
+}
+
+func TestSkillDiscriminatorOnlyForSkillTool(t *testing.T) {
+	// A non-Skill tool must never get a skill discriminator, even if its
+	// input happens to contain a "skill" key.
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "PreToolUse",
+		SessionID:     "s1",
+		ToolName:      "Edit",
+		ToolInput:     json.RawMessage(`{"skill":"sneaky"}`),
+	})
+	payload := evs[0]["payload"].(map[string]any)
+	if _, present := payload["skill"]; present {
+		t.Errorf("non-Skill tool got a skill discriminator: %+v", payload)
+	}
+}
+
+func TestSkillInvocationArgless(t *testing.T) {
+	got := skillInvocation("Skill", json.RawMessage(`{"skill":"self-review"}`))
+	if got == nil || got["name"] != "self-review" {
+		t.Fatalf("got %+v, want name=self-review", got)
+	}
+	if _, hasArgs := got["args"]; hasArgs {
+		t.Errorf("args present for an argless skill: %+v", got)
+	}
+}
+
+func TestSkillInvocationFailSoft(t *testing.T) {
+	cases := []struct {
+		name, tool, input string
+	}{
+		{"non-skill tool", "Bash", `{"skill":"x"}`},
+		{"empty skill name", "Skill", `{"args":"100"}`},
+		{"unparseable input", "Skill", `not json`},
+		{"empty input", "Skill", ``},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := skillInvocation(tc.tool, json.RawMessage(tc.input)); got != nil {
+				t.Errorf("skillInvocation(%q, %q) = %+v, want nil", tc.tool, tc.input, got)
+			}
+		})
+	}
+}
+
 func TestBuildEventsPostToolUse(t *testing.T) {
 	evs, _ := buildEvents(&claudeHookInput{
 		HookEventName: "PostToolUse",

--- a/web/src/components/CausalGraph.tsx
+++ b/web/src/components/CausalGraph.tsx
@@ -132,8 +132,13 @@ function nodeSummary(event: Event): string {
   const clip = (s: string, n: number) => (s.length > n ? s.slice(0, n) + "…" : s);
   switch (event.kind) {
     case "TOOL_CALL":
-    case "TOOL_RESULT":
+    case "TOOL_RESULT": {
+      const skill = p.skill as Record<string, unknown> | undefined;
+      if (skill && typeof skill.name === "string") {
+        return clip(`skill: ${skill.name}`, 24);
+      }
       return asStr(p.name);
+    }
     case "PROMPT":
     case "THOUGHT":
       return clip(asStr(p.text).replace(/\s+/g, " ").trim(), 24);

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -57,6 +57,18 @@ export function EventCard({ event }: { event: Event }) {
               </span>
             )}
             {(() => {
+              const skill = skillInfo(event);
+              return skill ? (
+                <span
+                  className="inline-flex items-center gap-0.5 rounded bg-violet-100 px-1.5 py-0.5 text-[10px] font-medium text-violet-900 ring-1 ring-violet-300"
+                  title={`Skill invocation: ${skill.name}${skill.args ? ` ${skill.args}` : ""}`}
+                >
+                  <span>⌘</span>
+                  <span>skill</span>
+                </span>
+              ) : null;
+            })()}
+            {(() => {
               const badge = authorizationBadge(event);
               return badge ? (
                 <span
@@ -178,6 +190,17 @@ export function EventCard({ event }: { event: Event }) {
   );
 }
 
+// skillInfo extracts the issue #101 skill discriminator from a TOOL_CALL.
+// Returns null for any other event, so the violet "skill" chip renders only
+// on actual skill invocations.
+function skillInfo(event: Event): { name: string; args: string } | null {
+  if (event.kind !== "TOOL_CALL") return null;
+  const p = (event.payload ?? {}) as Record<string, unknown>;
+  const skill = p.skill as Record<string, unknown> | undefined;
+  if (!skill || typeof skill.name !== "string") return null;
+  return { name: skill.name, args: typeof skill.args === "string" ? skill.args : "" };
+}
+
 function summarize(event: Event): string {
   const p = (event.payload ?? {}) as Record<string, unknown>;
   switch (event.kind) {
@@ -185,8 +208,14 @@ function summarize(event: Event): string {
     case "THOUGHT":
       return clip(asString(p.text));
     case "TOOL_CALL":
-    case "TOOL_RESULT":
+    case "TOOL_RESULT": {
+      const skill = p.skill as Record<string, unknown> | undefined;
+      if (skill && typeof skill.name === "string") {
+        const args = asString(skill.args);
+        return args ? `${skill.name} · ${clip(args)}` : skill.name;
+      }
       return asString(p.name);
+    }
     case "COMMIT": {
       const sha = asString(p.sha).slice(0, 7);
       const subject = asString(p.subject);


### PR DESCRIPTION
Addresses **gap 1 of #101**. (Gap 2 — capturing the skill's injected instruction body — is split into #110.)

## Problem
A skill / slash-command (`/review 100`) was captured only as a generic `tool_call` with `payload.name="Skill"` and `payload.input={"skill":"review","args":"100"}` — indistinguishable from any other tool call. No queryable marker that *a skill ran*, or which one.

## Change
**Hook** (`makeToolCall`): when the tool is `Skill`, add a normalized discriminator
```json
"skill": { "name": "review", "args": "100" }
```
to the `tool_call` payload. Fail-soft — unparseable/empty input leaves a plain `tool_call`. **No proto change, no new EventKind** (payload is a `Struct`), so **no ADR required**.

Deliberately **neutral**: `name`+`args` only. It does *not* claim human-typed (`/cmd`) vs model-invoked — the hook can't distinguish them, and that "human-initiated workflow" semantics is the open design question #101 raises (a possible `human_intervention` sub_kind, ADR 0004 — which isn't implemented in proto yet). Choosing the discriminator now is forward-compatible: a linker could later *derive* a `human_intervention.skill_invocation` from the marked `tool_call`, exactly as ADR 0004 D8 derives `review_decision` from `review`.

**Lens UI**: `EventCard` renders a violet `⌘ skill` chip + summarizes the skill `name · args`; `CausalGraph` node caption shows `skill: <name>` instead of generic `Skill`. GraphQL unchanged (payload already flows as JSON).

## Why split gap 2 (#110)
The injected instruction body isn't in the `PostToolUse` response (`{success, commandName}` only); it arrives as a `user`-role transcript entry that `reader.go` skips. Capturing it expands the fail-soft transcript model and overlaps with ADR 0003's static `SKILL.md` snapshot — it deserves its own design decision, tracked in #110.

## Tests
`TestBuildEventsSkillInvocation`, `TestSkillDiscriminatorOnlyForSkillTool`, `TestSkillInvocationArgless`, `TestSkillInvocationFailSoft` (4 sub-cases). `go test -race ./...` + `go vet` + web `tsc --noEmit` + `pnpm build` all green.

## Manual smoke needed (self-review can't cover UI rendering)
- The violet `⌘ skill` chip on a `Skill` `tool_call` card (color/contrast/placement among existing chips).
- `EventCard` summary line shows `review · 100`.
- Graph node tile shows `skill: review` and fits the 180-px tile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)