### PR TITLE
fix(web): 单数步数显示「1 step」

### DIFF
--- a/web/src/components/StoryTimeline.tsx
+++ b/web/src/components/StoryTimeline.tsx
@@ -272,7 +272,9 @@ function TurnCard({
             </span>
             <span aria-hidden>→</span>
             <span>🤖 {s.model ?? "agent"}</span>
-            <span className="text-zinc-400">· {s.steps} steps</span>
+            <span className="text-zinc-400">
+              · {s.steps} {s.steps === 1 ? "step" : "steps"}
+            </span>
             {s.durationMs != null && (
               <span className="text-zinc-400">· {formatDuration(s.durationMs)}</span>
             )}


### PR DESCRIPTION
Story 视图 turn 头一直显示「N steps」,单步 turn 现读作「1 step」。#128 像素冒烟时发现的纯文案瑕疵,与功能无关。

`tsc --noEmit` 干净;web-only。

🤖 Generated with [Claude Code](https://claude.com/claude-code)