### PR TITLE
feat(schema): 落地 human_intervention + context_transform EventKind(Phase 0)

### DIFF
--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -53,6 +53,11 @@ var validKinds = map[string]struct{}{
 	"review":      {},
 	"decision":    {},
 	"push":        {},
+	// v0.6 EventKinds (ADR 0003/0004/0005). Schema landed in Phase 0; producers
+	// land incrementally per their ADRs. agent_config_snapshot (0003) follows
+	// when its producer lands.
+	"human_intervention": {},
+	"context_transform":  {},
 }
 
 // Handler owns the per-session head-hash cache and is the single writer

--- a/internal/ingest/validkinds_test.go
+++ b/internal/ingest/validkinds_test.go
@@ -1,0 +1,33 @@
+package ingest
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/dong-qiu/agent-lens/internal/pb"
+)
+
+// TestValidKindsMatchProtoEnum guards the wire-kind allowlist against drift from
+// the canonical proto EventKind enum: every enum value (except UNSPECIFIED) must
+// have a lowercase entry in validKinds, and vice versa. Adding a kind to one
+// list but not the other silently drops it on the wire (rejected by ingest) or
+// accepts a kind the schema doesn't know — exactly the kind of split-brain a
+// hand-maintained allowlist invites.
+func TestValidKindsMatchProtoEnum(t *testing.T) {
+	fromProto := map[string]bool{}
+	for n, name := range pb.EventKind_name {
+		if n == 0 { // EVENT_KIND_UNSPECIFIED is not a wire value
+			continue
+		}
+		wire := strings.ToLower(strings.TrimPrefix(name, "EVENT_KIND_"))
+		fromProto[wire] = true
+		if _, ok := validKinds[wire]; !ok {
+			t.Errorf("proto EventKind %q (%s) missing from validKinds", wire, name)
+		}
+	}
+	for k := range validKinds {
+		if !fromProto[k] {
+			t.Errorf("validKinds has %q with no matching proto EventKind", k)
+		}
+	}
+}

--- a/internal/pb/event.pb.go
+++ b/internal/pb/event.pb.go
@@ -92,8 +92,8 @@ const (
 	EventKind_EVENT_KIND_REVIEW             EventKind = 11
 	EventKind_EVENT_KIND_DECISION           EventKind = 12
 	EventKind_EVENT_KIND_PUSH               EventKind = 13
-	EventKind_EVENT_KIND_HUMAN_INTERVENTION EventKind = 14 // ADR 0004 — 人对 agent 行为的反馈(permission/interrupt/review…)
-	EventKind_EVENT_KIND_CONTEXT_TRANSFORM  EventKind = 15 // ADR 0005 — turn 间 context 的有损变换(compaction/truncation/reminder)
+	EventKind_EVENT_KIND_HUMAN_INTERVENTION EventKind = 14 // ADR 0004 — human feedback on agent actions (permission/interrupt/review…)
+	EventKind_EVENT_KIND_CONTEXT_TRANSFORM  EventKind = 15 // ADR 0005 — lossy context transforms between turns (compaction/truncation/reminder)
 )
 
 // Enum value maps for EventKind.

