### PR TITLE
feat(web): 会话 episode 分段(#126 items 2+3)

### DIFF
--- a/web/src/components/StoryTimeline.tsx
+++ b/web/src/components/StoryTimeline.tsx
@@ -8,9 +8,11 @@ import {
   groupIntoTurns,
   summarizeTurn,
   formatDuration,
+  turnBoundaries,
   type Turn,
   type TurnSummary,
   type Initiator,
+  type BoundaryMark,
 } from "../lib/turns";
 
 // Per-initiator left-border colour + glyph: who drove the turn at a glance.
@@ -162,20 +164,54 @@ export function StoryTimeline({ sessionId }: { sessionId: string }) {
         <div className="text-sm text-zinc-500">No turns match the current filter.</div>
       ) : (
         <div className="space-y-3">
-          {rows.map(({ turn, summary, index }) => (
-            <TurnCard
-              key={turn.key}
-              turn={turn}
-              summary={summary}
-              index={index}
-              open={openKeys.has(turn.key)}
-              flashId={flashId}
-              onToggle={() => setOpen(turn.key, !openKeys.has(turn.key))}
-              onJumpTo={(eventId) => jumpTo(turn.key, eventId)}
-            />
-          ))}
+          {rows.map(({ turn, summary, index }) => {
+            const bounds = turnBoundaries(turn);
+            return (
+              <div key={turn.key} className="space-y-3">
+                {bounds
+                  .filter((b) => b.position === "before")
+                  .map((b, i) => (
+                    <SessionDivider key={`before-${i}`} mark={b} />
+                  ))}
+                <TurnCard
+                  turn={turn}
+                  summary={summary}
+                  index={index}
+                  open={openKeys.has(turn.key)}
+                  flashId={flashId}
+                  onToggle={() => setOpen(turn.key, !openKeys.has(turn.key))}
+                  onJumpTo={(eventId) => jumpTo(turn.key, eventId)}
+                />
+                {bounds
+                  .filter((b) => b.position === "after")
+                  .map((b, i) => (
+                    <SessionDivider key={`after-${i}`} mark={b} />
+                  ))}
+              </div>
+            );
+          })}
         </div>
       )}
+    </div>
+  );
+}
+
+// SessionDivider marks a session-episode boundary between turns — a closing
+// SessionEnd (grey) or a reopening resume/clear/compact SessionStart (amber) —
+// so a resumed/cleared session_id reads as distinct episodes. See ADR 0012.
+function SessionDivider({ mark }: { mark: BoundaryMark }) {
+  const isEnd = mark.tone === "end";
+  return (
+    <div className="flex items-center gap-2 py-0.5" role="separator" aria-label={mark.label}>
+      <span className="h-px flex-1 bg-zinc-200" />
+      <span
+        className={`rounded-full px-2 py-0.5 text-[11px] font-medium ${
+          isEnd ? "bg-zinc-100 text-zinc-500" : "bg-amber-50 text-amber-700"
+        }`}
+      >
+        {isEnd ? "■" : "▸"} {mark.label}
+      </span>
+      <span className="h-px flex-1 bg-zinc-200" />
     </div>
   );
 }

--- a/web/src/components/StoryTimeline.tsx
+++ b/web/src/components/StoryTimeline.tsx
@@ -168,11 +168,6 @@ export function StoryTimeline({ sessionId }: { sessionId: string }) {
             const bounds = turnBoundaries(turn);
             return (
               <div key={turn.key} className="space-y-3">
-                {bounds
-                  .filter((b) => b.position === "before")
-                  .map((b, i) => (
-                    <SessionDivider key={`before-${i}`} mark={b} />
-                  ))}
                 <TurnCard
                   turn={turn}
                   summary={summary}
@@ -182,11 +177,9 @@ export function StoryTimeline({ sessionId }: { sessionId: string }) {
                   onToggle={() => setOpen(turn.key, !openKeys.has(turn.key))}
                   onJumpTo={(eventId) => jumpTo(turn.key, eventId)}
                 />
-                {bounds
-                  .filter((b) => b.position === "after")
-                  .map((b, i) => (
-                    <SessionDivider key={`after-${i}`} mark={b} />
-                  ))}
+                {bounds.map((b, i) => (
+                  <SessionDivider key={`bound-${i}`} mark={b} />
+                ))}
               </div>
             );
           })}

--- a/web/src/lib/turns.ts
+++ b/web/src/lib/turns.ts
@@ -74,12 +74,11 @@ const asString = (v: unknown): string => (typeof v === "string" ? v : "");
 // A session episode boundary derived from the structural markers Claude Code
 // emits: SessionEnd (with `reason`) closes an episode; a non-startup
 // SessionStart (`source` = resume/clear/compact) opens one. Rendered as a
-// divider between turns so a single session_id that was resumed / cleared /
-// compacted reads as distinct episodes rather than one undifferentiated
-// stream. The initial `startup` is the session's opening, not a divider.
-// ADR 0012, issue #126.
+// divider after the turn that carries the marker so a single session_id that
+// was resumed / cleared / compacted reads as distinct episodes rather than one
+// undifferentiated stream. The initial `startup` is the session's opening, not
+// a divider. ADR 0012, issue #126.
 export interface BoundaryMark {
-  position: "before" | "after";
   tone: "end" | "start";
   label: string;
 }
