### PR TITLE
fix(hook): 同步 settings.example.json 到 setupHookEvents (#126 item 1)

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -1,5 +1,21 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "agent-lens-hook claude", "timeout": 5}
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "agent-lens-hook claude", "timeout": 5}
+        ]
+      }
+    ],
     "UserPromptSubmit": [
       {
         "matcher": "*",
@@ -24,19 +40,27 @@
         ]
       }
     ],
-    "SessionStart": [
-      {
-        "matcher": "startup",
-        "hooks": [
-          {"type": "command", "command": "agent-lens-hook claude", "timeout": 5}
-        ]
-      }
-    ],
     "Stop": [
       {
         "matcher": "*",
         "hooks": [
           {"type": "command", "command": "agent-lens-hook claude", "timeout": 30}
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "agent-lens-hook claude", "timeout": 5}
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "agent-lens-hook claude", "timeout": 5}
         ]
       }
     ]

--- a/cmd/agent-lens-hook/setup_test.go
+++ b/cmd/agent-lens-hook/setup_test.go
@@ -9,8 +9,49 @@ import (
 	"testing"
 )
 
-// TestMergeAgentLensHooksFreshFile: empty / missing settings.json → all
-// 5 events get our hook entry, no other keys appear.
+// TestSettingsExampleCoversAllHookEvents guards against
+// .claude/settings.example.json drifting behind setupHookEvents — the drift
+// that left SessionEnd / SubagentStart / SubagentStop uncaptured for dogfood
+// installs (issue #126). install-dogfood.sh copies this static example, so
+// every event the `setup` command would register must also appear here.
+func TestSettingsExampleCoversAllHookEvents(t *testing.T) {
+	path := filepath.Join("..", "..", ".claude", "settings.example.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var cfg struct {
+		Hooks map[string][]struct {
+			Hooks []struct {
+				Command string `json:"command"`
+			} `json:"hooks"`
+		} `json:"hooks"`
+	}
+	if err := json.Unmarshal(raw, &cfg); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	for _, ev := range setupHookEvents {
+		matchers, ok := cfg.Hooks[ev]
+		if !ok || len(matchers) == 0 {
+			t.Errorf("settings.example.json missing hook event %q (it is in setupHookEvents)", ev)
+			continue
+		}
+		wired := false
+		for _, m := range matchers {
+			for _, h := range m.Hooks {
+				if strings.Contains(h.Command, "agent-lens-hook") {
+					wired = true
+				}
+			}
+		}
+		if !wired {
+			t.Errorf("event %q present in example but no agent-lens-hook command wired", ev)
+		}
+	}
+}
+
+// TestMergeAgentLensHooksFreshFile: empty / missing settings.json → every
+// setupHookEvents event gets our hook entry, no other keys appear.
 func TestMergeAgentLensHooksFreshFile(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "settings.json")


### PR DESCRIPTION
#126 第 1 项:`.claude/settings.example.json`(install-dogfood.sh 拷贝的静态文件)落后于 Go 的 `setupHookEvents`,导致 dogfood 静默漏采。

## 修复
- 补 `SessionEnd`(ADR 0012)、`SubagentStart`/`SubagentStop`(#85),均 matcher `*`。
- `SessionStart` matcher 由 `startup` 放宽到 `*`(否则 `source=resume/clear/compact` 不触发)。
- 新增 `TestSettingsExampleCoversAllHookEvents`:example 再落后于 `setupHookEvents` 就直接测试失败(用会跑的代码守,而非靠文档)。

## 影响 / 风险
- 只改**示例**配置 + 测试,**无代码路径变更**;实际 dogfood 用的 `settings.local.json`(gitignored)需用户重拷或 `agent-lens-hook setup` 才生效。
- `go test ./cmd/agent-lens-hook` 全过、`go vet` 干净、JSON 合法。
- 未触碰 attest/hashchain/release/Dockerfile → `/self-review` 足够。

Part of #126(item 1);item 2 linker resume 配对、item 3 Lens UI 会话分段后续另开 PR。

🤖 Generated with [Claude Code](https://claude.com/claude-code)