### PR TITLE
feat(server): /healthz pings the store instead of always 200 (#10)

### DIFF
--- a/cmd/agent-lens/main.go
+++ b/cmd/agent-lens/main.go
@@ -25,13 +25,32 @@ import (
 	githubwh "github.com/dong-qiu/agent-lens/internal/webhooks/github"
 )
 
-// registerHealthz wires the liveness probe for both GET and HEAD. HEAD
-// support matters for uptime checkers / load balancers that probe with
-// HEAD (issue #99): chi's r.Get matches GET only, so HEAD fell through to
-// the catch-all UI handler and 404'd. The handler only sets the status —
-// net/http suppresses the body for HEAD responses automatically.
-func registerHealthz(r chi.Router) {
-	h := func(w http.ResponseWriter, _ *http.Request) {
+// healthChecker is the slice of store.Store the probe needs: a cheap
+// reachability check on the backing dependency.
+type healthChecker interface {
+	Ping(ctx context.Context) error
+}
+
+// registerHealthz wires the health probe for both GET and HEAD. HEAD support
+// matters for uptime checkers / load balancers that probe with HEAD (issue
+// #99): chi's r.Get matches GET only, so HEAD fell through to the catch-all
+// UI handler and 404'd. net/http suppresses the body for HEAD automatically.
+//
+// The probe pings the store (issue #10) so a dead dependency returns 503
+// instead of a misleading unconditional 200. A short timeout keeps a hung DB
+// from stalling the probe. NB: this couples /healthz to the store, so it
+// behaves as a *readiness* check; when the k8s HA deployment (SPEC §13) needs
+// a DB-independent liveness probe, split them — restarting on a DB outage
+// won't fix the DB.
+func registerHealthz(r chi.Router, hc healthChecker) {
+	h := func(w http.ResponseWriter, req *http.Request) {
+		ctx, cancel := context.WithTimeout(req.Context(), 2*time.Second)
+		defer cancel()
+		if err := hc.Ping(ctx); err != nil {
+			slog.Warn("healthz: store unreachable", "err", err)
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
 		w.WriteHeader(http.StatusOK)
 	}
 	r.Get("/healthz", h)
@@ -92,7 +111,7 @@ func main() {
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.Timeout(30 * time.Second))
 
-	registerHealthz(r)
+	registerHealthz(r, st)
 
 	token := os.Getenv("AGENT_LENS_TOKEN")
 	if token == "" {

--- a/cmd/agent-lens/main_test.go
+++ b/cmd/agent-lens/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -8,19 +10,33 @@ import (
 	"github.com/go-chi/chi/v5"
 )
 
-// TestRegisterHealthz guards issue #99: /healthz must answer 200 to both
-// GET and HEAD. Before the fix, only GET was registered, so HEAD probes
-// (uptime checkers, load balancers) fell through to the catch-all and 404'd.
-func TestRegisterHealthz(t *testing.T) {
-	r := chi.NewRouter()
-	registerHealthz(r)
+type fakeHealth struct{ err error }
 
-	for _, method := range []string{http.MethodGet, http.MethodHead} {
-		t.Run(method, func(t *testing.T) {
-			rec := httptest.NewRecorder()
-			r.ServeHTTP(rec, httptest.NewRequest(method, "/healthz", nil))
-			if rec.Code != http.StatusOK {
-				t.Errorf("%s /healthz = %d, want %d", method, rec.Code, http.StatusOK)
+func (f fakeHealth) Ping(context.Context) error { return f.err }
+
+// TestRegisterHealthz guards issue #99 (both GET and HEAD are answered — HEAD
+// probes used to fall through to the catch-all and 404) and issue #10 (the
+// probe reflects store reachability: 200 when the store pings, 503 when it
+// fails, instead of a misleading unconditional 200).
+func TestRegisterHealthz(t *testing.T) {
+	cases := []struct {
+		name string
+		hc   healthChecker
+		want int
+	}{
+		{"healthy", fakeHealth{nil}, http.StatusOK},
+		{"store down", fakeHealth{errors.New("dial tcp: connection refused")}, http.StatusServiceUnavailable},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := chi.NewRouter()
+			registerHealthz(r, tc.hc)
+			for _, method := range []string{http.MethodGet, http.MethodHead} {
+				rec := httptest.NewRecorder()
+				r.ServeHTTP(rec, httptest.NewRequest(method, "/healthz", nil))
+				if rec.Code != tc.want {
+					t.Errorf("%s /healthz (%s) = %d, want %d", method, tc.name, rec.Code, tc.want)
+				}
 			}
 		})
 	}

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -23,6 +23,10 @@ func NewMemory() *Memory {
 	}
 }
 
+// Ping always succeeds: the in-memory store has no external dependency to
+// fail. Keeps /healthz honest for memory-mode dogfood runs.
+func (m *Memory) Ping(context.Context) error { return nil }
+
 func (m *Memory) Close() error { return nil }
 
 func (m *Memory) AppendEvent(_ context.Context, e *Event) error {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -29,6 +29,12 @@ func OpenPostgres(ctx context.Context, dsn string) (*Postgres, error) {
 	return &Postgres{pool: pool}, nil
 }
 
+// Ping round-trips the connection pool so /healthz reflects real DB
+// reachability rather than an unconditional 200 (issue #10).
+func (p *Postgres) Ping(ctx context.Context) error {
+	return p.pool.Ping(ctx)
+}
+
 func (p *Postgres) Close() error {
 	p.pool.Close()
 	return nil

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -85,5 +85,10 @@ type Store interface {
 	// neighbouring sessions without paging through all events first
 	// (the link-bearing event may sit past any per-session limit).
 	LinksForSession(ctx context.Context, sessionID string) ([]*Link, error)
+	// Ping checks the backing store is reachable (e.g. a DB round-trip),
+	// returning nil when healthy. The /healthz probe calls it so a dead
+	// dependency surfaces as 503 instead of a misleading unconditional 200
+	// (issue #10).
+	Ping(ctx context.Context) error
 	Close() error
 }


### PR DESCRIPTION
Closes #10.

## Problem
`/healthz` returned `200` unconditionally — an uptime checker / load balancer saw "healthy" even with Postgres down. For an ops probe that's worse than no check: it actively misleads.

## Change
- Add `Store.Ping(ctx) error` — `Memory`: always `nil` (no external dep); `Postgres`: `pool.Ping(ctx)`.
- `registerHealthz` pings the store under a **2s timeout**: `200` when reachable, **`503`** when not. `GET` + `HEAD` both preserved (issue #99).
- Handler depends on a narrow `healthChecker` interface, so the test uses a fake (no real DB): healthy→200, store-down→503, across both methods.

## Readiness vs liveness (documented in-code)
Pinging the store couples `/healthz` to a dependency, so it now behaves as a **readiness** check. That's correct for the single-node MVP (the server is useless without its DB). A comment flags that when the k8s HA deployment (SPEC §13) needs a DB-independent **liveness** probe, the two should be split — restarting a pod on a DB outage won't fix the DB. Not splitting now (no k8s HA yet); the note hands the decision to whoever adds it.

## Tests
`TestRegisterHealthz` now covers GET+HEAD × {healthy 200, store-down 503}. `go test -race ./...` + `go vet` green. The real-Postgres ping is a one-line delegation to `pgxpool.Pool.Ping` (exercised by the existing PG integration job at compile/run time); the handler's 503 path is unit-tested via the fake.

No proto/schema change (internal Go interface only) → no ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)