### PR TITLE
feat(web): turn-grouped "Story" view for sessions

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
 import { Timeline } from "./components/Timeline";
+import { StoryTimeline } from "./components/StoryTimeline";
 import { SessionList } from "./components/SessionList";
 import { CausalGraph } from "./components/CausalGraph";
 
-type View = "timeline" | "graph";
+type View = "timeline" | "story" | "graph";
 
 function getInitialSession(): string {
   return new URLSearchParams(window.location.search).get("session") ?? "";
@@ -11,7 +12,7 @@ function getInitialSession(): string {
 
 function getInitialView(): View {
   const v = new URLSearchParams(window.location.search).get("view");
-  return v === "graph" ? "graph" : "timeline";
+  return v === "graph" ? "graph" : v === "story" ? "story" : "timeline";
 }
 
 function getInitialLinked(): boolean {
@@ -73,7 +74,9 @@ export default function App() {
       ? linked
         ? "M2 cross-session graph"
         : "M2 causal graph"
-      : "M1 timeline"
+      : view === "story"
+        ? "turn-grouped story"
+        : "M1 timeline"
     : "M2 sessions";
 
   // Graph view needs more horizontal room (dagre lays a wide DAG; the
@@ -127,6 +130,8 @@ export default function App() {
         {sessionId ? (
           view === "graph" ? (
             <CausalGraph sessionId={sessionId} linked={linked} />
+          ) : view === "story" ? (
+            <StoryTimeline sessionId={sessionId} />
           ) : (
             <Timeline sessionId={sessionId} />
           )
@@ -155,6 +160,12 @@ function ViewToggle({
         onClick={() => onSelect("timeline")}
       >
         Timeline
+      </ToggleButton>
+      <ToggleButton
+        active={view === "story"}
+        onClick={() => onSelect("story")}
+      >
+        Story
       </ToggleButton>
       <ToggleButton
         active={view === "graph"}

--- a/web/src/components/EventCard.tsx
+++ b/web/src/components/EventCard.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useMemo, useState } from "react";
 import type { Event } from "../types";
 import { styleFor, formatTimestamp } from "./kindStyle";
 import { payloadToDiff } from "../lib/payloadToDiff";
+import { parsePrompt } from "../lib/prompts";
 import { AgentDispatchChip } from "./AgentDispatchChip";
 import { RedactionChip } from "./RedactionChip";
 import { TokenUsageChip } from "./TokenUsageChip";
@@ -17,7 +18,19 @@ export function EventCard({ event }: { event: Event }) {
   const [showRaw, setShowRaw] = useState(false);
   const style = styleFor(event.kind);
 
-  const summary = summarize(event);
+  // A PROMPT may actually be a system-injected block (e.g. <task-notification>
+  // from a backgrounded task) the hook recorded as a human prompt — parse it so
+  // the card shows readable fields instead of raw XML (issue #118).
+  const promptParse = useMemo(
+    () =>
+      event.kind === "PROMPT"
+        ? parsePrompt(
+            typeof event.payload?.text === "string" ? (event.payload.text as string) : "",
+          )
+        : null,
+    [event.kind, event.payload],
+  );
+  const summary = promptParse ? promptParse.title : summarize(event);
   const hasPayload = event.payload && Object.keys(event.payload).length > 0;
   const diffs = useMemo(
     () =>
@@ -117,6 +130,14 @@ export function EventCard({ event }: { event: Event }) {
                 stopReason={event.stopReason}
               />
             )}
+            {promptParse && !promptParse.human && (
+              <span
+                className="inline-flex items-center gap-1 rounded bg-zinc-100 px-1.5 py-0.5 text-[10px] font-medium text-zinc-700 ring-1 ring-zinc-300"
+                title="System-injected message (e.g. a backgrounded task completing), not human input. Captured as a prompt by the hook — see issue #118."
+              >
+                🔔 injected
+              </span>
+            )}
             {event.links?.length > 0 && (
               <span
                 className="inline-flex items-center gap-0.5 rounded bg-white px-1.5 py-0.5 text-[10px] font-medium text-zinc-700 ring-1 ring-zinc-300"
@@ -136,6 +157,16 @@ export function EventCard({ event }: { event: Event }) {
             <div className="mt-1.5 text-sm text-zinc-800 break-words">
               {summary}
             </div>
+          )}
+          {promptParse && promptParse.fields.length > 0 && (
+            <dl className="mt-1.5 grid grid-cols-[auto_1fr] gap-x-2 gap-y-0.5 text-[11px]">
+              {promptParse.fields.map((f) => (
+                <div key={f.label} className="contents">
+                  <dt className="text-zinc-400">{f.label}</dt>
+                  <dd className="break-words font-mono text-zinc-700">{f.value}</dd>
+                </div>
+              ))}
+            </dl>
           )}
           <div className="mt-1.5 text-[11px] text-zinc-400 font-mono truncate">
             {event.id} · hash {event.hash.slice(0, 12)}

--- a/web/src/components/StoryTimeline.tsx
+++ b/web/src/components/StoryTimeline.tsx
@@ -1,0 +1,346 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { gql, eventsQuery } from "../api/client";
+import type { EventsResponse } from "../types";
+import { EventCard } from "./EventCard";
+import { TokenUsageChip } from "./TokenUsageChip";
+import {
+  groupIntoTurns,
+  summarizeTurn,
+  formatDuration,
+  type Turn,
+  type TurnSummary,
+  type Initiator,
+} from "../lib/turns";
+
+// Per-initiator left-border colour + glyph: who drove the turn at a glance.
+const initiatorStyle: Record<Initiator, { bar: string; icon: string }> = {
+  human: { bar: "border-l-blue-400", icon: "👤" },
+  agent: { bar: "border-l-amber-400", icon: "🤖" },
+  subagent: { bar: "border-l-violet-400", icon: "🤖" },
+  system: { bar: "border-l-zinc-300", icon: "⚙" },
+};
+
+// Open many turns by default only for short sessions; long ones start
+// collapsed so the page is scannable.
+const AUTO_OPEN_MAX = 8;
+
+type Filter = "failures" | "produced" | "human";
+
+// StoryTimeline groups the raw event stream into conversational turns so the
+// session reads like a narrated transcript rather than event-by-event soup.
+// Grouping + summarisation are pure (lib/turns.ts); expanding a turn drops to
+// the existing EventCard for full fidelity.
+export function StoryTimeline({ sessionId }: { sessionId: string }) {
+  const { data, error, isLoading, isFetching } = useQuery({
+    queryKey: ["events", sessionId, 5000],
+    queryFn: () => gql<EventsResponse>(eventsQuery, { sessionId, limit: 5000 }),
+    enabled: sessionId.length > 0,
+    refetchInterval: 2000,
+  });
+
+  const turns = useMemo(() => groupIntoTurns(data?.events ?? []), [data?.events]);
+  // Summaries are computed once here (not inside each card) so the toolbar can
+  // filter on them.
+  const summaries = useMemo(() => turns.map(summarizeTurn), [turns]);
+
+  // Lifted open-state so the toolbar can expand/collapse all. Initialised once
+  // when turns first arrive; refetch-appended turns stay collapsed so a 2 s
+  // poll never clobbers the user's expand state.
+  const [openKeys, setOpenKeys] = useState<Set<string>>(new Set());
+  const inited = useRef(false);
+  useEffect(() => {
+    if (inited.current || turns.length === 0) return;
+    inited.current = true;
+    setOpenKeys(
+      turns.length <= AUTO_OPEN_MAX
+        ? new Set([turns[turns.length - 1].key])
+        : new Set(),
+    );
+  }, [turns]);
+
+  const setOpen = (key: string, val: boolean) =>
+    setOpenKeys((prev) => {
+      const next = new Set(prev);
+      if (val) next.add(key);
+      else next.delete(key);
+      return next;
+    });
+
+  const [filters, setFilters] = useState<Set<Filter>>(new Set());
+  const toggleFilter = (f: Filter) =>
+    setFilters((prev) => {
+      const next = new Set(prev);
+      if (next.has(f)) next.delete(f);
+      else next.add(f);
+      return next;
+    });
+
+  // flashId briefly rings the event a "jump" landed on so it isn't lost.
+  const [flashId, setFlashId] = useState<string | null>(null);
+  const jumpTo = (turnKey: string, eventId: string) => {
+    setOpen(turnKey, true);
+    setFlashId(eventId);
+    // Defer the scroll until the expanded body has mounted.
+    window.setTimeout(() => {
+      document
+        .getElementById(`evt-${eventId}`)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 80);
+    window.setTimeout(
+      () => setFlashId((cur) => (cur === eventId ? null : cur)),
+      1800,
+    );
+  };
+
+  if (isLoading) return <div className="text-sm text-zinc-500">Loading…</div>;
+  if (error)
+    return (
+      <div className="text-sm text-rose-600">Error: {(error as Error).message}</div>
+    );
+  if (!data) return null;
+
+  const matches = (s: TurnSummary): boolean =>
+    filters.size === 0 ||
+    (filters.has("failures") && s.hasFailure) ||
+    (filters.has("produced") && s.produced.length > 0) ||
+    (filters.has("human") && s.initiator === "human");
+
+  // Keep original turn numbers (#N) stable even when filtered.
+  const rows = turns
+    .map((turn, i) => ({ turn, summary: summaries[i], index: i + 1 }))
+    .filter((r) => matches(r.summary));
+
+  return (
+    <div>
+      <div className="mb-4 flex flex-wrap items-center gap-x-4 gap-y-2">
+        <span className="text-sm text-zinc-700">
+          <span className="font-medium">{turns.length}</span>{" "}
+          {turns.length === 1 ? "turn" : "turns"}
+          <span className="text-zinc-500"> · {data.events.length} events</span>
+          {filters.size > 0 && (
+            <span className="text-zinc-500"> · {rows.length} shown</span>
+          )}
+        </span>
+        {isFetching && <span className="text-xs text-zinc-400">refreshing…</span>}
+
+        <div className="flex items-center gap-1.5 text-xs">
+          <FilterToggle active={filters.has("failures")} onClick={() => toggleFilter("failures")}>
+            ✗ failures
+          </FilterToggle>
+          <FilterToggle active={filters.has("produced")} onClick={() => toggleFilter("produced")}>
+            produced
+          </FilterToggle>
+          <FilterToggle active={filters.has("human")} onClick={() => toggleFilter("human")}>
+            👤 human
+          </FilterToggle>
+        </div>
+
+        {turns.length > 0 && (
+          <div className="ml-auto flex items-center gap-2 text-xs">
+            <button
+              type="button"
+              className="rounded border border-zinc-300 px-2 py-0.5 text-zinc-600 hover:bg-zinc-50"
+              onClick={() => setOpenKeys(new Set(turns.map((t) => t.key)))}
+            >
+              Expand all
+            </button>
+            <button
+              type="button"
+              className="rounded border border-zinc-300 px-2 py-0.5 text-zinc-600 hover:bg-zinc-50"
+              onClick={() => setOpenKeys(new Set())}
+            >
+              Collapse all
+            </button>
+          </div>
+        )}
+      </div>
+
+      {turns.length === 0 ? (
+        <div className="text-sm text-zinc-500">No events for this session yet.</div>
+      ) : rows.length === 0 ? (
+        <div className="text-sm text-zinc-500">No turns match the current filter.</div>
+      ) : (
+        <div className="space-y-3">
+          {rows.map(({ turn, summary, index }) => (
+            <TurnCard
+              key={turn.key}
+              turn={turn}
+              summary={summary}
+              index={index}
+              open={openKeys.has(turn.key)}
+              flashId={flashId}
+              onToggle={() => setOpen(turn.key, !openKeys.has(turn.key))}
+              onJumpTo={(eventId) => jumpTo(turn.key, eventId)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function FilterToggle({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      className={`rounded-full border px-2 py-0.5 transition ${
+        active
+          ? "border-zinc-900 bg-zinc-900 text-white"
+          : "border-zinc-300 bg-white text-zinc-600 hover:bg-zinc-50"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function TurnCard({
+  turn,
+  summary: s,
+  index,
+  open,
+  flashId,
+  onToggle,
+  onJumpTo,
+}: {
+  turn: Turn;
+  summary: TurnSummary;
+  index: number;
+  open: boolean;
+  flashId: string | null;
+  onToggle: () => void;
+  onJumpTo: (eventId: string) => void;
+}) {
+  const init = initiatorStyle[s.initiator];
+
+  return (
+    <div
+      className={`rounded-lg border border-l-4 border-zinc-200 bg-white shadow-sm ${init.bar} ${
+        s.initiator === "subagent" ? "ml-6" : ""
+      }`}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-start gap-3 px-4 py-3 text-left hover:bg-zinc-50/60"
+      >
+        <span className="mt-0.5 shrink-0 font-mono text-xs text-zinc-400">#{index}</span>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2 text-xs text-zinc-500">
+            <span>
+              {init.icon} {s.humanId ?? s.initiator}
+            </span>
+            <span aria-hidden>→</span>
+            <span>🤖 {s.model ?? "agent"}</span>
+            <span className="text-zinc-400">· {s.steps} steps</span>
+            {s.durationMs != null && (
+              <span className="text-zinc-400">· {formatDuration(s.durationMs)}</span>
+            )}
+            {s.usage && <TokenUsageChip usage={s.usage} />}
+          </div>
+
+          <div className="mt-1 break-words text-sm font-medium text-zinc-800">
+            {s.title}
+          </div>
+
+          {s.highlights.length > 0 && (
+            <div className="mt-1.5 flex flex-wrap gap-1.5">
+              {s.highlights.map((h, j) => (
+                <span
+                  key={j}
+                  role="button"
+                  tabIndex={0}
+                  title="jump to this step"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onJumpTo(h.firstEventId);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onJumpTo(h.firstEventId);
+                    }
+                  }}
+                  className={`inline-flex cursor-pointer items-center gap-1 rounded px-1.5 py-0.5 text-[11px] ${
+                    h.error
+                      ? "bg-rose-100 text-rose-800 ring-1 ring-rose-300 hover:bg-rose-200"
+                      : "bg-zinc-100 text-zinc-700 hover:bg-zinc-200"
+                  }`}
+                >
+                  <span aria-hidden>{h.icon}</span>
+                  <span>
+                    {h.text}
+                    {h.error ? " ✗" : ""}
+                    {h.count > 1 ? ` ×${h.count}` : ""}
+                  </span>
+                </span>
+              ))}
+            </div>
+          )}
+
+          {s.produced.length > 0 && (
+            <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+              <span className="text-[11px] text-zinc-400">produced</span>
+              {s.produced.map((p) => (
+                <span
+                  key={p.eventId}
+                  role="button"
+                  tabIndex={0}
+                  title="jump to this event"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onJumpTo(p.eventId);
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      onJumpTo(p.eventId);
+                    }
+                  }}
+                  className="inline-flex cursor-pointer items-center gap-1 rounded bg-emerald-100 px-1.5 py-0.5 text-[11px] font-medium text-emerald-900 ring-1 ring-emerald-300 hover:bg-emerald-200"
+                >
+                  <span aria-hidden>{p.icon}</span>
+                  <span>{p.label}</span>
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+        <span className="mt-0.5 shrink-0 select-none text-xs text-zinc-400">
+          {open ? "▼" : "▶"}
+        </span>
+      </button>
+
+      {open && (
+        <div className="space-y-2 border-t border-zinc-100 px-4 py-3">
+          {turn.events.map((e) => (
+            <div
+              key={e.id}
+              id={`evt-${e.id}`}
+              className={
+                flashId === e.id
+                  ? "rounded-md ring-2 ring-amber-400 ring-offset-2"
+                  : ""
+              }
+            >
+              <EventCard event={e} />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/prompts.ts
+++ b/web/src/lib/prompts.ts
@@ -1,0 +1,60 @@
+// Shared parsing for prompt events. Claude Code fires UserPromptSubmit for
+// genuine human input AND for system-injected blocks (a backgrounded task /
+// sub-agent completion arrives as <task-notification>, a system nudge as
+// <system-reminder>), and the hook captures them all as kind=prompt /
+// actor=human. parsePrompt distinguishes the two and, for notifications,
+// extracts the readable fields instead of dumping raw XML. (The capture-side
+// mis-attribution is tracked in issue #118; this is the display-layer parse.)
+
+const clip = (s: string, n: number): string =>
+  s.length > n ? s.slice(0, n) + "…" : s;
+
+// Only well-known injected tags are treated as non-human, so a human prompt
+// that merely starts with "<" (e.g. "<div> is broken") isn't misclassified.
+const INJECTION_TAG =
+  /^<(task-notification|system-reminder|task-reminder|command-message|command-name|local-command-stdout|local-command-stderr)\b/;
+
+function tagContent(text: string, name: string): string | null {
+  const m = text.match(new RegExp(`<${name}>([\\s\\S]*?)</${name}>`));
+  return m ? m[1].trim() : null;
+}
+
+export interface ParsedPrompt {
+  human: boolean;
+  title: string; // one-line label for summaries
+  fields: { label: string; value: string }[]; // structured detail (notifications)
+}
+
+export function parsePrompt(text: string): ParsedPrompt {
+  const t = text.replace(/^\s+/, "");
+  const tag = t.match(INJECTION_TAG)?.[1];
+  if (!tag) {
+    return {
+      human: true,
+      title: clip(text.replace(/\s+/g, " ").trim(), 100) || "(empty prompt)",
+      fields: [],
+    };
+  }
+  if (tag === "task-notification") {
+    const status = tagContent(text, "status");
+    const summary = tagContent(text, "summary");
+    const outputFile = tagContent(text, "output-file");
+    const taskId = tagContent(text, "task-id");
+    const toolUseId = tagContent(text, "tool-use-id");
+    const fields: { label: string; value: string }[] = [];
+    if (status) fields.push({ label: "status", value: status });
+    if (summary) fields.push({ label: "summary", value: summary });
+    if (outputFile)
+      fields.push({ label: "output", value: outputFile.split("/").pop() || outputFile });
+    if (taskId) fields.push({ label: "task-id", value: taskId });
+    if (toolUseId) fields.push({ label: "tool-use-id", value: toolUseId });
+    const title = summary
+      ? `🔔 ${clip(summary, 90)}`
+      : `🔔 task notification${taskId ? ` · ${taskId}` : ""}`;
+    return { human: false, title, fields };
+  }
+  if (tag === "system-reminder") {
+    return { human: false, title: "🔔 system reminder", fields: [] };
+  }
+  return { human: false, title: `🔔 ${tag}`, fields: [] };
+}

--- a/web/src/lib/turns.ts
+++ b/web/src/lib/turns.ts
@@ -1,0 +1,330 @@
+import type { Event, TokenUsage } from "../types";
+import { parsePrompt } from "./prompts";
+
+// A Turn is one conversational exchange: a human prompt and everything the
+// agent did in response, up to the next prompt.
+export interface Turn {
+  key: string; // stable React key (first event id)
+  events: Event[];
+  prompt: Event | null; // the PROMPT that opened the turn, if any
+}
+
+// groupIntoTurns folds an append-ordered event list into turns. Claude Code
+// does NOT populate turn_id (it's null on the wire — verified against real
+// dogfood capture), so the boundary is the human PROMPT: a turn runs from one
+// PROMPT up to (but not including) the next. Events before the first prompt —
+// SessionStart markers, config snapshots — form a leading group.
+export function groupIntoTurns(events: Event[]): Turn[] {
+  const turns: Turn[] = [];
+  let cur: Event[] = [];
+  const flush = () => {
+    if (cur.length === 0) return;
+    turns.push({
+      key: cur[0].id,
+      events: cur,
+      prompt: cur.find((e) => e.kind === "PROMPT") ?? null,
+    });
+    cur = [];
+  };
+  for (const e of events) {
+    if (e.kind === "PROMPT" && cur.length > 0) flush();
+    cur.push(e);
+  }
+  flush();
+  return turns;
+}
+
+// Highlight is one notable step in a turn's story line, with a repeat count
+// (e.g. "🔧 Edit ×2"). error marks a tool whose result reported failure;
+// firstEventId is the event the chip links to (first occurrence).
+export interface Highlight {
+  icon: string;
+  text: string;
+  count: number;
+  error?: boolean;
+  firstEventId: string;
+}
+
+// Who drove the turn — drives the card's colour + indent.
+export type Initiator = "human" | "agent" | "subagent" | "system";
+
+// Produced is a downstream artifact a turn caused (commit / PR / push / build
+// / deploy), surfaced on its own row and click-to-scroll to the event.
+export interface Produced {
+  icon: string;
+  label: string;
+  eventId: string;
+}
+
+export interface TurnSummary {
+  title: string;
+  initiator: Initiator;
+  humanId: string | null;
+  model: string | null;
+  steps: number; // meaningful actions (excludes tool_result + structural markers + the opening prompt)
+  durationMs: number | null;
+  usage: TokenUsage | null;
+  highlights: Highlight[];
+  produced: Produced[];
+  hasFailure: boolean;
+}
+
+const asString = (v: unknown): string => (typeof v === "string" ? v : "");
+
+// Prompt classification (human vs system-injected block) is shared with the
+// EventCard via lib/prompts.ts.
+
+// isErrorResult reads a tool_result payload for a clear failure signal.
+// Conservative: only the structured markers Claude Code sets, plus an
+// error-prefixed string — so a successful tool whose output merely mentions
+// "error" isn't mislabelled.
+function isErrorResult(pl: Record<string, unknown>): boolean {
+  const r = pl.response;
+  if (r && typeof r === "object") {
+    const o = r as Record<string, unknown>;
+    if (o.is_error === true || o.success === false) return true;
+  }
+  if (typeof r === "string" && /^\s*error\b|\berror:/i.test(r)) return true;
+  return false;
+}
+
+// isMeaningfulStep excludes plumbing from the step count: tool_result (paired
+// with its call), the opening prompt (shown as the title), and the structural
+// session_start / turn_end decision markers.
+function isMeaningfulStep(e: Event): boolean {
+  if (e.kind === "TOOL_RESULT" || e.kind === "PROMPT") return false;
+  if (e.kind === "DECISION") {
+    const pl = (e.payload ?? {}) as Record<string, unknown>;
+    const m = asString(pl.marker);
+    if (m === "session_start" || m === "turn_end") return false;
+    // Empty assistant_message events are synthesized metadata carriers
+    // (redacted-thinking / usage), not actions — same rule as the reply chip.
+    if (m === "assistant_message" && asString(pl.text).trim() === "") return false;
+  }
+  return true;
+}
+
+export function formatDuration(ms: number): string {
+  const s = Math.round(ms / 1000);
+  if (s < 1) return "<1s";
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  const rs = s % 60;
+  if (m < 60) return rs ? `${m}m ${rs}s` : `${m}m`;
+  const h = Math.floor(m / 60);
+  const rm = m % 60;
+  return rm ? `${h}h ${rm}m` : `${h}h`;
+}
+
+// summarizeTurn derives the header + story line shown on a collapsed turn —
+// what happened, who drove it, what it produced — without expanding to raw
+// events.
+export function summarizeTurn(turn: Turn): TurnSummary {
+  const { events, prompt } = turn;
+  const payloadOf = (e: Event) => (e.payload ?? {}) as Record<string, unknown>;
+  const first = events[0];
+  const firstMarker = asString(payloadOf(first).marker);
+
+  const promptInfo = prompt
+    ? parsePrompt(asString(payloadOf(prompt).text))
+    : null;
+
+  const initiator: Initiator = promptInfo
+    ? promptInfo.human
+      ? "human"
+      : "system" // injected notification/reminder — not a human turn
+    : firstMarker === "subagent_start"
+      ? "subagent"
+      : events.some((e) => e.actor.type === "AGENT")
+        ? "agent"
+        : "system";
+
+  const humanId = promptInfo?.human ? (prompt as Event).actor.id : null;
+  const model =
+    events.find((e) => e.actor.type === "AGENT" && e.actor.model)?.actor.model ??
+    null;
+
+  // Ordered, de-duplicated highlight list. bump() merges repeats (same key)
+  // into a count, keeps first-appearance order, and records the event the
+  // chip links to (first occurrence).
+  const order: string[] = [];
+  const byKey = new Map<string, Highlight>();
+  const bump = (
+    key: string,
+    icon: string,
+    text: string,
+    eventId: string,
+    error?: boolean,
+  ) => {
+    const existing = byKey.get(key);
+    if (existing) {
+      existing.count++;
+      return;
+    }
+    byKey.set(key, { icon, text, count: 1, error, firstEventId: eventId });
+    order.push(key);
+  };
+
+  const produced: Produced[] = [];
+
+  for (let i = 0; i < events.length; i++) {
+    const e = events[i];
+    const pl = payloadOf(e);
+    switch (e.kind) {
+      case "PROMPT":
+        break; // shown as the title
+      case "THOUGHT":
+        bump("thinking", "💭", "thinking", e.id);
+        break;
+      case "TOOL_CALL": {
+        const next = events[i + 1];
+        const errored =
+          !!next && next.kind === "TOOL_RESULT" && isErrorResult(payloadOf(next));
+        const tag = errored ? "err" : "ok";
+        const skill = pl.skill as Record<string, unknown> | undefined;
+        if (skill && typeof skill.name === "string") {
+          bump(`skill:${skill.name}:${tag}`, "⌘", skill.name, e.id, errored);
+        } else {
+          const name = asString(pl.name) || "tool";
+          bump(`tool:${name}:${tag}`, "🔧", name, e.id, errored);
+        }
+        break;
+      }
+      case "TOOL_RESULT":
+        break; // folded into the call above
+      case "DECISION": {
+        const marker = asString(pl.marker);
+        // Only count real replies. Empty assistant_message events are
+        // synthesized carriers for redacted-thinking / usage metadata
+        // (transcript reader.go), not actual agent prose.
+        if (marker === "assistant_message" && asString(pl.text).trim() !== "")
+          bump("reply", "💬", "reply", e.id);
+        else if (marker === "subagent_start")
+          bump(`sub:${asString(pl.agent_type)}`, "🤖", asString(pl.agent_type) || "sub-agent", e.id);
+        break; // session_start / turn_end are structural — omit
+      }
+      case "REVIEW":
+        bump(`review:${e.id}`, "👁", asString(pl.action) || "review", e.id);
+        break;
+      case "CODE_CHANGE":
+        bump("diff", "✎", "diff", e.id);
+        break;
+      // Downstream artifacts get their own "produced" row, not a story chip.
+      case "COMMIT":
+        produced.push({ icon: "📦", label: asString(pl.sha).slice(0, 7) || "commit", eventId: e.id });
+        break;
+      case "PR": {
+        const n = pl.number;
+        produced.push({ icon: "⇪", label: typeof n === "number" ? `#${n}` : "PR", eventId: e.id });
+        break;
+      }
+      case "PUSH":
+        produced.push({ icon: "↥", label: asString(pl.ref).replace(/^refs\/(heads|tags)\//, "") || "push", eventId: e.id });
+        break;
+      case "BUILD":
+        produced.push({ icon: "🛠", label: asString(pl.workflow) || "build", eventId: e.id });
+        break;
+      case "DEPLOY":
+        produced.push({ icon: "🚀", label: asString(pl.environment) || "deploy", eventId: e.id });
+        break;
+    }
+  }
+
+  const highlights = order.map((k) => byKey.get(k) as Highlight);
+  const title = promptInfo
+    ? promptInfo.title
+    : nonHumanTitle(initiator, firstMarker, payloadOf(first), highlights, produced);
+
+  return {
+    title,
+    initiator,
+    humanId,
+    model,
+    steps: events.filter(isMeaningfulStep).length,
+    durationMs: turnDuration(events),
+    usage: sumUsage(events),
+    highlights,
+    produced,
+    hasFailure: highlights.some((h) => h.error),
+  };
+}
+
+// nonHumanTitle builds an informative label for turns with no opening prompt,
+// instead of a bare "session start".
+function nonHumanTitle(
+  initiator: Initiator,
+  firstMarker: string,
+  firstPayload: Record<string, unknown>,
+  highlights: Highlight[],
+  produced: Produced[],
+): string {
+  if (initiator === "subagent") {
+    const t = asString(firstPayload.agent_type);
+    return `sub-agent${t ? `: ${t}` : ""}`;
+  }
+  if (initiator === "system") {
+    return firstMarker === "session_start" ? "session start" : "system";
+  }
+  // agent: summarize what it did
+  const toolN = highlights
+    .filter((h) => h.icon === "🔧" || h.icon === "⌘")
+    .reduce((a, h) => a + h.count, 0);
+  const bits: string[] = [];
+  if (toolN) bits.push(`${toolN} tool${toolN > 1 ? "s" : ""}`);
+  if (highlights.some((h) => h.text === "reply")) bits.push("reply");
+  for (const p of produced) bits.push(`${p.icon} ${p.label}`);
+  return bits.length ? `agent · ${bits.join(" · ")}` : "agent activity";
+}
+
+function turnDuration(events: Event[]): number | null {
+  if (events.length < 2) return null;
+  const a = new Date(events[0].ts).getTime();
+  const b = new Date(events[events.length - 1].ts).getTime();
+  if (isNaN(a) || isNaN(b) || b < a) return null;
+  return b - a;
+}
+
+// sumUsage aggregates per-event token counters across a turn. Mirrors the
+// server-side aggregateSessionUsage / Timeline's aggregateUsage: numeric
+// counters sum; vendor/model/tier collapse to a single value only when the
+// turn is homogeneous.
+function sumUsage(events: Event[]): TokenUsage | null {
+  let any = false;
+  let input = 0,
+    output = 0,
+    cacheR = 0,
+    c5 = 0,
+    c1 = 0,
+    ws = 0,
+    wf = 0;
+  const vendors = new Set<string>();
+  const models = new Set<string>();
+  const tiers = new Set<string>();
+  for (const e of events) {
+    if (!e.usage) continue;
+    any = true;
+    input += e.usage.inputTokens;
+    output += e.usage.outputTokens;
+    if (e.usage.cacheReadTokens) cacheR += e.usage.cacheReadTokens;
+    if (e.usage.cacheWrite5mTokens) c5 += e.usage.cacheWrite5mTokens;
+    if (e.usage.cacheWrite1hTokens) c1 += e.usage.cacheWrite1hTokens;
+    if (e.usage.webSearchCalls) ws += e.usage.webSearchCalls;
+    if (e.usage.webFetchCalls) wf += e.usage.webFetchCalls;
+    if (e.usage.vendor) vendors.add(e.usage.vendor);
+    if (e.usage.model) models.add(e.usage.model);
+    if (e.usage.serviceTier) tiers.add(e.usage.serviceTier);
+  }
+  if (!any) return null;
+  return {
+    vendor: vendors.size === 1 ? [...vendors][0] : "",
+    model: models.size === 1 ? [...models][0] : "",
+    serviceTier: tiers.size === 1 ? [...tiers][0] : null,
+    inputTokens: input,
+    outputTokens: output,
+    cacheReadTokens: cacheR || null,
+    cacheWrite5mTokens: c5 || null,
+    cacheWrite1hTokens: c1 || null,
+    webSearchCalls: ws || null,
+    webFetchCalls: wf || null,
+  };
+}


### PR DESCRIPTION
Adds a third session view — **Story** — alongside Timeline and Graph.

## Why
Timeline and Graph are **event-centric** (one card/node per raw event), so reading a session means reconstructing the narrative yourself. The **Story** view folds the event stream into conversational **turns** so a session reads like a narrated transcript. Expanding a turn drops to the existing `EventCard` for full fidelity — it's a lens over the same data, not a replacement.

## What
View toggle `Timeline | Story | Graph` (`?view=story` deep-link). All **frontend-only; no schema/backend change.**

- **`lib/turns.ts` (pure):** `groupIntoTurns` boundaries on the human PROMPT — Claude Code leaves `turn_id` **null** on the wire (verified against real capture), so prompt-boundary is the robust heuristic. `summarizeTurn` derives the header + a de-duplicated story line (💭 thinking, ⌘ skill, 🔧 tool ×N, 💬 reply), produced artifacts, token sum, duration.
- **`StoryTimeline.tsx`:** per-initiator colour bar + sub-agent indent (human/agent/sub-agent/system); produced-artifact row (commit/PR/push/build/deploy) **click-to-scroll + flash-highlight**; failed tools shown **✗** (conservative `is_error`/`success` detection); turn-level **filters** (failures / produced / human); **expand/collapse all**; meaningful-step count.
- **`lib/prompts.ts` (shared with EventCard):** a `UserPromptSubmit` may be a **system-injected** block — `<task-notification>` (a backgrounded task completing), `<system-reminder>` — that the hook recorded as a human prompt. `parsePrompt` extracts readable fields (status / summary / output) instead of dumping raw XML, marks the turn `system`, and flags the `EventCard` with a **🔔 injected** chip. (Capture-side mis-attribution → **#118**.)
- **Empty `assistant_message` carriers** (synthesized for redacted-thinking / usage metadata, not real prose) are excluded from both the reply count and the step count.

## Validation
- `tsc --noEmit` clean; `pnpm build` green.
- **Manually smoke-tested live across several iteration rounds** (dev server + real dogfood sessions) — surfaced and fixed the raw-XML notification rendering and the carrier-count inflation during review.

## Known / follow-ups
- **No unit tests yet:** `groupIntoTurns` / `summarizeTurn` / `parsePrompt` are written as pure, exported functions precisely so tests drop in once **#62** (vitest infra) lands. Strongest reviewer objection; called out deliberately.
- The produced/chip **flash** uses an 80 ms `setTimeout` to wait for the expanded body to mount — works; a ref/`useLayoutEffect` would be sturdier. Minor; left as-is.
- `parsePrompt` only relabels a conservative whitelist of injected tags; the data-layer fix is **#118**.

## Self-review — not covered (manual smoke)
Visual rendering / layout (initiator bars, sub-agent indent, chip wrapping), flash animation, expand-collapse-all, filter combinations, `?view=story` deep-link + back/forward, long-prompt clipping, no-prompt sessions, large-session perf. Web-only, single concern → no `/review` mandate (available if wanted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)