### PR TITLE
perf(query): batch Session.totalUsage, kill the SessionList N+1 (#65)

### DIFF
--- a/internal/query/generated.go
+++ b/internal/query/generated.go
@@ -31,7 +31,6 @@ type Config = graphql.Config[ResolverRoot, DirectiveRoot, ComplexityRoot]
 type ResolverRoot interface {
 	Event() EventResolver
 	Query() QueryResolver
-	Session() SessionResolver
 }
 
 type DirectiveRoot struct {
@@ -110,9 +109,6 @@ type QueryResolver interface {
 	SessionHead(ctx context.Context, sessionID string) (string, error)
 	Sessions(ctx context.Context, limit *int, since *time.Time) ([]*Session, error)
 	LinkedEvents(ctx context.Context, sessionID string, depth *int, perSessionLimit *int) ([]*Event, error)
-}
-type SessionResolver interface {
-	TotalUsage(ctx context.Context, obj *Session) (*TokenUsage, error)
 }
 
 type executableSchema graphql.ExecutableSchemaState[ResolverRoot, DirectiveRoot, ComplexityRoot]
@@ -1829,7 +1825,7 @@ func (ec *executionContext) _Session_totalUsage(ctx context.Context, field graph
 			return ec.fieldContext_Session_totalUsage(ctx, field)
 		},
 		func(ctx context.Context) (any, error) {
-			return ec.Resolvers.Session().TotalUsage(ctx, obj)
+			return obj.TotalUsage, nil
 		},
 		nil,
 		func(ctx context.Context, selections ast.SelectionSet, v *TokenUsage) graphql.Marshaler {
@@ -1843,8 +1839,8 @@ func (ec *executionContext) fieldContext_Session_totalUsage(_ context.Context, f
 	fc = &graphql.FieldContext{
 		Object:     "Session",
 		Field:      field,
-		IsMethod:   true,
-		IsResolver: true,
+		IsMethod:   false,
+		IsResolver: false,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			return ec.childFields_TokenUsage(ctx, field)
 		},
@@ -3607,56 +3603,25 @@ func (ec *executionContext) _Session(ctx context.Context, sel ast.SelectionSet, 
 		case "id":
 			out.Values[i] = ec._Session_id(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
 		case "firstEventAt":
 			out.Values[i] = ec._Session_firstEventAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
 		case "lastEventAt":
 			out.Values[i] = ec._Session_lastEventAt(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
 		case "eventCount":
 			out.Values[i] = ec._Session_eventCount(ctx, field, obj)
 			if out.Values[i] == graphql.Null {
-				atomic.AddUint32(&out.Invalids, 1)
+				out.Invalids++
 			}
 		case "totalUsage":
-			field := field
-
-			innerFunc := func(ctx context.Context, _ *graphql.FieldSet) (res graphql.Marshaler) {
-				defer func() {
-					if r := recover(); r != nil {
-						ec.Error(ctx, ec.Recover(ctx, r))
-					}
-				}()
-				res = ec._Session_totalUsage(ctx, field, obj)
-				return res
-			}
-
-			if field.Deferrable != nil {
-				dfs, ok := deferred[field.Deferrable.Label]
-				di := 0
-				if ok {
-					dfs.AddField(field)
-					di = len(dfs.Values) - 1
-				} else {
-					dfs = graphql.NewFieldSet([]graphql.CollectedField{field})
-					deferred[field.Deferrable.Label] = dfs
-				}
-				dfs.Concurrently(di, func(ctx context.Context) graphql.Marshaler {
-					return innerFunc(ctx, dfs)
-				})
-
-				// don't run the out.Concurrently() call below
-				out.Values[i] = graphql.Null
-				continue
-			}
-
-			out.Concurrently(i, func(ctx context.Context) graphql.Marshaler { return innerFunc(ctx, out) })
+			out.Values[i] = ec._Session_totalUsage(ctx, field, obj)
 		default:
 			panic("unknown field " + strconv.Quote(field.Name))
 		}

--- a/internal/query/gqlgen.yml
+++ b/internal/query/gqlgen.yml
@@ -34,9 +34,7 @@ models:
         resolver: true
       stopReason:
         resolver: true
-  Session:
-    fields:
-      # totalUsage loads all events in the session to aggregate; lazy
-      # so the cheap `sessions()` listing isn't burdened by it.
-      totalUsage:
-        resolver: true
+  # Session.totalUsage is served from the model field, populated eagerly in
+  # one batched query by the `sessions` resolver (issue #65). It used to be a
+  # per-Session resolver, which N+1'd a full-session load per row on every
+  # 5 s SessionList refetch.

--- a/internal/query/router_test.go
+++ b/internal/query/router_test.go
@@ -643,3 +643,89 @@ func TestLinkedEventsResolver_BearerChainContext(t *testing.T) {
 		t.Errorf("expected chain-context to bound result (~22 events), got %d — looks like seed session was returned in full", len(got.Data.LinkedEvents))
 	}
 }
+
+// TestSessionsTotalUsageBatched exercises the issue #65 path end-to-end:
+// `sessions { totalUsage }` must aggregate per session via the eager batched
+// query (no per-row resolver), sum numeric counters, keep a homogeneous
+// vendor, and return null for a session with no usage-bearing events.
+func TestSessionsTotalUsageBatched(t *testing.T) {
+	st := store.NewMemory()
+	r := chi.NewRouter()
+	r.Route("/v1", func(sub chi.Router) {
+		ingest.RegisterRoutes(sub, st)
+		query.RegisterRoutes(sub, st)
+	})
+	srv := httptest.NewServer(r)
+	defer srv.Close()
+
+	// s1: two usage-bearing events (sum 30/15) plus one without usage.
+	// s2: no usage at all → totalUsage must be null.
+	ndjson := strings.Join([]string{
+		`{"session_id":"s1","actor":{"type":"agent","id":"c","model":"m"},"kind":"thought","payload":{"usage":{"vendor":"anthropic","model":"m","input_tokens":10,"output_tokens":5}}}`,
+		`{"session_id":"s1","actor":{"type":"agent","id":"c","model":"m"},"kind":"decision","payload":{"usage":{"vendor":"anthropic","model":"m","input_tokens":20,"output_tokens":10}}}`,
+		`{"session_id":"s1","actor":{"type":"human","id":"a"},"kind":"prompt","payload":{"text":"hi"}}`,
+		`{"session_id":"s2","actor":{"type":"human","id":"a"},"kind":"prompt","payload":{"text":"no usage here"}}`,
+	}, "\n")
+	resp, err := http.Post(srv.URL+"/v1/events", "application/x-ndjson", strings.NewReader(ndjson))
+	if err != nil {
+		t.Fatalf("ingest post: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("ingest status = %d, want 200", resp.StatusCode)
+	}
+
+	gqlBody := `{"query":"{ sessions { id totalUsage { inputTokens outputTokens vendor } } }"}`
+	resp, err = http.Post(srv.URL+"/v1/graphql", "application/json", strings.NewReader(gqlBody))
+	if err != nil {
+		t.Fatalf("graphql post: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var got struct {
+		Data struct {
+			Sessions []struct {
+				ID         string `json:"id"`
+				TotalUsage *struct {
+					InputTokens  int    `json:"inputTokens"`
+					OutputTokens int    `json:"outputTokens"`
+					Vendor       string `json:"vendor"`
+				} `json:"totalUsage"`
+			} `json:"sessions"`
+		} `json:"data"`
+		Errors []map[string]any `json:"errors"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Errors) > 0 {
+		t.Fatalf("graphql errors: %+v", got.Errors)
+	}
+	if len(got.Data.Sessions) != 2 {
+		t.Fatalf("got %d sessions, want 2", len(got.Data.Sessions))
+	}
+
+	seen := map[string]bool{}
+	for _, s := range got.Data.Sessions {
+		seen[s.ID] = true
+		switch s.ID {
+		case "s1":
+			if s.TotalUsage == nil {
+				t.Fatal("s1 totalUsage is null, want aggregated 30/15")
+			}
+			if s.TotalUsage.InputTokens != 30 || s.TotalUsage.OutputTokens != 15 {
+				t.Errorf("s1 totalUsage = %d/%d, want 30/15", s.TotalUsage.InputTokens, s.TotalUsage.OutputTokens)
+			}
+			if s.TotalUsage.Vendor != "anthropic" {
+				t.Errorf("s1 totalUsage.vendor = %q, want anthropic", s.TotalUsage.Vendor)
+			}
+		case "s2":
+			if s.TotalUsage != nil {
+				t.Errorf("s2 totalUsage = %+v, want null (no usage-bearing events)", s.TotalUsage)
+			}
+		}
+	}
+	if !seen["s1"] || !seen["s2"] {
+		t.Errorf("missing sessions in result: %+v", seen)
+	}
+}

--- a/internal/query/schema.resolvers.go
+++ b/internal/query/schema.resolvers.go
@@ -95,8 +95,21 @@ func (r *queryResolver) Sessions(ctx context.Context, limit *int, since *time.Ti
 		return nil, err
 	}
 	out := make([]*Session, 0, len(list))
+	ids := make([]string, 0, len(list))
 	for _, s := range list {
 		out = append(out, toGQLSession(s))
+		ids = append(ids, s.ID)
+	}
+
+	// Populate totalUsage eagerly in one batched query rather than via a
+	// per-Session field resolver, which N+1'd a full-session load on every
+	// row of every 5 s SessionList refetch (issue #65).
+	usageEvents, err := r.Store.UsageEventsBySessions(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("UsageEventsBySessions: %w", err)
+	}
+	for _, s := range out {
+		s.TotalUsage = aggregateSessionUsage(usageEvents[s.ID])
 	}
 	return out, nil
 }
@@ -209,33 +222,11 @@ func (r *queryResolver) LinkedEvents(ctx context.Context, sessionID string, dept
 	return out, nil
 }
 
-// TotalUsage is the resolver for the totalUsage field.
-//
-// Loads every event in the session (limit=0 → unlimited) and walks
-// payload.usage on each. Aggregation is in-Go rather than SQL so the
-// memory store works the same way as Postgres; pushing this to a SQL
-// `SUM()` is a future optimization once sessions push past tens of
-// thousands of events.
-func (r *sessionResolver) TotalUsage(ctx context.Context, obj *Session) (*TokenUsage, error) {
-	if obj == nil {
-		return nil, nil
-	}
-	events, err := r.Store.ListBySession(ctx, obj.ID, 0)
-	if err != nil {
-		return nil, err
-	}
-	return aggregateSessionUsage(events), nil
-}
-
 // Event returns EventResolver implementation.
 func (r *Resolver) Event() EventResolver { return &eventResolver{r} }
 
 // Query returns QueryResolver implementation.
 func (r *Resolver) Query() QueryResolver { return &queryResolver{r} }
 
-// Session returns SessionResolver implementation.
-func (r *Resolver) Session() SessionResolver { return &sessionResolver{r} }
-
 type eventResolver struct{ *Resolver }
 type queryResolver struct{ *Resolver }
-type sessionResolver struct{ *Resolver }

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -27,6 +27,26 @@ func NewMemory() *Memory {
 // fail. Keeps /healthz honest for memory-mode dogfood runs.
 func (m *Memory) Ping(context.Context) error { return nil }
 
+// UsageEventsBySessions returns each requested session's events in append
+// order (issue #65). Unlike Postgres it does not pre-filter to usage-bearing
+// events — the events are already in memory, so the caller's aggregator
+// skipping non-usage events costs nothing and the totals are identical.
+func (m *Memory) UsageEventsBySessions(_ context.Context, ids []string) (map[string][]*Event, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	want := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		want[id] = struct{}{}
+	}
+	out := map[string][]*Event{}
+	for _, e := range m.events {
+		if _, ok := want[e.SessionID]; ok {
+			out[e.SessionID] = append(out[e.SessionID], e)
+		}
+	}
+	return out, nil
+}
+
 func (m *Memory) Close() error { return nil }
 
 func (m *Memory) AppendEvent(_ context.Context, e *Event) error {

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -29,6 +29,35 @@ func OpenPostgres(ctx context.Context, dsn string) (*Postgres, error) {
 	return &Postgres{pool: pool}, nil
 }
 
+// UsageEventsBySessions returns usage-bearing events for the given session
+// ids in a single query (issue #65). jsonb_exists filters to events that
+// actually carry payload.usage server-side, so the SessionList aggregation
+// doesn't transfer every event row. Only session_id + payload are selected —
+// the only fields aggregateSessionUsage reads.
+func (p *Postgres) UsageEventsBySessions(ctx context.Context, ids []string) (map[string][]*Event, error) {
+	out := map[string][]*Event{}
+	if len(ids) == 0 {
+		return out, nil
+	}
+	const q = `SELECT session_id, payload FROM events
+		WHERE session_id = ANY($1) AND jsonb_exists(payload, 'usage')
+		ORDER BY session_id, id ASC`
+	rows, err := p.pool.Query(ctx, q, ids)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var sid string
+		var payload []byte
+		if err := rows.Scan(&sid, &payload); err != nil {
+			return nil, err
+		}
+		out[sid] = append(out[sid], &Event{SessionID: sid, Payload: payload})
+	}
+	return out, rows.Err()
+}
+
 // Ping round-trips the connection pool so /healthz reflects real DB
 // reachability rather than an unconditional 200 (issue #10).
 func (p *Postgres) Ping(ctx context.Context) error {

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -438,3 +438,48 @@ func TestPostgresLinkRoundTrip(t *testing.T) {
 		t.Errorf("EventsByRef miss returned %d events", len(none))
 	}
 }
+
+// TestPostgresUsageEventsBySessions validates the issue #65 batched query:
+// jsonb_exists filters to usage-bearing events server-side, results group by
+// session, and absent ids don't appear. Exercises the raw SQL against a real
+// Postgres (the memory store takes a different, all-events path).
+func TestPostgresUsageEventsBySessions(t *testing.T) {
+	ctx := context.Background()
+	st, cleanup := openPostgresWithSchema(ctx, t)
+	defer cleanup()
+
+	now := time.Now().UTC()
+	withUsage := []byte(`{"usage":{"vendor":"anthropic","input_tokens":10,"output_tokens":5}}`)
+	noUsage := []byte(`{"text":"hi"}`)
+	events := []*Event{
+		{ID: "01USG1", TS: now, SessionID: "s1", ActorType: "agent", ActorID: "c", Kind: "decision", Hash: "u1", Payload: withUsage},
+		{ID: "01USG2", TS: now.Add(time.Second), SessionID: "s1", ActorType: "human", ActorID: "a", Kind: "prompt", Hash: "u2", PrevHash: "u1", Payload: noUsage},
+		{ID: "01USG3", TS: now.Add(2 * time.Second), SessionID: "s1", ActorType: "agent", ActorID: "c", Kind: "decision", Hash: "u3", PrevHash: "u2", Payload: withUsage},
+		{ID: "01USG4", TS: now, SessionID: "s2", ActorType: "agent", ActorID: "c", Kind: "decision", Hash: "v1", Payload: withUsage},
+		{ID: "01USG5", TS: now.Add(time.Second), SessionID: "s2", ActorType: "human", ActorID: "a", Kind: "prompt", Hash: "v2", PrevHash: "v1", Payload: noUsage},
+	}
+	for _, e := range events {
+		if err := st.AppendEvent(ctx, e); err != nil {
+			t.Fatalf("append %s: %v", e.ID, err)
+		}
+	}
+
+	got, err := st.UsageEventsBySessions(ctx, []string{"s1", "s2", "s3-absent"})
+	if err != nil {
+		t.Fatalf("UsageEventsBySessions: %v", err)
+	}
+	if len(got["s1"]) != 2 {
+		t.Errorf("s1: got %d usage events, want 2 (jsonb_exists should drop the no-usage prompt)", len(got["s1"]))
+	}
+	if len(got["s2"]) != 1 {
+		t.Errorf("s2: got %d usage events, want 1", len(got["s2"]))
+	}
+	if _, present := got["s3-absent"]; present {
+		t.Errorf("s3-absent must not appear in the result map")
+	}
+
+	empty, err := st.UsageEventsBySessions(ctx, nil)
+	if err != nil || len(empty) != 0 {
+		t.Errorf("empty ids: got %v (err %v), want empty map and no query", empty, err)
+	}
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -78,6 +78,14 @@ type Store interface {
 	// limit <= 0 means "no limit". If since is non-zero, only sessions
 	// with LastEventAt >= since are returned.
 	ListSessions(ctx context.Context, limit int, since time.Time) ([]*SessionSummary, error)
+	// UsageEventsBySessions returns, per session id, the events needed to
+	// aggregate Session.totalUsage — in one round trip for the whole set, so
+	// the SessionList page doesn't fan out to a full-session load per row
+	// (issue #65). Postgres filters to usage-bearing events server-side;
+	// memory returns each session's events and lets the caller's aggregator
+	// skip the rest — both yield identical totals. Ids absent from the map
+	// have no usage to aggregate.
+	UsageEventsBySessions(ctx context.Context, ids []string) (map[string][]*Event, error)
 	AppendLink(ctx context.Context, l *Link) error
 	LinksForEvent(ctx context.Context, eventID string) ([]*Link, error)
 	// LinksForSession returns every link with at least one endpoint


### PR DESCRIPTION
Closes #65.

## Problem
`Session.totalUsage` was a **per-Session field resolver** running `ListBySession(sid, 0)` — a full-session load — for every row of `sessions(limit:50)`. The Lens SessionList refetches every 5 s, so each poll fanned out to up to **50 full-session scans**. #65 names two compounding issues: N+1 fan-out + per-row full-session load.

## Fix — eager batched population
`totalUsage` becomes a **model field served eagerly**: the `sessions` resolver populates every row from **one batched query**. The **GraphQL contract (`schema.graphql`) is unchanged** — only resolution moves from per-row resolver → eager batch, so every existing query returns identical results.

- **store**: new `UsageEventsBySessions(ids)` — one round trip for the whole set. Postgres filters to usage-bearing events server-side via `jsonb_exists(payload, 'usage')` (no full-session transfer); memory returns each session's events and lets `aggregateSessionUsage` skip the rest. Both yield identical totals.
- **gqlgen.yml**: drop `Session.totalUsage`'s `resolver: true`; regenerated (the `SessionResolver` interface + per-Session resolver method are gone).
- **query**: `sessions` resolver collects ids → one `UsageEventsBySessions` call → `aggregateSessionUsage` per session. The aggregator is **unchanged**, so the homogeneity semantics (single vendor/model/tier, else empty) are preserved.

**No DataLoader needed**: `Sessions` is the *only* producer of `Session` objects, so eager population is complete (verified — no `session(id)` query exists).

## Why not SQL `SUM()` / denormalization
`aggregateSessionUsage` collapses vendor/model/tier to a single value only when homogeneous (a `COUNT(DISTINCT)` semantic, not a plain SUM) — replicating that in JSONB SQL risks divergence between the pg and memory paths. Fetching usage-bearing events + reusing the Go aggregator keeps one source of truth. Denormalization (trigger/columns) was overkill for a deferred optimization and touches the hash-chain ingest path.

## Tests
- **`query/router_test`** (memory, GraphQL round-trip): `sessions { totalUsage }` sums **30/15**, keeps homogeneous `vendor`, returns **null** for a usage-free session.
- **store integration** (real Postgres): `jsonb_exists` filtering, per-session grouping, absent ids — **verified locally against a testcontainer PG** (`DOCKER_HOST=…colima… TESTCONTAINERS_RYUK_DISABLED=true`).
- `go test -race ./...` + `go vet` green; gqlgen codegen stable (regen is a no-op on the committed output).

## Self-review notes
- Spans 2 packages (query + store); `schema.graphql` untouched (GraphQL contract identical) → not the risk-asymmetric `/review` set, mechanical+judgment sufficient. `/review` available if you want a second look at the resolver-strategy change.
- **Behavior delta**: a store error during a `sessions` query now fails the whole query (was: per-field error on `totalUsage`). Acceptable — the list is useless without it.
- Not covered: real production-scale latency (the win is structural: 50 queries → 1). The `/metrics` `agent_lens_graphql_request_duration_seconds` histogram (just added in #4) can confirm p99 improvement under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)