### PR TITLE
feat(hook): capture SubagentStart/SubagentStop lifecycle (#85 PR1)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -174,7 +174,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 ### 10.1 Claude Code（首发）
 
 **事件捕获路径**：
-- **Hook 直采**（`SessionStart` / `UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `Stop`）：覆盖 prompt、工具调用与结果、会话/turn 边界。事件由 `agent-lens-hook claude` 子命令解析 stdin 并 POST 到 Ingest；Ingest 不可达时回落 `~/.agent-lens/sessions/<sid>.ndjson` 文件 sink，供日后 `agent-lens replay`。
+- **Hook 直采**（`SessionStart` / `UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `Stop` / `SubagentStart` / `SubagentStop`）：覆盖 prompt、工具调用与结果、会话/turn 边界、sub-agent 生命周期。事件由 `agent-lens-hook claude` 子命令解析 stdin 并 POST 到 Ingest；Ingest 不可达时回落 `~/.agent-lens/sessions/<sid>.ndjson` 文件 sink，供日后 `agent-lens replay`。
 - **Transcript 旁路**（`Stop` 触发时）：读取 hook payload 的 `transcript_path`，对自上次 cursor 起新增的 jsonl 行做增量解析，提取每个 assistant 消息的 `thinking` 与 `text` content block：
   - `thinking` block → `EVENT_KIND_THOUGHT`
   - `text` block → `EVENT_KIND_DECISION`，payload.marker = `assistant_message`
@@ -198,7 +198,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 - **Compaction 边界**：harness 自动 compaction 在 transcript 里是否显式标记**未经系统验证**，首版按 token-budget 启发式推断，生成 `context_transform.compaction` 事件并置 `loss_hint.confidence = "inferred"`。验证通过则 confidence 升到 `observed`；Truncation 与 system reminder 注入在 transcript 中可见，直接观测。详见 ADR 0005 D5。
 - **手工编辑归因**：agent 改完代码 → 人手在 IDE 微调 → commit 这条混合贡献路径，在 §10.1 路径不可还原。`HumanIntervention.manual_edit` 与 `code_change.contributor_mix` 字段位预留，等 IDE 插件层（M4+）。详见 ADR 0004 D4。
 - 仍**没有**的能力：实时拦截 / token 流式即时反馈 / policy gate。要这些得走 §10.4。
-- **Sub-agent 派发**（Agent 工具）：父侧 tool_call/result 完整捕获（含 `response.agentId` 等元数据，UI 显式 surface）。子 session 在 user-global hook 装好（`agent-lens-hook setup --personal`）的前提下以独立 UUID session 捕获；父→子的自动 `delegates` link 留 v0.2，详见 ADR 0008 与追踪 issue #85。Audit reader 在 v0.1 通过 timestamp + prompt 文本人眼对应。
+- **Sub-agent 派发**（Agent 工具）：父侧 tool_call/result 完整捕获（含 `response.agentId` 等元数据，UI 显式 surface）。子 session 在 user-global hook 装好（`agent-lens-hook setup --personal`）的前提下以独立 UUID session 捕获；`SubagentStart` / `SubagentStop` 生命周期事件以 `decision` marker 捕获，子侧带 `agent_id`，构成父→子桥接的子侧一半（预期与父侧 `tool_result.response.agentId` 配对——待 v0.2 实证）。自动 emit `delegates` link（含 `RELATION_DELEGATES` schema）仍留 v0.2，详见 ADR 0008 与追踪 issue #85。在此之前 audit reader 通过 timestamp + prompt 文本人眼对应。
 
 ### 10.4 代理深模式（M4+，未启用）
 

--- a/cmd/agent-lens-hook/claude.go
+++ b/cmd/agent-lens-hook/claude.go
@@ -34,6 +34,11 @@ type claudeHookInput struct {
 	ToolName       string          `json:"tool_name,omitempty"`
 	ToolInput      json.RawMessage `json:"tool_input,omitempty"`
 	ToolResponse   json.RawMessage `json:"tool_response,omitempty"`
+	// SubagentStart / SubagentStop carry the sub-agent's identity. agent_id
+	// is the child-side key that matches the parent's Agent tool_result
+	// response.agentId (issue #85).
+	AgentID   string `json:"agent_id,omitempty"`
+	AgentType string `json:"agent_type,omitempty"`
 }
 
 // runClaude reads a Claude Code hook payload on stdin and forwards a wire
@@ -90,8 +95,38 @@ func buildEvents(in *claudeHookInput) (events []map[string]any, commit func() er
 		return []map[string]any{makeSessionStart(in)}, nil
 	case "Stop":
 		return makeStopEvents(in)
+	case "SubagentStart":
+		return []map[string]any{makeSubagentLifecycle(in, "subagent_start")}, nil
+	case "SubagentStop":
+		return []map[string]any{makeSubagentLifecycle(in, "subagent_stop")}, nil
 	}
 	return nil, nil
+}
+
+// makeSubagentLifecycle captures a Claude Code SubagentStart / SubagentStop
+// hook as a decision-marker event, mirroring makeSessionStart's shape. The
+// hook fires in the *sub-agent's own* session, so in.SessionID is the child
+// session id and payload.agent_id is the child's agent id.
+//
+// That (session_id, agent_id) pair is the child-side half of the parent→child
+// bridge: the parent's Agent tool_result carries the same agent_id under
+// response.agentId, so a linker can match the two and emit a `delegates` link
+// from parent to child. Capturing the lifecycle is ADR-free (payload-only);
+// the delegates link + RELATION_DELEGATES schema change is the ADR-gated
+// follow-up (issue #85, PR 2). Until then this already ends our blindness to
+// sub-agent start/stop in the timeline.
+func makeSubagentLifecycle(in *claudeHookInput, marker string) map[string]any {
+	payload := map[string]any{
+		"marker": marker,
+		"cwd":    in.CWD,
+	}
+	if in.AgentID != "" {
+		payload["agent_id"] = in.AgentID
+	}
+	if in.AgentType != "" {
+		payload["agent_type"] = in.AgentType
+	}
+	return baseEvent(in, map[string]any{"type": "system", "id": "claude-code"}, "decision", payload)
 }
 
 func makePrompt(in *claudeHookInput) map[string]any {

--- a/cmd/agent-lens-hook/claude_test.go
+++ b/cmd/agent-lens-hook/claude_test.go
@@ -151,6 +151,78 @@ func TestBuildEventsPostToolUse(t *testing.T) {
 	}
 }
 
