### PR TITLE
feat(hook): 接受并实现 ADR 0011 — 本地 test_run 采集

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,9 @@
 # Agent Lens — 项目 SPEC
 
-> 版本：v0.7（2026-05-30）
+> 版本：v0.8（2026-05-31）
 > 状态：草案 / 规划阶段
+>
+> v0.8 变更：填上 `test_run` EventKind 的空产出方——`PostToolUse`(Bash)首-token 识别本地测试命令派生 `test_run`，结果可解析时带 pass/fail/计数、否则仅 ran，裁决一律 `confidence=inferred`。详见 `docs/ADR/0011-local-test-run-capture.md`。
 >
 > v0.7 变更：订阅 `SessionEnd` hook，给会话补显式闭边界（`decision.session_end` + `reason`）；`SessionStart` 增采 `source`（startup/resume/clear/compact）。详见 `docs/ADR/0012-session-end-hook.md`。
 >
@@ -187,6 +189,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 - **配置快照**（SessionStart + 配置漂移）：每次 SessionStart 起一条 `agent_config_snapshot` 事件，bundle 内容走 artifact store。`UserPromptSubmit` / `PreToolUse` 时若指令文件 / settings hash 漂移，补发新快照。`hook_binary_sha256` 在 SessionStart 算一次，与 bundle 同事件入 hash chain，作为 capture-time attestation。详见 ADR 0003。
 - **人工干预**（PreToolUse 派生 + Stop 启发式 + GitHub webhook 派生）：`PreToolUse` permission decision 派生 `human_intervention.permission_decision`（与 tool_call 共存，via `target_event_id` 链回）；`Stop` 时按 `stop_reason == null` 且无后续 tool_result 启发式推断 `interrupt`；GitHub `pull_request_review` handler 派生 `review_decision`，merge 事件回扫 request_changes 状态派生 `merge_override`。详见 ADR 0004 D2 / D3 / D5。
 - **上下文变换**（transcript 解析 + PostToolUse 截断检测）：transcript 解析新增识别 compaction（降级为启发式）、system reminder 注入（以 hash 去重发首次）；PostToolUse 检测 tool_result 截断占位符并发 `context_transform.truncation`。详见 ADR 0005 D3 / D4 / D5。
+- **测试执行**（PostToolUse Bash 识别）：`PostToolUse` 时对 `Bash` 命令做首-token 识别（剥 `cd &&`/`env`/`sudo`/`npx`/`bash -c` 等包装器与启动器、拒绝 `echo`/`cat`/`grep` 等假阳），命中测试运行器则派生 `test_run` 事件（与 `tool_result` 共存）；能解析 exit/stdout 时带 pass/fail/计数、否则仅 `ran` + `exit_code`，裁决一律 `confidence=inferred`（本地路径无 observed 级）。`command` 姿态随 `tool_result`（verbatim）。详见 ADR 0011。
 
 **Thinking 捕获条件**：仅当 Claude Code 在该轮启用了 extended thinking，transcript 中才会有 `thinking` block 可读。本路径不主动开启该选项，也不强制其存在。
 
@@ -286,6 +289,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 | R8 | Compaction 与部分 context 变换在 §10.1 hook 路径仅能启发式探测，精确建模等 §10.4 代理深模式或 IDE 插件层。事件载体（`context_transform`）已就位，`loss_hint.confidence = inferred / observed` 标记区分，审计端不会被静默漏报。详见 ADR 0005 D5。 |
 | R9 | 「某 skill 的指令正文是否进入了某一轮 context」无法从 §10.1 hook 路径验证——hook 不暴露 system prompt / context 窗口，Claude Code 也没有 skill-load hook。可得的只有两个间接信号：skill 文件在磁盘上的存在性（ADR 0003 `agent_config_snapshot` config bundle 快照）与 skill 被**调用**（`Skill` 工具的 PreToolUse / PostToolUse，见 issue #101）。精确的「context 此刻含 skill X 指令」断言等 §10.4 代理深模式。审计端据此把 skill **可用性** 与 skill **调用** 分别建模，不假装能证明 context 成分。 |
 | R10 | `SessionEnd` 在进程崩溃 / 被 kill 时不发（hook 没机会运行）——会话闭边界靠「有 `session_start` 无对应 `session_end` 收尾」反推。正常退出（`reason=prompt_input_exit`）、`/clear`（`clear`）、会话内 `/resume` 切走（`resume`）均已实测发 `session_end`（2026-05-31 抓样）；同一 `session_id` 跨多次退出 / resume 续接可发**多条** `session_end`。详见 ADR 0012。 |
+| R11 | 本地 `test_run`（ADR 0011）裁决**一律 `inferred`**：首-token 识别可能漏冷门 runner（`./run-tests.sh`/`tox`/`gradle test` 等→静默欠计，「无 `test_run`」≠「没跑测试」）、exit code 可能被管道 / `tee` / `; echo` 掩盖（解析错位），且看不进 Makefile / 脚本内部（`make test` 实跑 lint→伪 pass）。审计端不得把本地 `test_run` 当 observed 真值；observed 级留给 wrapper-CLI 后续路径。 |
 
 ---
 