--- a/internal/pb/event.pb.go
+++ b/internal/pb/event.pb.go
@@ -78,20 +78,22 @@ func (ActorType) EnumDescriptor() ([]byte, []int) {
 type EventKind int32
 
 const (
-	EventKind_EVENT_KIND_UNSPECIFIED EventKind = 0
-	EventKind_EVENT_KIND_PROMPT      EventKind = 1
-	EventKind_EVENT_KIND_THOUGHT     EventKind = 2
-	EventKind_EVENT_KIND_TOOL_CALL   EventKind = 3
-	EventKind_EVENT_KIND_TOOL_RESULT EventKind = 4
-	EventKind_EVENT_KIND_CODE_CHANGE EventKind = 5
-	EventKind_EVENT_KIND_COMMIT      EventKind = 6
-	EventKind_EVENT_KIND_PR          EventKind = 7
-	EventKind_EVENT_KIND_TEST_RUN    EventKind = 8
-	EventKind_EVENT_KIND_BUILD       EventKind = 9
-	EventKind_EVENT_KIND_DEPLOY      EventKind = 10
-	EventKind_EVENT_KIND_REVIEW      EventKind = 11
-	EventKind_EVENT_KIND_DECISION    EventKind = 12
-	EventKind_EVENT_KIND_PUSH        EventKind = 13
+	EventKind_EVENT_KIND_UNSPECIFIED        EventKind = 0
+	EventKind_EVENT_KIND_PROMPT             EventKind = 1
+	EventKind_EVENT_KIND_THOUGHT            EventKind = 2
+	EventKind_EVENT_KIND_TOOL_CALL          EventKind = 3
+	EventKind_EVENT_KIND_TOOL_RESULT        EventKind = 4
+	EventKind_EVENT_KIND_CODE_CHANGE        EventKind = 5
+	EventKind_EVENT_KIND_COMMIT             EventKind = 6
+	EventKind_EVENT_KIND_PR                 EventKind = 7
+	EventKind_EVENT_KIND_TEST_RUN           EventKind = 8
+	EventKind_EVENT_KIND_BUILD              EventKind = 9
+	EventKind_EVENT_KIND_DEPLOY             EventKind = 10
+	EventKind_EVENT_KIND_REVIEW             EventKind = 11
+	EventKind_EVENT_KIND_DECISION           EventKind = 12
+	EventKind_EVENT_KIND_PUSH               EventKind = 13
+	EventKind_EVENT_KIND_HUMAN_INTERVENTION EventKind = 14 // ADR 0004 — 人对 agent 行为的反馈(permission/interrupt/review…)
+	EventKind_EVENT_KIND_CONTEXT_TRANSFORM  EventKind = 15 // ADR 0005 — turn 间 context 的有损变换(compaction/truncation/reminder)
 )
 
 // Enum value maps for EventKind.
@@ -111,22 +113,26 @@ var (
 		11: "EVENT_KIND_REVIEW",
 		12: "EVENT_KIND_DECISION",
 		13: "EVENT_KIND_PUSH",
+		14: "EVENT_KIND_HUMAN_INTERVENTION",
+		15: "EVENT_KIND_CONTEXT_TRANSFORM",
 	}
 	EventKind_value = map[string]int32{
-		"EVENT_KIND_UNSPECIFIED": 0,
-		"EVENT_KIND_PROMPT":      1,
-		"EVENT_KIND_THOUGHT":     2,
-		"EVENT_KIND_TOOL_CALL":   3,
-		"EVENT_KIND_TOOL_RESULT": 4,
-		"EVENT_KIND_CODE_CHANGE": 5,
-		"EVENT_KIND_COMMIT":      6,
-		"EVENT_KIND_PR":          7,
-		"EVENT_KIND_TEST_RUN":    8,
-		"EVENT_KIND_BUILD":       9,
-		"EVENT_KIND_DEPLOY":      10,
-		"EVENT_KIND_REVIEW":      11,
-		"EVENT_KIND_DECISION":    12,
-		"EVENT_KIND_PUSH":        13,
+		"EVENT_KIND_UNSPECIFIED":        0,
+		"EVENT_KIND_PROMPT":             1,
+		"EVENT_KIND_THOUGHT":            2,
+		"EVENT_KIND_TOOL_CALL":          3,
+		"EVENT_KIND_TOOL_RESULT":        4,
+		"EVENT_KIND_CODE_CHANGE":        5,
+		"EVENT_KIND_COMMIT":             6,
+		"EVENT_KIND_PR":                 7,
+		"EVENT_KIND_TEST_RUN":           8,
+		"EVENT_KIND_BUILD":              9,
+		"EVENT_KIND_DEPLOY":             10,
+		"EVENT_KIND_REVIEW":             11,
+		"EVENT_KIND_DECISION":           12,
+		"EVENT_KIND_PUSH":               13,
+		"EVENT_KIND_HUMAN_INTERVENTION": 14,
+		"EVENT_KIND_CONTEXT_TRANSFORM":  15,
 	}
 )
 
