### PR TITLE
feat(hook): 接受并实现 ADR 0012 — 订阅 SessionEnd 补齐会话边界

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -285,7 +285,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 | R7 | 跨厂商 TokenUsage 可比性：OpenCode / Cursor / 自研 Agent 的 usage schema 不一致——尤其 cache 语义(Anthropic 是 TTL 分桶 + 写入按倍率,OpenAI 是缓存输入打折)无法用同一字段名表达。SDK 层定义最小公约数 `TokenUsage`(input / output 通用,cache 字段按需扩展),vendor 字段保留出处,聚合时按 vendor 分组而非强行求和。详见 ADR 0002 D2。 |
 | R8 | Compaction 与部分 context 变换在 §10.1 hook 路径仅能启发式探测，精确建模等 §10.4 代理深模式或 IDE 插件层。事件载体（`context_transform`）已就位，`loss_hint.confidence = inferred / observed` 标记区分，审计端不会被静默漏报。详见 ADR 0005 D5。 |
 | R9 | 「某 skill 的指令正文是否进入了某一轮 context」无法从 §10.1 hook 路径验证——hook 不暴露 system prompt / context 窗口，Claude Code 也没有 skill-load hook。可得的只有两个间接信号：skill 文件在磁盘上的存在性（ADR 0003 `agent_config_snapshot` config bundle 快照）与 skill 被**调用**（`Skill` 工具的 PreToolUse / PostToolUse，见 issue #101）。精确的「context 此刻含 skill X 指令」断言等 §10.4 代理深模式。审计端据此把 skill **可用性** 与 skill **调用** 分别建模，不假装能证明 context 成分。 |
-| R10 | `SessionEnd` 在进程崩溃 / 被 kill 时不发（hook 没机会运行）——会话闭边界靠「有 `session_start` 无对应 `session_end` 收尾」反推。正常退出（`reason=prompt_input_exit`）、`/clear`（`clear`）已实测发 `session_end`（2026-05-31 抓样）；同一 `session_id` 跨多次退出 / resume 续接可发**多条** `session_end`。详见 ADR 0012。 |
+| R10 | `SessionEnd` 在进程崩溃 / 被 kill 时不发（hook 没机会运行）——会话闭边界靠「有 `session_start` 无对应 `session_end` 收尾」反推。正常退出（`reason=prompt_input_exit`）、`/clear`（`clear`）、会话内 `/resume` 切走（`resume`）均已实测发 `session_end`（2026-05-31 抓样）；同一 `session_id` 跨多次退出 / resume 续接可发**多条** `session_end`。详见 ADR 0012。 |
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,9 @@
 # Agent Lens — 项目 SPEC
 
-> 版本：v0.6（2026-05-12）
+> 版本：v0.7（2026-05-30）
 > 状态：草案 / 规划阶段
+>
+> v0.7 变更：订阅 `SessionEnd` hook，给会话补显式闭边界（`decision.session_end` + `reason`）；`SessionStart` 增采 `source`（startup/resume/clear/compact）。详见 `docs/ADR/0012-session-end-hook.md`。
 >
 > v0.6 变更：把"agent 决策时所处配置"、"人对 agent 行为的反馈"、"context 在 turn 间的有损变换"分别升为头等事件，新增 EventKind `agent_config_snapshot` / `human_intervention` / `context_transform`。新增 Link.relation `intervenes`。新增 R8（compaction 启发式建模）。capture-time attestation 内联进配置快照，与事件 hash chain 同节点定锚。详见 `docs/ADR/0003-agent-config-snapshot.md` / `0004-human-intervention-events.md` / `0005-context-transform-events.md`。
 >
@@ -174,7 +176,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 ### 10.1 Claude Code（首发）
 
 **事件捕获路径**：