@@ -90,10 +89,13 @@ const SOURCE_LABEL: Record<string, string> = {
   compact: "resumed after compaction",
 };
 
-// turnBoundaries extracts the session-episode dividers carried by a turn's
-// own events. A turn can carry more than one (e.g. ends then a later start),
-// so the result is ordered; callers render `before` marks above the turn card
-// and `after` marks below it.
+// turnBoundaries extracts the session-episode dividers carried by a turn's own
+// events, in event order. groupIntoTurns folds the events that precede the next
+// prompt (a SessionEnd, then the resuming SessionStart) onto the *tail* of the
+// current turn, so every boundary marker sits at the end of its turn — callers
+// render these dividers *after* the turn card, which places them chronologically
+// between the closing episode and the next one. A turn can carry more than one
+// (close then reopen), hence a list.
 export function turnBoundaries(turn: Turn): BoundaryMark[] {
   const marks: BoundaryMark[] = [];
   for (const e of turn.events) {
@@ -103,7 +105,6 @@ export function turnBoundaries(turn: Turn): BoundaryMark[] {
     if (marker === "session_end") {
       const reason = asString(pl.reason);
       marks.push({
-        position: "after",
         tone: "end",
         label: reason ? `session ended · ${reason}` : "session ended",
       });
@@ -111,7 +112,6 @@ export function turnBoundaries(turn: Turn): BoundaryMark[] {
       const source = asString(pl.source);
       if (source && source !== "startup") {
         marks.push({
-          position: "before",
           tone: "start",
           label: SOURCE_LABEL[source] ?? `resumed · ${source}`,
         });

--- a/web/src/lib/turns.ts
+++ b/web/src/lib/turns.ts
@@ -71,6 +71,56 @@ export interface TurnSummary {
 
 const asString = (v: unknown): string => (typeof v === "string" ? v : "");
 
+// A session episode boundary derived from the structural markers Claude Code
+// emits: SessionEnd (with `reason`) closes an episode; a non-startup
+// SessionStart (`source` = resume/clear/compact) opens one. Rendered as a
+// divider between turns so a single session_id that was resumed / cleared /
+// compacted reads as distinct episodes rather than one undifferentiated
+// stream. The initial `startup` is the session's opening, not a divider.
+// ADR 0012, issue #126.
+export interface BoundaryMark {
+  position: "before" | "after";
+  tone: "end" | "start";
+  label: string;
+}
+
+const SOURCE_LABEL: Record<string, string> = {
+  resume: "resumed",
+  clear: "cleared — fresh context",
+  compact: "resumed after compaction",
+};
+
+// turnBoundaries extracts the session-episode dividers carried by a turn's
+// own events. A turn can carry more than one (e.g. ends then a later start),
+// so the result is ordered; callers render `before` marks above the turn card
+// and `after` marks below it.
+export function turnBoundaries(turn: Turn): BoundaryMark[] {
+  const marks: BoundaryMark[] = [];
+  for (const e of turn.events) {
+    if (e.kind !== "DECISION") continue;
+    const pl = (e.payload ?? {}) as Record<string, unknown>;
+    const marker = asString(pl.marker);
+    if (marker === "session_end") {
+      const reason = asString(pl.reason);
+      marks.push({
+        position: "after",
+        tone: "end",
+        label: reason ? `session ended · ${reason}` : "session ended",
+      });
+    } else if (marker === "session_start") {
+      const source = asString(pl.source);
+      if (source && source !== "startup") {
+        marks.push({
+          position: "before",
+          tone: "start",
+          label: SOURCE_LABEL[source] ?? `resumed · ${source}`,
+        });
+      }
+    }
+  }
+  return marks;
+}
+
 // Prompt classification (human vs system-injected block) is shared with the
 // EventCard via lib/prompts.ts.
 


### PR DESCRIPTION
#126 第 2+3 项(按 issue 内 **option B** 决定合并):Story 视图把一个被 resume/clear/compact 的 `session_id` 显式切成 episode。

## 做法(无 schema、无 ADR)
- `turns.ts` 加纯函数 `turnBoundaries(turn)`:从 ADR 0012 现采的 marker 派生边界——`session_end`(带 `reason`)闭合 episode、非 startup 的 `session_start`(`source`=resume/clear/compact)开启 episode。
- `StoryTimeline` 在 turn 卡片间渲染 `SessionDivider`:灰色「■ session ended · <reason>」/ 琥珀「▸ resumed」。
- 边界纯在 query/UI 层派生,**不新增 Link 关系、不改 schema、不起 ADR**(#126 option B)。

## ⚠️ 需手动冒烟(self-review 不覆盖视觉/感知)
- 在跑起来的 Lens UI 里开一个被 `/resume` 过、或 `/clear` 过的会话,确认:分隔条出现在正确位置、文案/配色清晰、不破坏既有 turn 间距。
- 已知限制:`session_start` 落在"下个 prompt 之前所属的 turn"里,故 resume 分隔条位置是启发式的、可能不精确落在 episode 缝。被过滤掉的 turn 其边界条也随之不显示(可接受)。

## 验证
- `tsc --noEmit` 干净;web-only,无 Go/proto/schema 改动 → `/self-review` 足够(已过)。

Part of #126(items 2+3;item 1 = #127)。两者都合并后 #126 可关。

🤖 Generated with [Claude Code](https://claude.com/claude-code)