+func TestBuildEventsSubagentStart(t *testing.T) {
+	evs, commit := buildEvents(&claudeHookInput{
+		HookEventName: "SubagentStart",
+		SessionID:     "child-uuid",
+		CWD:           "/repo",
+		AgentID:       "a06a387fa5403439d",
+		AgentType:     "Explore",
+	})
+	if commit != nil {
+		t.Errorf("SubagentStart should not return a commit fn")
+	}
+	if len(evs) != 1 || evs[0]["kind"] != "decision" {
+		t.Fatalf("got %+v, want one decision event", evs)
+	}
+	ev := evs[0]
+	// Attributed to the *child* session — the side that carries
+	// (session_id, agent_id) for the #85 parent→child bridge.
+	if ev["session_id"] != "child-uuid" {
+		t.Errorf("session_id = %v, want child-uuid", ev["session_id"])
+	}
+	if actor := ev["actor"].(map[string]any); actor["type"] != "system" {
+		t.Errorf("actor.type = %v, want system", actor["type"])
+	}
+	p := ev["payload"].(map[string]any)
+	if p["marker"] != "subagent_start" {
+		t.Errorf("marker = %v, want subagent_start", p["marker"])
+	}
+	if p["agent_id"] != "a06a387fa5403439d" {
+		t.Errorf("agent_id = %v, want a06a387fa5403439d", p["agent_id"])
+	}
+	if p["agent_type"] != "Explore" {
+		t.Errorf("agent_type = %v, want Explore", p["agent_type"])
+	}
+}
+
+func TestBuildEventsSubagentStop(t *testing.T) {
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "SubagentStop",
+		SessionID:     "child-uuid",
+		AgentID:       "a06a387fa5403439d",
+	})
+	if len(evs) != 1 || evs[0]["kind"] != "decision" {
+		t.Fatalf("got %+v, want one decision event", evs)
+	}
+	p := evs[0]["payload"].(map[string]any)
+	if p["marker"] != "subagent_stop" {
+		t.Errorf("marker = %v, want subagent_stop", p["marker"])
+	}
+	if p["agent_id"] != "a06a387fa5403439d" {
+		t.Errorf("agent_id = %v, want a06a387fa5403439d", p["agent_id"])
+	}
+}
+
+func TestBuildEventsSubagentStartOmitsEmptyIDs(t *testing.T) {
+	// The lifecycle marker still emits without agent_id/agent_type (it has
+	// timeline value); the optional keys are simply omitted, not null.
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "SubagentStart",
+		SessionID:     "child-uuid",
+	})
+	p := evs[0]["payload"].(map[string]any)
+	if p["marker"] != "subagent_start" {
+		t.Errorf("marker = %v, want subagent_start", p["marker"])
+	}
+	if _, ok := p["agent_id"]; ok {
+		t.Errorf("agent_id present despite empty input: %+v", p)
+	}
+	if _, ok := p["agent_type"]; ok {
+		t.Errorf("agent_type present despite empty input: %+v", p)
+	}
+}
+
 func TestBuildEventsUnknown(t *testing.T) {
 	evs, _ := buildEvents(&claudeHookInput{HookEventName: "Mystery", SessionID: "s1"})
 	if len(evs) != 0 {

--- a/cmd/agent-lens-hook/setup.go
+++ b/cmd/agent-lens-hook/setup.go
@@ -66,6 +66,11 @@ var setupHookEvents = []string{
 	"PreToolUse",
 	"PostToolUse",
 	"Stop",
+	// Sub-agent (Task tool) lifecycle. SubagentStart fires in the child
+	// session and carries agent_id — the child-side half of the parent→child
+	// bridge the linker needs for the `delegates` link (issue #85).
+	"SubagentStart",
+	"SubagentStop",
 }
 
 func runSetup(args []string) {


### PR DESCRIPTION
**PR 1 of 2 for #85.** This ships the ADR-free capture; the `delegates` link (schema + ADR) is PR 2.

## Background
ADR 0008 deferred parent→child sub-agent linking because there was no capturable mapping between the parent's Agent `tool_result.response.agentId` and the child's hook `session_id`. **That changed:** Claude Code added a **`SubagentStart`** hook (post-dating ADR 0008's empirical work) that fires in the *child* session and carries `agent_id` + `agent_type` alongside the child `session_id`.

## Change
Register `SubagentStart` / `SubagentStop` (`setup.go`) and emit them as `decision`-marker events (same shape as `SessionStart`):
```
kind=decision, actor=system/claude-code, session_id=<child>
payload = { marker: "subagent_start"|"subagent_stop", cwd, agent_id?, agent_type? }
```
Fail-soft: empty ids are omitted; if Claude Code doesn't emit these events the `buildEvents` switch never fires (no dead weight, no error).

## Why it matters for #85
The `(child session_id, agent_id)` pair captured here is the **child-side half** of the parent→child bridge. The parent's Agent `tool_result` already carries `response.agentId`. **If** that equals the child's `agent_id`, a linker can match them and emit a `delegates` link.

This PR deliberately does **NOT** add that link:
- `RELATION_DELEGATES` is a proto/schema change → needs an ADR (per repo convention + ADR 0008 "后续工作" #2).
- The `agentId` ↔ `agent_id` equality is **still unverified**.

Both are **PR 2** (ADR-gated). This PR ships the capture and **generates the dogfood data PR 2 needs to verify the match**.

## Honesty / scope
- The `SubagentStart` hook existence + payload field names (`agent_id`, `agent_type`) are per **current Claude Code docs** (researched via the claude-code-guide agent), **not yet dogfood-verified**. The capture is fail-soft so a docs/reality mismatch degrades gracefully (we'd still get the marker + cwd). PR 2's §验证 confirms empirically (and whether `agentId == agent_id`).
- Parent side already fully captured (verified in dogfood sinks: `response.agentId` present, e.g. 16-char hex `a06a387fa5403439d`).

## SPEC
§10.1 hook list now includes `SubagentStart`/`SubagentStop`; the sub-agent dispatch note records the lifecycle capture and keeps the `delegates` link explicitly deferred to v0.2 (agent_id pairing marked "待 v0.2 实证").

## Tests
`TestBuildEventsSubagentStart` / `SubagentStop` / `SubagentStartOmitsEmptyIDs`. `setup_test.go` iterates `setupHookEvents`, so it now also asserts the two new events register with one matcher each. `go test -race ./...` + `go vet` green; no ADR (decision-marker pattern extension, payload-only, no proto change).

## Not covered (→ PR 2 / dogfood)
Real confirmation that `SubagentStart` fires with the expected payload, and that `parent.tool_result.agentId == child.SubagentStart.agent_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)