### PR TITLE
fix(hook): attribute system-injected UserPromptSubmit blocks to system (#118)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -174,7 +174,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 ### 10.1 Claude Code（首发）
 
 **事件捕获路径**：
-- **Hook 直采**（`SessionStart` / `UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `Stop` / `SubagentStart` / `SubagentStop`）：覆盖 prompt、工具调用与结果、会话/turn 边界、sub-agent 生命周期。事件由 `agent-lens-hook claude` 子命令解析 stdin 并 POST 到 Ingest；Ingest 不可达时回落 `~/.agent-lens/sessions/<sid>.ndjson` 文件 sink，供日后 `agent-lens replay`。
+- **Hook 直采**（`SessionStart` / `UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `Stop` / `SubagentStart` / `SubagentStop`）：覆盖 prompt、工具调用与结果、会话/turn 边界、sub-agent 生命周期。`UserPromptSubmit` 中的系统注入块(后台任务完成的 `<task-notification>`、`<system-reminder>` 等)归 `actor=system` 并带 `payload.source`,不被当作人类 prompt(#118)。事件由 `agent-lens-hook claude` 子命令解析 stdin 并 POST 到 Ingest；Ingest 不可达时回落 `~/.agent-lens/sessions/<sid>.ndjson` 文件 sink，供日后 `agent-lens replay`。
 - **Transcript 旁路**（`Stop` 触发时）：读取 hook payload 的 `transcript_path`，对自上次 cursor 起新增的 jsonl 行做增量解析，提取每个 assistant 消息的 `thinking` 与 `text` content block：
   - `thinking` block → `EVENT_KIND_THOUGHT`
   - `text` block → `EVENT_KIND_DECISION`，payload.marker = `assistant_message`

--- a/cmd/agent-lens-hook/claude.go
+++ b/cmd/agent-lens-hook/claude.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/dong-qiu/agent-lens/internal/redact"
@@ -138,7 +139,37 @@ func makePrompt(in *claudeHookInput) map[string]any {
 	if n > 0 {
 		payload["redacted_count"] = n
 	}
-	return baseEvent(in, map[string]any{"type": "human", "id": "user"}, "prompt", payload)
+	// UserPromptSubmit also fires for system-injected blocks — a backgrounded
+	// task / sub-agent completion (<task-notification>) or a system nudge
+	// (<system-reminder>) — which are NOT human input. Attribute them to the
+	// system and record payload.source so "who said what" stays honest and
+	// "human prompt" queries don't over-count (issue #118). Detection is on the
+	// raw prompt (the structural tag survives redaction and rides at the head).
+	actor := map[string]any{"type": "human", "id": "user"}
+	if src := injectedPromptSource(in.Prompt); src != "" {
+		actor = map[string]any{"type": "system", "id": "claude-code"}
+		payload["source"] = src
+	}
+	return baseEvent(in, actor, "prompt", payload)
+}
+
+// injectedPromptSource classifies a UserPromptSubmit body that is actually a
+// system-injected block rather than human input, returning a low-cardinality
+// source label ("" for a genuine human prompt). Conservative on purpose:
+// only clearly system-generated blocks are matched — slash-command echoes are
+// human-initiated and intentionally left as human input. Content-based because
+// the hook payload carries no source field; the blocks open with known tags.
+func injectedPromptSource(prompt string) string {
+	t := strings.TrimLeft(prompt, " \t\r\n")
+	switch {
+	case strings.HasPrefix(t, "<task-notification"):
+		return "task_notification"
+	case strings.HasPrefix(t, "<system-reminder"):
+		return "system_reminder"
+	case strings.HasPrefix(t, "<task-reminder"):
+		return "task_reminder"
+	}
+	return ""
 }
 
 func makeToolCall(in *claudeHookInput) map[string]any {

--- a/cmd/agent-lens-hook/claude_test.go
+++ b/cmd/agent-lens-hook/claude_test.go
@@ -58,6 +58,67 @@ func TestBuildEventsUserPromptRedacts(t *testing.T) {
 	}
 }
 
+func TestMakePromptHumanUnchanged(t *testing.T) {
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "UserPromptSubmit",
+		SessionID:     "s1",
+		Prompt:        "build me an X",
+	})
+	actor := evs[0]["actor"].(map[string]any)
+	if actor["type"] != "human" || actor["id"] != "user" {
+		t.Errorf("actor = %+v, want human/user", actor)
+	}
+	if _, ok := evs[0]["payload"].(map[string]any)["source"]; ok {
+		t.Errorf("a genuine human prompt should not carry payload.source")
+	}
+}
+
+// TestMakePromptInjectedAttributedToSystem guards issue #118: system-injected
+// UserPromptSubmit blocks must be attributed to the system, not the human, and
+// carry a source discriminator.
+func TestMakePromptInjectedAttributedToSystem(t *testing.T) {
+	cases := []struct{ name, prompt, wantSource string }{
+		{"task-notification", "<task-notification>\n<task-id>blr2t3oka</task-id>\n<status>completed</status>\n</task-notification>", "task_notification"},
+		{"system-reminder", "<system-reminder>Plan mode is active.</system-reminder>", "system_reminder"},
+		{"leading whitespace", "\n  <task-notification><task-id>x</task-id></task-notification>", "task_notification"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			evs, _ := buildEvents(&claudeHookInput{
+				HookEventName: "UserPromptSubmit",
+				SessionID:     "s1",
+				Prompt:        tc.prompt,
+			})
+			if evs[0]["kind"] != "prompt" {
+				t.Fatalf("kind = %v, want prompt", evs[0]["kind"])
+			}
+			actor := evs[0]["actor"].(map[string]any)
+			if actor["type"] != "system" || actor["id"] != "claude-code" {
+				t.Errorf("actor = %+v, want system/claude-code", actor)
+			}
+			if got := evs[0]["payload"].(map[string]any)["source"]; got != tc.wantSource {
+				t.Errorf("payload.source = %v, want %v", got, tc.wantSource)
+			}
+		})
+	}
+}
+
+func TestInjectedPromptSource(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"build me an X", ""},
+		{"<div> is broken, fix it", ""}, // human prompt that merely starts with "<"
+		{"<task-notification><task-id>x</task-id></task-notification>", "task_notification"},
+		{"  \n<system-reminder>hi</system-reminder>", "system_reminder"},
+		{"<task-reminder>do the thing</task-reminder>", "task_reminder"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := injectedPromptSource(tc.in); got != tc.want {
+			t.Errorf("injectedPromptSource(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestBuildEventsPreToolUse(t *testing.T) {
 	evs, _ := buildEvents(&claudeHookInput{
 		HookEventName: "PreToolUse",


### PR DESCRIPTION
Closes #118.

## Problem
`makePrompt` tagged **every** `UserPromptSubmit` event as `actor=human/user`. Claude Code fires `UserPromptSubmit` for **system-injected** blocks too — a backgrounded task / sub-agent completion (`<task-notification>`), a system nudge (`<system-reminder>`) — which are **not** human input. They were recorded as human prompts, mis-attributing machine content to the user and inflating "human prompt" counts. (Surfaced by the Story view, which titled turns with the raw `<task-notification>` XML.)

## Fix
`injectedPromptSource` classifies a prompt body by its opening tag; on a match the event is attributed **`actor=system/claude-code`** with a **`payload.source`** discriminator (`task_notification` / `system_reminder` / `task_reminder`), mirroring #101's `payload.skill` pattern. Raw text is still captured (forensic fidelity) — only the classification changes.

- **Content-based detection** because the hook payload carries no source field; a future Claude Code source field would be preferable (noted in code).
- **Conservative whitelist** — only clearly system-generated blocks. **Slash-command echoes are human-initiated and intentionally left as human input**, so this is *narrower* than the web `parsePrompt` whitelist (which only relabels turn titles, display-only).
- **SPEC §10.1** notes the attribution.

## Tests
Human prompt unchanged (no `source`); injected blocks → `actor=system` + correct `source` (task-notification / system-reminder / leading-whitespace); `injectedPromptSource` table including a human `"<div>…"` that must NOT match. `go vet` clean; `agent-lens-hook` package green in isolation (5/5).

## ⚠️ Pre-existing flake observed (not from this PR) → #120
During /self-review, `go test ./...` (parallel) intermittently failed `TestExportCodeProvenanceEndToEnd` (a positional `pred.Events[2]` assertion). **Confirmed pre-existing**: reproduces on clean `origin/main` via `git stash`, and the test passes 5/5 in isolation; this PR's change is prompt-only and the assertion is about a tool_call. Filed as **#120**. CI's `go test -race ./...` could in principle hit it (has been green across recent PRs).

## Relation
- Display-layer workaround already shipped in #119 (Story view relabels these); this is the data-layer fix. New captures now carry correct attribution; already-stored events are immutable and keep the old `actor=human`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)