@@ -379,7 +385,7 @@ const file_event_proto_rawDesc = "" +
 	"\x16ACTOR_TYPE_UNSPECIFIED\x10\x00\x12\x14\n" +
 	"\x10ACTOR_TYPE_HUMAN\x10\x01\x12\x14\n" +
 	"\x10ACTOR_TYPE_AGENT\x10\x02\x12\x15\n" +
-	"\x11ACTOR_TYPE_SYSTEM\x10\x03*\xdd\x02\n" +
+	"\x11ACTOR_TYPE_SYSTEM\x10\x03*\xa2\x03\n" +
 	"\tEventKind\x12\x1a\n" +
 	"\x16EVENT_KIND_UNSPECIFIED\x10\x00\x12\x15\n" +
 	"\x11EVENT_KIND_PROMPT\x10\x01\x12\x16\n" +
@@ -395,7 +401,9 @@ const file_event_proto_rawDesc = "" +
 	"\x12\x15\n" +
 	"\x11EVENT_KIND_REVIEW\x10\v\x12\x17\n" +
 	"\x13EVENT_KIND_DECISION\x10\f\x12\x13\n" +
-	"\x0fEVENT_KIND_PUSH\x10\rB/Z-github.com/dong-qiu/agent-lens/internal/pb;pbb\x06proto3"
+	"\x0fEVENT_KIND_PUSH\x10\r\x12!\n" +
+	"\x1dEVENT_KIND_HUMAN_INTERVENTION\x10\x0e\x12 \n" +
+	"\x1cEVENT_KIND_CONTEXT_TRANSFORM\x10\x0fB/Z-github.com/dong-qiu/agent-lens/internal/pb;pbb\x06proto3"
 
 var (
 	file_event_proto_rawDescOnce sync.Once

--- a/internal/query/models_gen.go
+++ b/internal/query/models_gen.go
@@ -155,19 +155,21 @@ func (e ActorType) MarshalJSON() ([]byte, error) {
 type EventKind string
 
 const (
-	EventKindPrompt     EventKind = "PROMPT"
-	EventKindThought    EventKind = "THOUGHT"
-	EventKindToolCall   EventKind = "TOOL_CALL"
-	EventKindToolResult EventKind = "TOOL_RESULT"
-	EventKindCodeChange EventKind = "CODE_CHANGE"
-	EventKindCommit     EventKind = "COMMIT"
-	EventKindPr         EventKind = "PR"
-	EventKindTestRun    EventKind = "TEST_RUN"
-	EventKindBuild      EventKind = "BUILD"
-	EventKindDeploy     EventKind = "DEPLOY"
-	EventKindReview     EventKind = "REVIEW"
-	EventKindDecision   EventKind = "DECISION"
-	EventKindPush       EventKind = "PUSH"
+	EventKindPrompt            EventKind = "PROMPT"
+	EventKindThought           EventKind = "THOUGHT"
+	EventKindToolCall          EventKind = "TOOL_CALL"
+	EventKindToolResult        EventKind = "TOOL_RESULT"
+	EventKindCodeChange        EventKind = "CODE_CHANGE"
+	EventKindCommit            EventKind = "COMMIT"
+	EventKindPr                EventKind = "PR"
+	EventKindTestRun           EventKind = "TEST_RUN"
+	EventKindBuild             EventKind = "BUILD"
+	EventKindDeploy            EventKind = "DEPLOY"
+	EventKindReview            EventKind = "REVIEW"
+	EventKindDecision          EventKind = "DECISION"
+	EventKindPush              EventKind = "PUSH"
+	EventKindHumanIntervention EventKind = "HUMAN_INTERVENTION"
+	EventKindContextTransform  EventKind = "CONTEXT_TRANSFORM"
 )
 
 var AllEventKind = []EventKind{
@@ -184,11 +186,13 @@ var AllEventKind = []EventKind{
 	EventKindReview,
 	EventKindDecision,
 	EventKindPush,
+	EventKindHumanIntervention,
+	EventKindContextTransform,
 }
 
 func (e EventKind) IsValid() bool {
 	switch e {
-	case EventKindPrompt, EventKindThought, EventKindToolCall, EventKindToolResult, EventKindCodeChange, EventKindCommit, EventKindPr, EventKindTestRun, EventKindBuild, EventKindDeploy, EventKindReview, EventKindDecision, EventKindPush:
+	case EventKindPrompt, EventKindThought, EventKindToolCall, EventKindToolResult, EventKindCodeChange, EventKindCommit, EventKindPr, EventKindTestRun, EventKindBuild, EventKindDeploy, EventKindReview, EventKindDecision, EventKindPush, EventKindHumanIntervention, EventKindContextTransform:
 		return true
 	}
 	return false

--- a/internal/query/schema.graphql
+++ b/internal/query/schema.graphql
@@ -93,6 +93,8 @@ enum EventKind {
   REVIEW
   DECISION
   PUSH
+  HUMAN_INTERVENTION
+  CONTEXT_TRANSFORM
 }
 
 """Aggregated view of a session: id plus first/last activity and event count."""

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -52,6 +52,6 @@ enum EventKind {
   EVENT_KIND_REVIEW = 11;
   EVENT_KIND_DECISION = 12;
   EVENT_KIND_PUSH = 13;
-  EVENT_KIND_HUMAN_INTERVENTION = 14;  // ADR 0004 — 人对 agent 行为的反馈(permission/interrupt/review…)
-  EVENT_KIND_CONTEXT_TRANSFORM = 15;   // ADR 0005 — turn 间 context 的有损变换(compaction/truncation/reminder)
+  EVENT_KIND_HUMAN_INTERVENTION = 14;  // ADR 0004 — human feedback on agent actions (permission/interrupt/review…)
+  EVENT_KIND_CONTEXT_TRANSFORM = 15;   // ADR 0005 — lossy context transforms between turns (compaction/truncation/reminder)
 }

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -52,4 +52,6 @@ enum EventKind {
   EVENT_KIND_REVIEW = 11;
   EVENT_KIND_DECISION = 12;
   EVENT_KIND_PUSH = 13;
+  EVENT_KIND_HUMAN_INTERVENTION = 14;  // ADR 0004 — 人对 agent 行为的反馈(permission/interrupt/review…)
+  EVENT_KIND_CONTEXT_TRANSFORM = 15;   // ADR 0005 — turn 间 context 的有损变换(compaction/truncation/reminder)
 }


### PR DESCRIPTION
ADR 0004(`human_intervention`)/ 0005(`context_transform`)的 **schema 地基**——两者 v0.6 即 Accepted 但一直未落 proto。本 PR **只落 schema、不带任何派生器**:

- `proto/event.proto`:加 `EVENT_KIND_HUMAN_INTERVENTION=14` / `CONTEXT_TRANSFORM=15` → `make proto`(regen `internal/pb`)。
- `internal/ingest/handler.go`:`validKinds` 加两个字符串。
- `internal/query/schema.graphql`:`EventKind` 加两个值 → `make gqlgen`(regen `models_gen.go`)。wire→GraphQL 映射是通用 `ToUpper`,无需 per-kind resolver。
- **新增 `TestValidKindsMatchProtoEnum`**:守卫 validKinds 与 proto 枚举不漂移(enforce-by-code)。

## 边界
- **无产出方**:这两类现在能被接受入库 / 查询,但派生器按 ADR 0004/0005(及 0010/0013 对采集机制的修订)**后续增量落地**。
- **不加 `agent_config_snapshot`(0003)**:它没有正在落地的产出方,加了就是孤儿;留待 0003 落地时取下一个枚举位。

## 验证
- `go test ./...` **353 passed**;`vet`/`gofmt` 干净;**codegen 幂等**(重跑 `make proto`/`make gqlgen` 无新 diff)。
- 观察:`TestExportCodeProvenanceEndToEnd` 偶发 flaky(时间/ULID 序敏感,孤立运行 + 两次全量复跑均过)——**pre-existing,与本 schema 改动无关**。

## 风险 / 评审
- 触 `proto/*.proto` + `schema.graphql`(公共 schema 面)→ 按项目策略 **建议 `/review`**(非强制的 attest/hashchain/release,但 schema 值得二审)。纯加性、无语义改动、无产出方。

🤖 Generated with [Claude Code](https://claude.com/claude-code)