--- a/cmd/agent-lens-hook/claude.go
+++ b/cmd/agent-lens-hook/claude.go
@@ -95,7 +95,15 @@ func buildEvents(in *claudeHookInput) (events []map[string]any, commit func() er
 	case "PreToolUse":
 		return []map[string]any{makeToolCall(in)}, nil
 	case "PostToolUse":
-		return []map[string]any{makeToolResult(in)}, nil
+		evs := []map[string]any{makeToolResult(in)}
+		// A Bash command that ran a test suite additionally derives a
+		// `test_run` event, co-existing with the tool_result (ADR 0011).
+		if in.ToolName == "Bash" {
+			if tr := makeTestRun(in); tr != nil {
+				evs = append(evs, tr)
+			}
+		}
+		return evs, nil
 	case "SessionStart":
 		return []map[string]any{makeSessionStart(in)}, nil
 	case "SessionEnd":

--- a/cmd/agent-lens-hook/testrun.go
+++ b/cmd/agent-lens-hook/testrun.go
@@ -1,0 +1,304 @@
+package main
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// testrun.go implements ADR 0011: recognise a Bash PostToolUse that ran a test
+// suite and derive a `test_run` event alongside the tool_result. Recognition is
+// anchored to the command's *effective* first token (after stripping wrappers /
+// launchers) and explicitly rejects non-executing commands that merely mention
+// a runner name (echo/cat/grep/…). Result parsing is conservative: pass/fail is
+// filled only when a runner's output says so unambiguously — otherwise the event
+// records `ran` only. Every derived verdict is confidence=inferred (D5).
+
+// makeTestRun returns a `test_run` event for a recognised test command, or nil.
+// Fail-soft throughout: any parse miss degrades to "ran only", never a guess.
+func makeTestRun(in *claudeHookInput) map[string]any {
+	cmd := bashCommand(in.ToolInput)
+	if cmd == "" {
+		return nil
+	}
+	runner := recognizeRunner(cmd)
+	if runner == "" {
+		return nil
+	}
+	payload := map[string]any{
+		"runner":     runner,
+		"command":    cmd, // verbatim — same redaction posture as tool_result (D4)
+		"confidence": "inferred",
+		"ran":        true,
+	}
+	if in.CWD != "" {
+		payload["cwd"] = in.CWD
+	}
+	parseTestResult(in.ToolResponse, payload)
+	return baseEvent(in, agentActor(), "test_run", payload)
+}
+
+func bashCommand(toolInput json.RawMessage) string {
+	var input struct {
+		Command string `json:"command"`
+	}
+	if err := json.Unmarshal(toolInput, &input); err != nil {
+		return ""
+	}
+	return strings.TrimSpace(input.Command)
+}
+
+// --- recognition -----------------------------------------------------------
+
+// rejectLeads are commands that read / print / search but do NOT execute a test
+// suite, even when a runner name appears in their arguments (e.g.
+// `echo "run go test"`, `grep FAIL log`, `git log --grep=pytest`). A command
+// whose effective lead is one of these never yields a test_run.
+var rejectLeads = map[string]bool{
+	"echo": true, "cat": true, "grep": true, "rg": true, "printf": true,
+	"git": true, "ls": true, "find": true, "head": true, "tail": true,
+	"sed": true, "awk": true, "less": true, "which": true,
+}
+
+// wrapperLeads are transparent prefixes stripped to reach the real command
+// (e.g. `sudo go test`, `time pytest`, `env A=B go test`).
+var wrapperLeads = map[string]bool{
+	"sudo": true, "time": true, "nice": true, "nohup": true,
+	"env": true, "xargs": true, "command": true, "exec": true,
+}
+
+var envAssign = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*=`)
+
+// recognizeRunner returns a runner label if cmd invokes a known test runner,
+// else "". It scans each &&/;/| -joined segment, normalises its leading tokens
+// (strip env-assignments and wrappers, unwrap launchers), rejects non-executing
+// leads, and matches the runner table. First match wins.
+func recognizeRunner(cmd string) string {
+	for _, seg := range splitSegments(cmd) {
+		if r := runnerOfSegment(seg); r != "" {
+			return r
+		}
+	}
+	return ""
+}
+
+// splitSegments breaks a command line on shell sequencing operators so that
+// `cd x && go test` is examined segment-by-segment. Quotes are not parsed (a
+// best-effort split); launcher unwrapping (bash -c "…") is handled separately.
+func splitSegments(cmd string) []string {
+	parts := regexp.MustCompile(`&&|\|\||;|\|`).Split(cmd, -1)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func runnerOfSegment(seg string) string {
+	toks := strings.Fields(seg)
+	// Strip leading env-assignments and transparent wrappers.
+	for len(toks) > 0 && (envAssign.MatchString(toks[0]) || wrapperLeads[toks[0]]) {
+		toks = toks[1:]
+	}
+	if len(toks) == 0 {
+		return ""
+	}
+	// Unwrap a launcher: take the inner command's leading tokens.
+	if inner := unwrapLauncher(toks); inner != nil {
+		toks = inner
+		if len(toks) == 0 {
+			return ""
+		}
+	}
+	if rejectLeads[toks[0]] {
+		return ""
+	}
+	return matchRunner(toks)
+}
+
+// unwrapLauncher peels runner-launchers so the wrapped command is matched:
+// `npx jest` → [jest], `poetry run pytest` → [pytest], `bash -lc "go test"` →
+// [go test]. Returns nil when toks isn't a launcher invocation.
+func unwrapLauncher(toks []string) []string {
+	switch toks[0] {
+	case "npx":
+		return toks[1:]
+	case "pnpm", "yarn", "poetry", "pdm", "uv", "rye":
+		// pnpm exec X / yarn dlx X / poetry run X / uv run X
+		if len(toks) >= 3 && (toks[1] == "exec" || toks[1] == "dlx" || toks[1] == "run") {
+			return toks[2:]
+		}
+	case "bash", "sh", "zsh":
+		// bash -lc "go test ./..." → the quoted script. Rejoin from the first
+		// non-flag token so the inner command survives the Fields() split.
+		for i := 1; i < len(toks); i++ {
+			if strings.HasPrefix(toks[i], "-") {
+				continue
+			}
+			inner := strings.Trim(strings.Join(toks[i:], " "), `"'`)
+			return strings.Fields(inner)
+		}
+	case "python", "python3":
+		// python -m pytest
+		if len(toks) >= 3 && toks[1] == "-m" {
+			return toks[2:]
+		}
+	}
+	return nil
+}
+
+// matchRunner maps normalised leading tokens to a runner label. Extend this
+// table to teach new runners (D5); recognition is intentionally non-exhaustive
+// and confidence stays `inferred`.
+func matchRunner(toks []string) string {
+	lead := toks[0]
+	second := ""
+	if len(toks) > 1 {
+		second = toks[1]
+	}
+	switch lead {
+	case "go":
+		if second == "test" {
+			return "go test"
+		}
+	case "make":
+		// `make test`, `make test-integration`, `make test-unit` … any target
+		// whose name contains "test". (R11: a test-named target that actually
+		// lints is an accepted false-positive; confidence=inferred covers it.)
+		if strings.Contains(second, "test") {
+			return "make " + second
+		}
+	case "npm", "pnpm", "yarn", "bun":
+		if second == "test" || second == "t" ||
+			(second == "run" && len(toks) > 2 && strings.Contains(toks[2], "test")) {
+			return lead + " test"
+		}
+	case "pytest", "py.test":
+		return "pytest"
+	case "cargo":
+		if second == "test" || second == "nextest" {
+			return "cargo test"
+		}
+	case "jest", "vitest", "ctest", "tox", "mocha", "ava", "rspec", "phpunit":
+		return lead
+	case "gradle", "./gradlew", "gradlew":
+		if strings.Contains(second, "test") || strings.Contains(second, "check") {
+			return "gradle test"
+		}
+	case "dotnet":
+		if second == "test" {
+			return "dotnet test"
+		}
+	case "deno":
+		if second == "test" {
+			return "deno test"
+		}
+	}
+	return ""
+}
+
+// --- result parsing --------------------------------------------------------
+
+var (
+	reGoFail   = regexp.MustCompile(`(?m)^(--- FAIL|FAIL\b|FAIL\t)`)
+	reGoOK     = regexp.MustCompile(`(?m)^(ok\s|PASS\b)`)
+	rePyPassed = regexp.MustCompile(`(\d+) passed`)
+	rePyFailed = regexp.MustCompile(`(\d+) failed`)
+	rePyError  = regexp.MustCompile(`(\d+) error`)
+	rePySkip   = regexp.MustCompile(`(\d+) skipped`)
+	reGenFail  = regexp.MustCompile(`(?i)\b(\d+) (failing|failed)\b`)
+	reGenPass  = regexp.MustCompile(`(?i)\b(\d+) (passing|passed)\b`)
+)
+
+// parseTestResult reads the Bash tool_response and fills outcome / counts on the
+// payload when the output says so unambiguously. Conservative: it never invents
+// a pass/fail; ambiguous output leaves the event as `ran` only. exit_code is
+// captured opportunistically (its presence/shape is harness-dependent — ADR
+// §验证), but is not the primary signal since pipes/tee can mask it.
+func parseTestResult(toolResponse json.RawMessage, payload map[string]any) {
+	if len(toolResponse) == 0 {
+		return
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(toolResponse, &resp); err != nil {
+		return
+	}
+	if b, ok := resp["interrupted"].(bool); ok && b {
+		payload["interrupted"] = true
+		return // interrupted run → no verdict
+	}
+	for _, k := range []string{"exit_code", "exitCode", "code", "returnCode", "status"} {
+		if v, ok := resp[k].(float64); ok {
+			payload["exit_code"] = int(v)
+			break
+		}
+	}
+	var text strings.Builder
+	for _, k := range []string{"stdout", "stderr", "output"} {
+		if s, ok := resp[k].(string); ok {
+			text.WriteString(s)
+			text.WriteString("\n")
+		}
+	}
+	out := text.String()
+	if strings.TrimSpace(out) == "" {
+		return
+	}
+
+	failed, hasFailed := firstCount(out, rePyFailed, reGenFail)
+	passed, hasPassed := firstCount(out, rePyPassed, reGenPass)
+	if errs, ok := matchCount(out, rePyError); ok {
+		failed += errs
+		hasFailed = true
+	}
+	if sk, ok := matchCount(out, rePySkip); ok {
+		payload["skipped"] = sk
+	}
+
+	switch {
+	case hasFailed && failed > 0:
+		setOutcome(payload, "fail", passed, failed, hasPassed)
+	case reGoFail.MatchString(out):
+		setOutcome(payload, "fail", passed, failed, hasPassed)
+	case hasFailed && failed == 0 && hasPassed:
+		setOutcome(payload, "pass", passed, failed, hasPassed)
+	case reGoOK.MatchString(out) && !reGoFail.MatchString(out):
+		setOutcome(payload, "pass", passed, failed, hasPassed)
+	case hasPassed && !hasFailed:
+		setOutcome(payload, "pass", passed, failed, hasPassed)
+	}
+	// else: leave as `ran` only — no confident verdict.
+}
+
+func setOutcome(payload map[string]any, outcome string, passed, failed int, hasPassed bool) {
+	payload["outcome"] = outcome
+	if hasPassed {
+		payload["passed"] = passed
+	}
+	if failed > 0 {
+		payload["failed"] = failed
+	}
+}
+
+func firstCount(s string, res ...*regexp.Regexp) (int, bool) {
+	for _, re := range res {
+		if n, ok := matchCount(s, re); ok {
+			return n, true
+		}
+	}
+	return 0, false
+}
+
+func matchCount(s string, re *regexp.Regexp) (int, bool) {
+	m := re.FindStringSubmatch(s)
+	if m == nil {
+		return 0, false
+	}
+	n := 0
+	for _, r := range m[1] {
+		n = n*10 + int(r-'0')
+	}
+	return n, true
+}

--- a/cmd/agent-lens-hook/testrun_test.go
+++ b/cmd/agent-lens-hook/testrun_test.go
@@ -1,0 +1,187 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRecognizeRunnerPositive(t *testing.T) {
+	cases := map[string]string{
+		"go test ./...":            "go test",
+		"make test":                "make test",
+		"make test-integration":    "make test-integration",
+		"npm test":                 "npm test",
+		"npm run test:unit":        "npm test",
+		"pnpm test":                "pnpm test",
+		"pytest -q":                "pytest",
+		"cargo test":               "cargo test",
+		"jest --watch=false":       "jest",
+		"vitest run":               "vitest",
+		"npx vitest run":           "vitest",
+		"poetry run pytest tests/": "pytest",
+		"uv run pytest":            "pytest",
+		"sudo pytest":              "pytest",
+		"env CI=1 go test ./...":   "go test",
+		"cd web && npm test":       "npm test",
+		"cd x && go test ./...":    "go test",
+		`bash -lc "go test ./..."`: "go test",
+		"python -m pytest":         "pytest",
+		"time go test ./...":       "go test",
+		"dotnet test":              "dotnet test",
+	}
+	for cmd, want := range cases {
+		if got := recognizeRunner(cmd); got != want {
+			t.Errorf("recognizeRunner(%q) = %q, want %q", cmd, got, want)
+		}
+	}
+}
+
+func TestRecognizeRunnerRejectsNonExec(t *testing.T) {
+	// Commands that mention a runner but don't execute one → no test_run.
+	for _, cmd := range []string{
+		`echo "run go test before pushing"`,
+		"cat test_output.log",
+		"grep FAIL test.log",
+		`git log --grep="pytest"`,
+		"rg 'go test' Makefile",
+		"make build",
+		"make lint",
+		"ls test/",
+		"go build ./...",
+		"npm run lint",
+	} {
+		if got := recognizeRunner(cmd); got != "" {
+			t.Errorf("recognizeRunner(%q) = %q, want \"\" (should reject)", cmd, got)
+		}
+	}
+}
+
+func TestParseTestResultGoPass(t *testing.T) {
+	p := map[string]any{}
+	parseTestResult(json.RawMessage(`{"stdout":"ok  \tgithub.com/x/y\t0.5s\nok  \tgithub.com/x/z\t0.1s\n"}`), p)
+	if p["outcome"] != "pass" {
+		t.Errorf("outcome = %v, want pass", p["outcome"])
+	}
+}
+
+func TestParseTestResultGoFail(t *testing.T) {
+	p := map[string]any{}
+	parseTestResult(json.RawMessage(`{"stdout":"--- FAIL: TestX (0.00s)\nFAIL\tgithub.com/x/y\t0.2s\n"}`), p)
+	if p["outcome"] != "fail" {
+		t.Errorf("outcome = %v, want fail", p["outcome"])
+	}
+}
+
+func TestParseTestResultPytestCounts(t *testing.T) {
+	p := map[string]any{}
+	parseTestResult(json.RawMessage(`{"stdout":"=== 2 failed, 5 passed, 1 skipped in 0.3s ==="}`), p)
+	if p["outcome"] != "fail" {
+		t.Errorf("outcome = %v, want fail", p["outcome"])
+	}
+	if p["failed"] != 2 {
+		t.Errorf("failed = %v, want 2", p["failed"])
+	}
+	if p["passed"] != 5 {
+		t.Errorf("passed = %v, want 5", p["passed"])
+	}
+	if p["skipped"] != 1 {
+		t.Errorf("skipped = %v, want 1", p["skipped"])
+	}
+}
+
+func TestParseTestResultPytestAllPass(t *testing.T) {
+	p := map[string]any{}
+	parseTestResult(json.RawMessage(`{"stdout":"=== 7 passed in 1.2s ==="}`), p)
+	if p["outcome"] != "pass" {
+		t.Errorf("outcome = %v, want pass", p["outcome"])
+	}
+	if p["passed"] != 7 {
+		t.Errorf("passed = %v, want 7", p["passed"])
+	}
+}
+
+func TestParseTestResultInterruptedNoVerdict(t *testing.T) {
+	p := map[string]any{}
+	parseTestResult(json.RawMessage(`{"interrupted":true,"stdout":"ok  \tfoo\n"}`), p)
+	if _, ok := p["outcome"]; ok {
+		t.Errorf("interrupted run should have no outcome, got %v", p["outcome"])
+	}
+	if p["interrupted"] != true {
+		t.Errorf("interrupted flag not set")
+	}
+}
+
+func TestParseTestResultAmbiguousRanOnly(t *testing.T) {
+	// Output with no clear pass/fail signal → no outcome (ran only).
+	p := map[string]any{}
+	parseTestResult(json.RawMessage(`{"stdout":"running suite...\ndone\n"}`), p)
+	if _, ok := p["outcome"]; ok {
+		t.Errorf("ambiguous output should leave outcome unset, got %v", p["outcome"])
+	}
+}
+
+func TestParseTestResultExitCode(t *testing.T) {
+	p := map[string]any{}
+	parseTestResult(json.RawMessage(`{"stdout":"FAIL\n","exit_code":1}`), p)
+	if p["exit_code"] != 1 {
+		t.Errorf("exit_code = %v, want 1", p["exit_code"])
+	}
+}
+
+func TestBuildEventsBashTestRunDerivesTestRun(t *testing.T) {
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "PostToolUse",
+		SessionID:     "s1",
+		CWD:           "/repo",
+		ToolName:      "Bash",
+		ToolInput:     json.RawMessage(`{"command":"go test ./..."}`),
+		ToolResponse:  json.RawMessage(`{"stdout":"ok  \tx\t0.1s\n"}`),
+	})
+	if len(evs) != 2 {
+		t.Fatalf("got %d events, want 2 (tool_result + test_run): %+v", len(evs), evs)
+	}
+	if evs[0]["kind"] != "tool_result" || evs[1]["kind"] != "test_run" {
+		t.Fatalf("kinds = %v / %v, want tool_result / test_run", evs[0]["kind"], evs[1]["kind"])
+	}
+	p := evs[1]["payload"].(map[string]any)
+	if p["runner"] != "go test" {
+		t.Errorf("runner = %v, want go test", p["runner"])
+	}
+	if p["command"] != "go test ./..." {
+		t.Errorf("command = %v, want verbatim", p["command"])
+	}
+	if p["confidence"] != "inferred" {
+		t.Errorf("confidence = %v, want inferred", p["confidence"])
+	}
+	if p["outcome"] != "pass" {
+		t.Errorf("outcome = %v, want pass", p["outcome"])
+	}
+	if actor := evs[1]["actor"].(map[string]any); actor["type"] != "agent" {
+		t.Errorf("test_run actor = %v, want agent", actor)
+	}
+}
+
+func TestBuildEventsBashNonTestNoTestRun(t *testing.T) {
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "PostToolUse",
+		SessionID:     "s1",
+		ToolName:      "Bash",
+		ToolInput:     json.RawMessage(`{"command":"go build ./..."}`),
+		ToolResponse:  json.RawMessage(`{"stdout":""}`),
+	})
+	if len(evs) != 1 || evs[0]["kind"] != "tool_result" {
+		t.Errorf("non-test Bash should yield only tool_result, got %+v", evs)
+	}
+}
+
+func TestBuildEventsNonBashNoTestRun(t *testing.T) {
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "PostToolUse",
+		SessionID:     "s1",
+		ToolName:      "Edit",
+		ToolResponse:  json.RawMessage(`{"ok":true}`),
+	})
+	if len(evs) != 1 || evs[0]["kind"] != "tool_result" {
+		t.Errorf("non-Bash should yield only tool_result, got %+v", evs)
+	}
+}