-- **Hook 直采**（`SessionStart` / `UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `Stop` / `SubagentStart` / `SubagentStop`）：覆盖 prompt、工具调用与结果、会话/turn 边界、sub-agent 生命周期。`UserPromptSubmit` 中的系统注入块(后台任务完成的 `<task-notification>`、`<system-reminder>` 等)归 `actor=system` 并带 `payload.source`,不被当作人类 prompt(#118)。事件由 `agent-lens-hook claude` 子命令解析 stdin 并 POST 到 Ingest；Ingest 不可达时回落 `~/.agent-lens/sessions/<sid>.ndjson` 文件 sink，供日后 `agent-lens replay`。
+- **Hook 直采**（`SessionStart` / `SessionEnd` / `UserPromptSubmit` / `PreToolUse` / `PostToolUse` / `Stop` / `SubagentStart` / `SubagentStop`）：覆盖 prompt、工具调用与结果、会话/turn 边界、sub-agent 生命周期。`SessionStart` 派生 `decision.session_start`（含 `source`：startup/resume/clear/compact）、`SessionEnd` 派生 `decision.session_end`（含 `reason`：clear/resume/logout/prompt_input_exit/…），给会话显式闭边界；resume 续接按 `source`/`reason` 配对还原，崩溃 / 被 kill 时无 `session_end`、靠"未收尾"反推（详见 ADR 0012）。`UserPromptSubmit` 中的系统注入块(后台任务完成的 `<task-notification>`、`<system-reminder>` 等)归 `actor=system` 并带 `payload.source`,不被当作人类 prompt(#118)。事件由 `agent-lens-hook claude` 子命令解析 stdin 并 POST 到 Ingest；Ingest 不可达时回落 `~/.agent-lens/sessions/<sid>.ndjson` 文件 sink，供日后 `agent-lens replay`。
 - **Transcript 旁路**（`Stop` 触发时）：读取 hook payload 的 `transcript_path`，对自上次 cursor 起新增的 jsonl 行做增量解析，提取每个 assistant 消息的 `thinking` 与 `text` content block：
   - `thinking` block → `EVENT_KIND_THOUGHT`
   - `text` block → `EVENT_KIND_DECISION`，payload.marker = `assistant_message`

--- a/SPEC.md
+++ b/SPEC.md
@@ -285,6 +285,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 | R7 | 跨厂商 TokenUsage 可比性：OpenCode / Cursor / 自研 Agent 的 usage schema 不一致——尤其 cache 语义(Anthropic 是 TTL 分桶 + 写入按倍率,OpenAI 是缓存输入打折)无法用同一字段名表达。SDK 层定义最小公约数 `TokenUsage`(input / output 通用,cache 字段按需扩展),vendor 字段保留出处,聚合时按 vendor 分组而非强行求和。详见 ADR 0002 D2。 |
 | R8 | Compaction 与部分 context 变换在 §10.1 hook 路径仅能启发式探测，精确建模等 §10.4 代理深模式或 IDE 插件层。事件载体（`context_transform`）已就位，`loss_hint.confidence = inferred / observed` 标记区分，审计端不会被静默漏报。详见 ADR 0005 D5。 |
 | R9 | 「某 skill 的指令正文是否进入了某一轮 context」无法从 §10.1 hook 路径验证——hook 不暴露 system prompt / context 窗口，Claude Code 也没有 skill-load hook。可得的只有两个间接信号：skill 文件在磁盘上的存在性（ADR 0003 `agent_config_snapshot` config bundle 快照）与 skill 被**调用**（`Skill` 工具的 PreToolUse / PostToolUse，见 issue #101）。精确的「context 此刻含 skill X 指令」断言等 §10.4 代理深模式。审计端据此把 skill **可用性** 与 skill **调用** 分别建模，不假装能证明 context 成分。 |
+| R10 | `SessionEnd` 在进程崩溃 / 被 kill 时不发（hook 没机会运行）——会话闭边界靠「有 `session_start` 无对应 `session_end` 收尾」反推。正常退出（`reason=prompt_input_exit`）、`/clear`（`clear`）已实测发 `session_end`（2026-05-31 抓样）；同一 `session_id` 跨多次退出 / resume 续接可发**多条** `session_end`。详见 ADR 0012。 |
 
 ---
 

--- a/cmd/agent-lens-hook/claude.go
+++ b/cmd/agent-lens-hook/claude.go
@@ -40,6 +40,10 @@ type claudeHookInput struct {
 	// response.agentId (issue #85).
 	AgentID   string `json:"agent_id,omitempty"`
 	AgentType string `json:"agent_type,omitempty"`
+	// SessionStart carries source (startup/resume/clear/compact); SessionEnd
+	// carries reason (clear/resume/logout/prompt_input_exit/...). ADR 0012.
+	Source string `json:"source,omitempty"`
+	Reason string `json:"reason,omitempty"`
 }
 
 // runClaude reads a Claude Code hook payload on stdin and forwards a wire
@@ -94,6 +98,8 @@ func buildEvents(in *claudeHookInput) (events []map[string]any, commit func() er
 		return []map[string]any{makeToolResult(in)}, nil
 	case "SessionStart":
 		return []map[string]any{makeSessionStart(in)}, nil
+	case "SessionEnd":
+		return []map[string]any{makeSessionEnd(in)}, nil
 	case "Stop":
 		return makeStopEvents(in)
 	case "SubagentStart":
@@ -273,12 +279,37 @@ func makeSessionStart(in *claudeHookInput) map[string]any {
 		"marker": "session_start",
 		"cwd":    in.CWD,
 	}
+	// SessionStart.source (startup/resume/clear/compact) gives the session a
+	// typed origin; source=resume pairs with SessionEnd.reason=resume to
+	// reconstruct cross-process continuation. ADR 0012 D2. Only `source` is
+	// taken here — model / agent_type / session_title belong to the
+	// agent_config_snapshot (ADR 0003), not loose in this payload.
+	if in.Source != "" {
+		payload["source"] = in.Source
+	}
 	// Capture the project-local Claude Code permission policy in
 	// effect for this session so audit reports can answer "what
 	// authorization rules were running at the time?". Absent settings
 	// is fine — the field is just omitted.
 	if perms := loadPermissionsSnapshot(in.CWD); perms != nil {
 		payload["permissions"] = perms
+	}
+	return baseEvent(in, map[string]any{"type": "system", "id": "claude-code"}, "decision", payload)
+}
+
+// makeSessionEnd captures the Claude Code SessionEnd hook as a decision-marker
+// event, mirroring makeSessionStart, so a session has an explicit closing
+// boundary. reason (clear/resume/logout/prompt_input_exit/...) lets audit
+// distinguish a clean exit from a resume continuation or a /clear. A crash or
+// kill fires no SessionEnd — the absence of session_end is itself the signal.
+// ADR 0012 D1.
+func makeSessionEnd(in *claudeHookInput) map[string]any {
+	payload := map[string]any{
+		"marker": "session_end",
+		"cwd":    in.CWD,
+	}
+	if in.Reason != "" {
+		payload["reason"] = in.Reason
 	}
 	return baseEvent(in, map[string]any{"type": "system", "id": "claude-code"}, "decision", payload)
 }

--- a/cmd/agent-lens-hook/claude_test.go
+++ b/cmd/agent-lens-hook/claude_test.go
@@ -284,6 +284,82 @@ func TestBuildEventsSubagentStartOmitsEmptyIDs(t *testing.T) {
 	}
 }
 
+func TestBuildEventsSessionEnd(t *testing.T) {
+	evs, commit := buildEvents(&claudeHookInput{
+		HookEventName: "SessionEnd",
+		SessionID:     "s1",
+		CWD:           "/repo",
+		Reason:        "logout",
+	})
+	if commit != nil {
+		t.Errorf("SessionEnd should not return a commit fn")
+	}
+	if len(evs) != 1 || evs[0]["kind"] != "decision" {
+		t.Fatalf("got %+v, want one decision event", evs)
+	}
+	ev := evs[0]
+	if actor := ev["actor"].(map[string]any); actor["type"] != "system" || actor["id"] != "claude-code" {
+		t.Errorf("actor = %v, want system/claude-code", actor)
+	}
+	p := ev["payload"].(map[string]any)
+	if p["marker"] != "session_end" {
+		t.Errorf("marker = %v, want session_end", p["marker"])
+	}
+	if p["reason"] != "logout" {
+		t.Errorf("reason = %v, want logout", p["reason"])
+	}
+	if p["cwd"] != "/repo" {
+		t.Errorf("cwd = %v, want /repo", p["cwd"])
+	}
+}
+
+func TestBuildEventsSessionEndOmitsEmptyReason(t *testing.T) {
+	// SessionEnd still emits the boundary marker without a reason; the
+	// optional key is omitted, not null.
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "SessionEnd",
+		SessionID:     "s1",
+	})
+	p := evs[0]["payload"].(map[string]any)
+	if p["marker"] != "session_end" {
+		t.Errorf("marker = %v, want session_end", p["marker"])
+	}
+	if _, ok := p["reason"]; ok {
+		t.Errorf("reason present despite empty input: %+v", p)
+	}
+}
+
+func TestBuildEventsSessionStartCapturesSource(t *testing.T) {
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "SessionStart",
+		SessionID:     "s1",
+		CWD:           "/repo",
+		Source:        "resume",
+	})
+	if len(evs) != 1 || evs[0]["kind"] != "decision" {
+		t.Fatalf("got %+v, want one decision event", evs)
+	}
+	p := evs[0]["payload"].(map[string]any)
+	if p["marker"] != "session_start" {
+		t.Errorf("marker = %v, want session_start", p["marker"])
+	}
+	if p["source"] != "resume" {
+		t.Errorf("source = %v, want resume", p["source"])
+	}
+}
+
+func TestBuildEventsSessionStartOmitsEmptySource(t *testing.T) {
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "SessionStart",
+		SessionID:     "s1",
+		CWD:           "/repo",
+	})
+	p := evs[0]["payload"].(map[string]any)
+	if _, ok := p["source"]; ok {
+		t.Errorf("source present despite empty input: %+v", p)
+	}
+}
+
 func TestBuildEventsUnknown(t *testing.T) {
 	evs, _ := buildEvents(&claudeHookInput{HookEventName: "Mystery", SessionID: "s1"})
 	if len(evs) != 0 {

--- a/cmd/agent-lens-hook/setup.go
+++ b/cmd/agent-lens-hook/setup.go
@@ -62,6 +62,7 @@ Exit codes: 0 success, 2 usage / IO / docker errors.
 // stop being captured silently.
 var setupHookEvents = []string{
 	"SessionStart",
+	"SessionEnd",
 	"UserPromptSubmit",
 	"PreToolUse",
 	"PostToolUse",

--- a/docs/ADR/0012-session-end-hook.md
+++ b/docs/ADR/0012-session-end-hook.md
@@ -33,7 +33,7 @@ Claude Code 官方 hooks 文档(https://code.claude.com/docs/en/hooks,2026-05-29
 - ✅ **字段名确认**:真实 SessionEnd stdin payload 的字段就是顶层 **`reason`**(非 `end_reason`、非嵌套),`claude.go` 的 `json:"reason"` 正确,无需改码。
 - ✅ **取值**:观测到 `prompt_input_exit`(正常退出)、`clear`(`/clear`),均在文档集合内。
 - 📌 **同 session 多条**:同一 `session_id` 跨多次退出 / 续接会发**多条** `session_end`(实测一个 id 出现 3 条 `prompt_input_exit`)——据此修正 §后果"每 session 1 条"。
-- ⏳ 未观测到 `reason=resume`(本次未触发到该退出路径),文档值保留待后续遇到时确认。
+- ✅ **`reason=resume` 确认**:在活动会话内用 `/resume` **切走到另一段对话**时,被离开的会话发 `session_end` 带 `reason=resume`(实测:新会话切走得 `resume`;被切入的会话随后正常退出得 `prompt_input_exit`)。即 `resume` = "会话被存盘待续"而非终止。
 - 进程崩溃 / 被 kill 时不发 `SessionEnd`(预期,hook 没机会跑),会话靠"无 session_end 收尾"反推——已记入 §15 R10。
 
 抓样方法:临时项目级 SessionEnd dump hook(`cat >> …`),触发正常退出 / `/clear` / resume,读原始 payload(ADR 0002 同款覆盖度记录)。

--- a/docs/ADR/0012-session-end-hook.md
+++ b/docs/ADR/0012-session-end-hook.md
@@ -1,0 +1,89 @@
+# ADR 0012:订阅 SessionEnd,补齐会话边界
+
+- 状态:Accepted
+- 日期:2026-05-29
+- 取代:—
+
+## 背景
+
+会话当前只有开、没有闭。已订阅 `SessionStart`(`claude.go:95`、派生 `decision.session_start`),但**没有 `SessionEnd`**。会话结束只能靠 `Stop` hook 的 `turn_end` marker 推断,而 `turn_end` 是 **turn** 边界不是 **session** 边界——分不清"正常退出 / 清空上下文(clear)/ 退出后又 resume 续接 / 进程崩溃"。
+
+一个 resume 续接的 session 会有多段 turn 串在同一 `session_id` 下,没有 `session_end` 就无法分段,审计端读不出"这里其实断过一次"。这是"Claude Code 提供了 hook、我们没订阅"的现成盲区。
+
+> 本 ADR 原与 PreCompact 合并(草案早期版本)。考虑到 SessionEnd 只复用既有 `decision` marker、**今天就能独立接受**,而 PreCompact 依赖 ADR 0005 的 `context_transform` EventKind 先落地、接受时机不同步,故拆分:PreCompact 移至 ADR 0013。
+
+## 验证
+
+Claude Code 官方 hooks 文档(https://code.claude.com/docs/en/hooks,2026-05-29 抓取核对):
+
+| Hook | 触发时机 | 关键 payload / matcher |
+|---|---|---|
+| `SessionEnd` | 会话终止时 | matcher 按 **`reason`**:`clear` / `resume` / `logout` / `prompt_input_exit` / `bypass_permissions_disabled` / `other`;不可 block |
+| `SessionStart` | 会话开始 / 恢复 | matcher 按 `source`:`startup` / `resume` / `clear` / `compact`;payload 另含 `model`、`agent_type`(可选)、`session_title`(可选) |
+
+关键观察与**修正**:
+
+- `SessionEnd` 的 matcher / 字段是 **`reason`**(早期草案写作 `end_reason`,经文档核对纠正为 `reason`)。
+- `SessionStart.source = resume` 与 `SessionEnd.reason = resume` 配对,能还原跨进程的 session 续接。
+- `SessionStart` 除 `source` 外还暴露 `model`、`agent_type`、`session_title`——可顺手采下,补强 0003 的 session 锚点(见 D2)。
+- `source = compact` 在一次 compaction 之后触发;ADR 0013 已改用专门的 `PostCompact` 作后括号、不再依赖本字段,故本字段在此仅作 compaction 的辅助佐证,非 0013 的必需前置。
+
+**仍未决、落地前必须抓样核对**:
+
+- `SessionEnd` 的实际 payload 字段名是否就是 `reason`(matcher key 已确认为 `reason`,但 stdin payload 的字段名待抓样确认)。
+- `SessionEnd` 在进程崩溃 / 被 kill 时是否仍发(预期不发——崩溃没机会跑 hook;此时会话只能靠"无 session_end 收尾"反推,需在 §15 标注)。
+
+落地 PR 按 ADR 0002 同款记录覆盖度:用一份正常退出、一次 clear、一次 resume 续接的真实 session 核对上表。
+
+## 决定
+
+### D1. 订阅 `SessionEnd`,派生 `decision` marker `session_end`,镜像 `makeSessionStart`
+
+`buildEvents` 增 `SessionEnd` 分支,派生 `actor=system(claude-code)`、`kind=decision`、`payload.marker=session_end`,带 `reason` 与 `cwd`。形态对称于 `claude.go:271` 的 `makeSessionStart`。
+
+会话从此有显式闭边界;`reason` 让审计端区分"正常退出(prompt_input_exit)/ 清空(clear)/ resume 续接 / logout"。
+
+**否决备选**:继续靠 `Stop` 的 `turn_end` 末条推断会话结束。`turn_end` 是 turn 边界,resume 续接的多段 turn 共享一个 `session_id`,无 `session_end` 无法分段——这正是当前盲点。
+
+**否决备选**:为 `session_end` 新增独立 EventKind。`session_start` 当前就是 `decision` marker(`claude.go:271`),闭边界与开边界同档处理,无需 schema 变更——新增 EventKind 没换来任何区分度。
+
+### D2. `SessionStart` 仅增采 `source`(`model` / `agent_type` 等归 ADR 0003)
+
+`makeSessionStart` 增记 `payload.source`(startup / resume / clear / compact)。这不是新事件,是既有事件的小增强:
+
+- `source=resume` 与 D1 的 `reason=resume` 配对,还原跨进程续接——审计端能把"退出"与"续接"接成一条连续会话史。
+- `source=startup` / `clear` 区分全新会话 vs 清空上下文重开;`source=compact` 仅作 compaction 的辅助佐证(0013 的后括号已改用 `PostCompact`,不依赖此字段)。
+
+**只采 `source`,不采 `model` / `agent_type` / `session_title`**:文档显示 SessionStart payload 还含这几项,但它们属于 agent 配置 / 身份,归 ADR 0003 的 `agent_config_snapshot`——0003 在同一 SessionStart 起快照(bundle 含 model 等),且 `makeSessionStart` 今天已把 `permissions` 写进该 payload(`claude.go:280`)。若本 ADR 再把 `model` 松散写进 SessionStart payload,就成了"什么 model"的第二个真相源,与 0003 的配置漂移检测可能打架。`source` 是 session **边界**语义(本 ADR 的 domain),与 0003 的配置快照不重叠,故只采它。
+
+**否决备选**:顺手把 `model` / `agent_type` 一并采下("零成本")。这正是"无害多采一个字段"的反例:当字段落在另一份 ADR(0003)拥有的 payload 上,就制造静默的双写漂移;需要它们时由 0003 的快照承载,不在此重复。
+**否决备选**:不动 `SessionStart`。`source` 是 resume 配对的必需,且与 0003 无重叠,采了划算。
+
+### D3. 纯观测、绝不 block、fail-soft
+
+`SessionEnd` 本就不可 block。解析失败 warn 到 stderr、一律 `os.Exit(0)`,与现有所有 hook 分支一致(`claude.go:80`),绝不中断 Claude Code。
+
+## Scope
+
+本 ADR 只做文档。落地涉及:
+
+- `proto/event.proto`:**不变**——`SessionEnd` 复用 `decision` marker。
+- `cmd/agent-lens-hook/setup.go`:hook 订阅列表增 `SessionEnd`。
+- `cmd/agent-lens-hook/claude.go`:`buildEvents` 增 `SessionEnd` 分支;`makeSessionStart` 增 `source`。
+- `internal/linking/`:resume 续接关联(SessionEnd resume ↔ SessionStart resume)。
+- GraphQL + Lens UI:timeline 显式 session 闭边界;会话史按 resume 边界分段。
+
+**本 ADR 不带任何代码改动。**
+
+## 后果
+
+- §10.1 Hook 直采列表增 `SessionEnd`;`SessionStart` 采集字段增 `source`(仅此一项)。
+- §7 `EventKind` 不变(`session_end` 用 `decision` marker,与 `session_start` 同档)。
+- §15:崩溃 / 被 kill 时 `SessionEnd` 不发,会话只能靠"无 session_end 收尾"反推——按 §验证 实测结论加一条已知局限。
+- 与 ADR 0003 的关系:本 ADR**只**增采 `source`(session 边界语义),**不碰** 0003 拥有的 SessionStart 配置 payload(`model` / `agent_type` / `session_title` / `permissions`)——避免对同一 SessionStart payload 的双写漂移。`source` 与 0003 的 bundle 快照正交、同事件、不重叠。
+- 与 ADR 0013 的关系:0013 改用 `PostCompact` 作 compaction 后括号后,**两份 ADR 已互相独立**——本 ADR 的 `source=compact` 仅作 0013 的辅助佐证,非其必需前置;双方均可独立接受,无依赖方向。
+- 数据量:`session_end` 每 session 1 条,可忽略。
+
+## 落地
+
+实现挂本 ADR,与接受同 PR:`SessionEnd` 订阅(setup.go)+ `buildEvents` 的 `SessionEnd` 分支与 `makeSessionEnd`(claude.go)+ `makeSessionStart` 增 `source`,并附单测。`internal/linking` 的 resume 续接关联与 Lens UI 会话分段为后续子项,跟踪 issue 另开。

--- a/docs/ADR/0012-session-end-hook.md
+++ b/docs/ADR/0012-session-end-hook.md
@@ -28,12 +28,15 @@ Claude Code 官方 hooks 文档(https://code.claude.com/docs/en/hooks,2026-05-29
 - `SessionStart` 除 `source` 外还暴露 `model`、`agent_type`、`session_title`——可顺手采下,补强 0003 的 session 锚点(见 D2)。
 - `source = compact` 在一次 compaction 之后触发;ADR 0013 已改用专门的 `PostCompact` 作后括号、不再依赖本字段,故本字段在此仅作 compaction 的辅助佐证,非 0013 的必需前置。
 
-**仍未决、落地前必须抓样核对**:
+**抓样核对结果(2026-05-31,#125 落地前)**:
 
-- `SessionEnd` 的实际 payload 字段名是否就是 `reason`(matcher key 已确认为 `reason`,但 stdin payload 的字段名待抓样确认)。
-- `SessionEnd` 在进程崩溃 / 被 kill 时是否仍发(预期不发——崩溃没机会跑 hook;此时会话只能靠"无 session_end 收尾"反推,需在 §15 标注)。
+- ✅ **字段名确认**:真实 SessionEnd stdin payload 的字段就是顶层 **`reason`**(非 `end_reason`、非嵌套),`claude.go` 的 `json:"reason"` 正确,无需改码。
+- ✅ **取值**:观测到 `prompt_input_exit`(正常退出)、`clear`(`/clear`),均在文档集合内。
+- 📌 **同 session 多条**:同一 `session_id` 跨多次退出 / 续接会发**多条** `session_end`(实测一个 id 出现 3 条 `prompt_input_exit`)——据此修正 §后果"每 session 1 条"。
+- ⏳ 未观测到 `reason=resume`(本次未触发到该退出路径),文档值保留待后续遇到时确认。
+- 进程崩溃 / 被 kill 时不发 `SessionEnd`(预期,hook 没机会跑),会话靠"无 session_end 收尾"反推——已记入 §15 R10。
 
-落地 PR 按 ADR 0002 同款记录覆盖度:用一份正常退出、一次 clear、一次 resume 续接的真实 session 核对上表。
+抓样方法:临时项目级 SessionEnd dump hook(`cat >> …`),触发正常退出 / `/clear` / resume,读原始 payload(ADR 0002 同款覆盖度记录)。
 
 ## 决定
 
@@ -79,10 +82,10 @@ Claude Code 官方 hooks 文档(https://code.claude.com/docs/en/hooks,2026-05-29
 
 - §10.1 Hook 直采列表增 `SessionEnd`;`SessionStart` 采集字段增 `source`(仅此一项)。
 - §7 `EventKind` 不变(`session_end` 用 `decision` marker,与 `session_start` 同档)。
-- §15:崩溃 / 被 kill 时 `SessionEnd` 不发,会话只能靠"无 session_end 收尾"反推——按 §验证 实测结论加一条已知局限。
+- §15:崩溃 / 被 kill 时 `SessionEnd` 不发,会话只能靠"无 session_end 收尾"反推——已加为 §15 R10(并记入实测:正常退出 / `/clear` 发、同 `session_id` 可多条)。
 - 与 ADR 0003 的关系:本 ADR**只**增采 `source`(session 边界语义),**不碰** 0003 拥有的 SessionStart 配置 payload(`model` / `agent_type` / `session_title` / `permissions`)——避免对同一 SessionStart payload 的双写漂移。`source` 与 0003 的 bundle 快照正交、同事件、不重叠。
 - 与 ADR 0013 的关系:0013 改用 `PostCompact` 作 compaction 后括号后,**两份 ADR 已互相独立**——本 ADR 的 `source=compact` 仅作 0013 的辅助佐证,非其必需前置;双方均可独立接受,无依赖方向。
-- 数据量:`session_end` 每 session 1 条,可忽略。
+- 数据量:`session_end` 每次会话退出 1 条;resume 续接的同一 `session_id` 可多条(实测一个 id 3 条),整体仍可忽略。
 
 ## 落地
 

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -135,6 +135,7 @@ Patch 文件的硬性约束:
 - **0007 Sub-agent(Task 工具)透明度**(草案):父→子 `delegates` link 设计与开放问题。
 - **0008 Sub-agent 自动 link fallback**(草案):v0.1 K1 实证,撤回 `delegates`,落地 fallback。
 - **0009 Sub-agent 父→子自动链接(`delegates`)**(草案):SubagentStart.agent_id ↔ tool_result.agentId 桥接;v0.2 恢复 ADR 0007 D4 / 取代 ADR 0008 D3。
+- **0012 订阅 SessionEnd 补齐会话边界**(Accepted):`SessionEnd` 派生 `decision.session_end`(`reason`)、`SessionStart` 增采 `source`;复用既有 `decision` marker,不新增 EventKind。(0010/0011/0013 草案见 PR #124。)
 
 (0003–0005 接受时的 `spec-patches-pending-0003-0005.md` 已随 #100 合入删除。)
 

--- a/web/src/lib/turns.ts
+++ b/web/src/lib/turns.ts
@@ -90,13 +90,14 @@ function isErrorResult(pl: Record<string, unknown>): boolean {
 
 // isMeaningfulStep excludes plumbing from the step count: tool_result (paired
 // with its call), the opening prompt (shown as the title), and the structural
-// session_start / turn_end decision markers.
+// session_start / session_end / turn_end decision markers.
 function isMeaningfulStep(e: Event): boolean {
   if (e.kind === "TOOL_RESULT" || e.kind === "PROMPT") return false;
   if (e.kind === "DECISION") {
     const pl = (e.payload ?? {}) as Record<string, unknown>;
     const m = asString(pl.marker);
-    if (m === "session_start" || m === "turn_end") return false;
+    if (m === "session_start" || m === "session_end" || m === "turn_end")
+      return false;
     // Empty assistant_message events are synthesized metadata carriers
     // (redacted-thinking / usage), not actions — same rule as the reply chip.
     if (m === "assistant_message" && asString(pl.text).trim() === "") return false;
@@ -201,7 +202,7 @@ export function summarizeTurn(turn: Turn): TurnSummary {
           bump("reply", "💬", "reply", e.id);
         else if (marker === "subagent_start")
           bump(`sub:${asString(pl.agent_type)}`, "🤖", asString(pl.agent_type) || "sub-agent", e.id);
-        break; // session_start / turn_end are structural — omit
+        break; // session_start / session_end / turn_end are structural — omit
       }
       case "REVIEW":
         bump(`review:${e.id}`, "👁", asString(pl.action) || "review", e.id);


### PR DESCRIPTION
接受并实现 **ADR 0012**(从草案 PR #124 拆出独立推进)。两个 commit:

1. **接受(原子,纯文档)**:0012 翻 `草案→Accepted`;改 SPEC §10.1(hook 列表 + `session_start`/`session_end` 边界语义);SPEC `v0.6→v0.7` + 版本注;更新 ADR 索引。
2. **实现(核心采集)**:
   - 订阅 `SessionEnd` hook(`setup.go`)。
   - `buildEvents` 增 `SessionEnd` 分支 + `makeSessionEnd` → `decision` marker `session_end`(带 `reason`、`cwd`),镜像 `makeSessionStart`。
   - `makeSessionStart` 增采 `source`(startup/resume/clear/compact);`source=resume` 与 `reason=resume` 配对还原跨进程续接。
   - **不新增 EventKind**(复用 `decision` marker)。

## 设计要点(ADR 0012)
- **只采 `source`**:`model`/`agent_type`/`session_title` 归 ADR 0003 的 `agent_config_snapshot`,不在 SessionStart payload 双写(避免与配置漂移检测打架)。
- 崩溃 / 被 kill 不发 `SessionEnd`——"无 session_end 收尾"本身即信号。

## 验证
- `go test ./...` **340 passed / 18 packages**;`go vet ./...` 干净。
- 新增单测:SessionEnd 发射 + 空 reason 省略;SessionStart source 采集 + 空 source 省略。
- 机械扫描:无 debug marker;无 proto/gqlgen/web 漂移。

## ⚠️ 需手动冒烟(self-review 覆盖不到)
- 触发一次**真实 SessionEnd**(退出 / `/clear` / resume)确认:`session_end` 事件落库、`reason` 有值。ADR §验证 标注 SessionEnd 的 **stdin 字段名** `reason` 仅由 matcher key 推定、未抓真实 payload;当前 fail-soft(字段缺失只省略 reason、marker 照发)。

## 后续(已显式延后,非本 PR)
- `internal/linking`:resume 续接关联(SessionEnd resume ↔ SessionStart resume)。
- Lens UI:会话显式闭边界 + 按 resume 分段。

## 路径与风险
- 仅动 `cmd/agent-lens-hook`(非 `main.go`/attest/hashchain/release/Dockerfile)+ docs/SPEC → 单包小改,`/self-review` 足够(已过)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)