--- a/docs/ADR/0011-local-test-run-capture.md
+++ b/docs/ADR/0011-local-test-run-capture.md
@@ -1,0 +1,103 @@
+# ADR 0011:本地测试执行的采集(填 `test_run` 的空产出方)
+
+- 状态:Accepted
+- 日期:2026-05-29
+- 取代:—
+
+## 背景
+
+`EVENT_KIND_TEST_RUN`(=8)早在 `proto/event.proto:49` 就定义了,`internal/ingest/handler.go:50` 的 `validKinds` 也接受 `test_run`——**但全仓库没有任何产出方**。这是个隐性盲区:schema 留了位、UI / query 看上去支持"测试执行"这一类,实际上一条都不会写进来。
+
+现状下测试执行的可见性:
+
+- **远端 CI**:GitHub `workflow_run` webhook 派生 `build` 事件(`internal/webhooks/github/mapper.go:242`),把"CI 工作流跑了"作为整体记录,但**不区分**其中的测试步骤,也拿不到 pass / fail / 用例数。
+- **本地** `make test` / `go test` / `npm test`:只作为 `Bash` 工具的 `tool_result` 以**不透明文本**落库(`claude.go:252`)。无法结构化查询"这个 commit 前本地跑过测试吗、过了吗、跑了多少用例"。
+
+于是证据链在"测试通过"这个节点是断的。审计问"这次提交前测试过吗、结果如何",答不出——而"agent 改完代码、声称测试通过"正是最该被验证的一类声明(参 §17 dogfood 与 `self-review` skill 的存在动机)。本 ADR 决定**本地测试执行的采集机制**,把 `test_run` 从空 schema 位变成有数据的事件。
+
+## 验证
+
+代码探查(2026-05-29,本仓库):
+
+- `test_run` 仅出现在 `proto/event.proto:49`(enum 定义)与 `internal/ingest/handler.go:50`(校验白名单);`rg '"test_run"'` 在 hook / webhook 产出路径下**零命中**——确认无 emitter。
+- `cmd/agent-lens-hook/claude.go:252-269` 的 `makeToolResult` 对所有 `PostToolUse` 一视同仁,仅 `Bash` 命令额外抽 `git:<sha>` ref(`git_commit_ref.go`),不识别测试命令。
+
+本地测试调用的可观测通道:
+
+| 通道 | 能看到命令 | 能看到结果 | 改用户工作流 | 结果置信 |
+|---|---|---|---|---|
+| `PostToolUse`(Bash) | 是(`tool_input.command`) | 部分(`tool_response` 含 exit / stdout,需解析) | 否 | inferred |
+| git `pre-push` hook | 否(只知道要 push) | 否 | 需装 hook | — |
+| 显式 wrapper `agent-lens test -- <cmd>` | 是(精确) | 是(自跑自读 exit) | 是(每次手动包裹) | observed |
+
+**仍未决、落地前必须抓样核对**:
+
+- 各测试运行器的 `tool_response` 实际形态——exit code 是否如实透出(`go test`、`pytest`、`jest`),还是被管道 / `tee` / `; echo` 掩盖;摘要行格式。这是 D1 结果解析的事实基础,**未实测**。落地采 fail-soft:解析不确定即只记 `ran` + `exit_code`,不臆造 pass/fail。
+- 命令首 token 在真实 `tool_input.command` 中的位置(是否常被 `cd x && `、`env A=B ` 等前缀包裹),供 D1 的锚定规则校准。
+
+## 决定
+
+### D1. 用 `PostToolUse`(Bash)识别测试命令,派生 `test_run`,与 `tool_result` 共存
+
+`makeToolResult` 在 `tool_name == "Bash"` 时,除既有 `git:<sha>` 抽取外,再对 `tool_input.command` 跑测试运行器识别;命中则**附加**一条 `test_run` 事件(与 `tool_result` 共存,不替代)。
+
+- **识别(必须锚到命令首 token)**:剥掉前缀后取**实际执行的首 token** 匹配内置测试运行器表(`go test`、`make test` / `make test-integration`、`npm/pnpm/yarn test`、`pytest`、`cargo test`、`jest`、`vitest`、`ctest` 等)。需剥/递归的前缀分两类:(a)**透明包装器**——`cd … &&`、`env A=B`、前导变量赋值、`sudo`/`time`/`nice`/`nohup`、`xargs`,剥到其后的真实命令首 token;(b)**运行器启动器**——`npx`/`pnpm exec`/`yarn dlx`、`poetry run`/`pdm run`/`uv run`、`bash -lc "…"`/`sh -c "…"`,取其后第一个参数 / 引号内首 token 再匹配。这两类硬编码在识别表里,随发版扩(D5)。
+- **必须拒绝的假阳**:首 token 是 `echo` / `cat` / `grep` / `rg` / `printf` / `git`(如 `git log --grep=pytest`)等**非执行测试**的命令,即便其参数里出现 runner 名,一律不发 `test_run`;runner 名出现在引号字符串内(非 `bash -c` 那种确为执行体的情形)或 `#` 注释内同样不发。理由见下方否决备选。
+- **结果解析**:从 `tool_response` 的 exit code + stdout 抽 pass / fail / 用例数(`go test` 的 `ok` / `FAIL` 行、jest / vitest 摘要行等)。**只有解析出明确结果时才填 `passed` / `failed` / `outcome`**;解析不出(或 exit code 可能被管道掩盖)则**只记 `ran=true` + 原始 `exit_code`,不臆造 pass/fail**,`confidence=inferred`。
+- **payload**:`runner`、`command`(verbatim,见 D4)、`exit_code`、`passed` / `failed` / `skipped`(仅解析成功时present)、`duration`(可空)、`cwd`、`confidence`。
+
+**否决备选(子串匹配)**:像早期设想那样只对 `command` 做 runner 名子串匹配。`echo "run go test before pushing"`、`cat test_output.log`、`grep FAIL test.log`、`git log --grep="pytest"` 都会命中,发出一条 exit=0 的幻影 `test_run`——在审计里被读成"**测试通过了**"。这不是"多一行",而是**伪造了一个裁决**,恰是本系统该防止的事。故识别必须锚首 token 且显式拒绝上述命令族。
+**否决备选(git pre-push)**:只在 push 边界记录。只覆盖 push 时刻、漏掉本地反复跑;且 `pre-push` 时测试早跑完,拿不到结果。
+
+### D2. session 归属用 Claude session,附 `git:<sha>` ref 让 linker 缝到 commit
+
+`test_run` 复用 `PostToolUse` 所在的 Claude `session_id`(它本就是 agent turn 内的动作),并在能从 `cwd` 解析出 HEAD 时附 `git:<sha>` ref(复用 `git_commit_ref.go` 同款逻辑),让 linking worker 把 `test_run` 缝到对应 `commit` / `push` 事件。
+
+**否决备选**:为测试另起独立 git-session(像 `git.go:127` 的 `gitSessionID`)。会把 turn 内动作割裂到另一条 session,反而切断"这个 turn 里 agent 跑了测试"的因果。
+
+### D3. 不引入新 EventKind
+
+`test_run` 已在 `proto/event.proto` 与 `validKinds`,本 ADR **只填产出方**,无 schema 变更、无 proto bump。这也是把它单列 ADR 而非顺手实现的理由:采集机制(启发式 vs wrapper vs git hook)是个"三个月后会被问为什么这样"的决定,值得记;schema 本身没动。
+
+### D4. `test_run` 与其源 `tool_result` 同一 §12 脱敏姿态,不单独脱敏
+
+`test_run` 的 `command`(及解析出的输出片段)与它共存的 `tool_result` 是**同一次 Bash 调用的两个视角**。`claude.go` 现有策略对 tool-call **命令**有意不脱敏(为审计可复现,`claude.go:16-21`)。`test_run` **沿用同一姿态**:`command` 保持 verbatim,与 `tool_result` 一致。
+
+**不**对 `test_run` 单独脱敏——这一点经评审纠正了早期草案:单独脱敏 `test_run.command` **既不减少 store 级泄露面**(明文孪生始终在共存的 `tool_result` 里,D1),又制造同一条命令"一处脱敏、一处明文"的不一致审计记录。`test_run` 的泄露边界由 §12 对 tool 命令 / 输出的**统一**姿态治理;§12 若将来收紧对 tool 输出的脱敏,`test_run` 与 `tool_result` **同步**跟随,不在本 ADR 单独设一道半截的脱敏。
+
+**否决备选**:像早期草案那样只脱敏 `test_run`、保留 `tool_result` 明文(类比 0005 D6 的 summary 脱敏)。该类比不成立:0005 D6 明确**丢弃** summary 的 raw(无明文孪生),而 `test_run.command` 按 D1 **必然**有明文孪生共存——脱敏投影买不到真实的泄露收益,只换来不一致。
+
+### D5. 识别表内置 + 注释化扩展,`confidence` 承载"识别可能不全"
+
+测试运行器识别表硬编码在 hook 内,新增 runner 改表即可(注释说明)。不做运行时可配置——配置面是新故障源。识别与解析的不确定性统一由 `confidence` 字段对审计端显式声明。`confidence=observed` 仅留给 D1 否决备选里的 wrapper-CLI 高保真路径(自跑自读 exit);**经 PostToolUse 派生的 test_run 一律 `inferred`**——v1 本地 `test_run` 没有 observed 级。
+
+### D6. 与 `build` 的关系:视角不同,不重复
+
+`build`(CI `workflow_run`)是"CI 工作流整体跑了";`test_run` 是"一次测试执行的结果"。CI 里跑测试,首版只产出 `build`(webhook 派生 CI 侧 `test_run` 留作后续,非本 ADR);本地跑测试只产出 `test_run`。两者来源不同、粒度不同,不构成重复。
+
+## Scope
+
+本 ADR 文档不带代码。落地涉及:
+
+- `proto/event.proto`:**不变**(`test_run` 既有)。
+- `cmd/agent-lens-hook/claude.go`:`makeToolResult` 增测试识别(首 token 锚定 + 包装器/启动器剥离 + 假阳拒绝)+ 结果解析 + 派生 `test_run`(返回多事件,沿用 `buildEvents` 已支持的多事件返回形态);`command` 姿态与 `tool_result` 一致(verbatim,见 D4)。
+- 测试运行器识别 / 结果解析表(新文件,hook 内)。
+- `internal/linking/`:复用 `git:<sha>` ref 把 `test_run` 缝到 commit / push。
+- GraphQL + Lens UI:timeline 显示 `test_run` 节点(pass / fail / 仅 ran 三态色阶),session 维度聚合需对 `confidence=inferred` 显式标注、不当作精确通过率。
+
+**本 ADR 文档本身不带代码改动;落地实现与接受同 PR(见 § 落地)。**
+
+## 后果
+
+- §10.1 Hook 直采路径新增一条:"测试执行(`PostToolUse` Bash 首-token 识别派生 `test_run`,结果可解析时带 pass/fail/计数、否则仅 ran,`confidence=inferred`)"。
+- §7 `EventKind` 不变(`test_run` 既有,本 ADR 只激活它)。
+- §15 增三条风险:(1)**所有 v1 本地 `test_run` 裁决均为 inferred**——识别 / 解析启发式可能漏识别(`./run-tests.sh`、`make ci`、`tox`、`gradle test`、`dotnet test` 等非常规 runner 假阴)或解析错位(exit code 被管道掩盖);审计端不得把 `test_run` 当 observed 真值。(2)漏识别造成的**静默欠计**(无 `test_run` ≠ 没跑测试,也可能是 runner 未被识别)需在 UI / 查询语义上显式区分。(3)**目标名说谎的假阳**:首-token 启发式看不进 Makefile / 脚本内部,`make test` 若实际跑的是 lint,会被记成一次"测试"——首-token 方案无法消除此类,只能由 `confidence=inferred` 兜底声明。
+- 数据量:每 session 0–N 条,取决于跑测试频率;dogfood 下中等。
+- 重放幂等:`test_run` 经 hook transport at-least-once 通道可能随 `replay` 重复;这是既有 hook 路径通性,session 维度聚合须按 (session_id, command, ts 窗) 去重,避免双计通过率。具体去重归 ingest 既有机制。
+- 与 ADR 0002 的关系:`test_run` 不带 `usage`(测试执行无 token 语义),与 token 链路正交。
+- attestation predicate(§11):`test_run` 是否进入未来 predicate 版本(把"测试通过"纳入 commit ↔ turn 证据链)留给 attestation 修订决策,本 ADR 不越权收纳——尤其 inferred 级的本地 `test_run` 不宜直接进 attestation。
+- 显式留给后续:CI 侧 `test_run`(从 `workflow_run` / check_run webhook 解析单测试步骤)、wrapper CLI 的 observed 级路径(D1 否决备选)——均不需新 EventKind,后续按需各起小 ADR 或挂落地 PR。
+
+## 落地
+
+实现与接受同 PR:`cmd/agent-lens-hook/testrun.go`(识别表 + 首-token 剥离 + 结果解析)+ `makeToolResult` 在 Bash 命中时附加 `test_run` 事件 + 单测。GraphQL / Lens UI 的 `test_run` 节点展示为后续子项,另起跟踪。

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -135,6 +135,7 @@ Patch 文件的硬性约束:
 - **0007 Sub-agent(Task 工具)透明度**(草案):父→子 `delegates` link 设计与开放问题。
 - **0008 Sub-agent 自动 link fallback**(草案):v0.1 K1 实证,撤回 `delegates`,落地 fallback。
 - **0009 Sub-agent 父→子自动链接(`delegates`)**(草案):SubagentStart.agent_id ↔ tool_result.agentId 桥接;v0.2 恢复 ADR 0007 D4 / 取代 ADR 0008 D3。
+- **0011 本地测试执行的采集**(Accepted):填 proto 既有但无产出方的 `test_run`;`PostToolUse`(Bash)首-token 识别派生,裁决均 `inferred`,不新增 EventKind。
 - **0012 订阅 SessionEnd 补齐会话边界**(Accepted):`SessionEnd` 派生 `decision.session_end`(`reason`)、`SessionStart` 增采 `source`;复用既有 `decision` marker,不新增 EventKind。(0010/0011/0013 草案见 PR #124。)
 
 (0003–0005 接受时的 `spec-patches-pending-0003-0005.md` 已随 #100 合入删除。)


### PR DESCRIPTION
接受并实现 **ADR 0011**(从草案 PR #124 拆出)。五个设计拍板点已由作者人工审阅确认(均=现行设计)。两个 commit:

1. **接受(原子,纯文档)**:0011 翻 `草案→Accepted`;SPEC §10.1 加测试采集 bullet + §15 R11(全 inferred 的告警);SPEC `v0.7→v0.8` + 版本注;ADR 索引。
2. **实现**:
   - `testrun.go`:`makeTestRun` 识别 Bash 测试命令——**首-token 锚定**(剥 env 赋值/`sudo`/`time`/`env`/`xargs` 包装器、拆 `npx`/`poetry run`/`bash -c`/`python -m` 启动器),**显式拒绝** `echo`/`cat`/`grep`/`git` 等非执行命令(防伪"passed")。
   - `buildEvents`:Bash 命中时在 `tool_result` 旁**附加** `test_run`。
   - **保守结果解析**:只在输出明确时填 pass/fail+计数(go `ok`/`FAIL`、pytest/jest `N passed/failed`);中断 / 含糊 → 只记 `ran`,**绝不臆造裁决**。一律 `confidence=inferred`(D5);命令 verbatim、脱敏姿态随 tool_result(D4)。**不新增 EventKind**。

## 验证
- `go test ./...` **353 passed**(+13 新);`go vet`、`gofmt` 干净;无 debug marker;无 proto/web/schema 改动。
- 单测覆盖:识别正例 + 非执行拒绝、go/pytest pass/fail 解析、中断/含糊→ran-only、2 事件 PostToolUse 接线。

## 可选手动冒烟
在 dogfood 里真跑一次 `go test`,确认 `test_run` 事件落库(带 outcome=pass)。逻辑已被单测端到端覆盖,非阻塞。

## 路径与风险
- 仅 `cmd/agent-lens-hook`(非 main.go/attest/hashchain/release/Dockerfile)+ docs/SPEC → `/self-review` 足够。

Closes ADR 0011 的接受+实现;0010/0013 草案仍在 #124。

🤖 Generated with [Claude Code](https://claude.com/claude-code)