### PR TITLE
feat(hook): 采集 system_reminder_injection(ADR 0005 D3,Phase 1)

### DIFF
--- a/cmd/agent-lens-hook/claude.go
+++ b/cmd/agent-lens-hook/claude.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -340,6 +342,16 @@ func makeStopEvents(in *claudeHookInput) ([]map[string]any, func() error) {
 		return []map[string]any{turnEnd}, nil
 	}
 
+	// Per-session dedup state for system-reminder injections (ADR 0005 D3):
+	// emit each distinct reminder once. Fail-soft — a read error just means we
+	// might re-emit a reminder, never lose the turn's other events.
+	seenReminders, err := r.SeenReminders(in.SessionID)
+	if err != nil {
+		warn("seen reminders: %v", err)
+		seenReminders = map[string]bool{}
+	}
+	var newReminderHashes []string
+
 	events := make([]map[string]any, 0, len(blocks)+1)
 	for _, b := range blocks {
 		switch b.Kind {
@@ -374,12 +386,46 @@ func makeStopEvents(in *claudeHookInput) ([]map[string]any, func() error) {
 			}
 			attachUsageMetadata(payload, &b)
 			events = append(events, baseEvent(in, agentActorWithModel(b.Model), "decision", payload))
+		case "system_reminder":
+			// Harness-injected <system-reminder> → context_transform (ADR 0005
+			// D3). Dedup by content hash so a re-injected static reminder is
+			// recorded once per session; dynamic reminders (hash varies) each
+			// land once. observed: the reminder text is in the transcript.
+			h := sha256Hex(b.Content)
+			if seenReminders[h] {
+				continue
+			}
+			seenReminders[h] = true
+			newReminderHashes = append(newReminderHashes, h)
+			text, n := redactText(b.Content)
+			payload := map[string]any{
+				"sub_kind":       "system_reminder_injection",
+				"triggered_by":   "harness_auto",
+				"content_sha256": h,
+				"after":          map[string]any{"injected_text": text},
+				"loss_hint":      map[string]any{"confidence": "observed"},
+			}
+			if n > 0 {
+				payload["redacted_count"] = n
+			}
+			events = append(events, baseEvent(in, map[string]any{"type": "system", "id": "claude-code"}, "context_transform", payload))
 		}
 	}
 	events = append(events, turnEnd)
 
-	commit := func() error { return r.Commit(in.SessionID, offset) }
+	commit := func() error {
+		if err := r.Commit(in.SessionID, offset); err != nil {
+			return err
+		}
+		return r.AddSeenReminders(in.SessionID, newReminderHashes)
+	}
 	return events, commit
+}
+
+// sha256Hex is the content key used to dedup system-reminder injections.
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
 }
 
 // attachUsageMetadata copies per-message usage / stop_reason from the

--- a/cmd/agent-lens-hook/claude_test.go
+++ b/cmd/agent-lens-hook/claude_test.go
@@ -505,3 +505,83 @@ func TestTransportFallsBackToSinkOn5xx(t *testing.T) {
 		t.Errorf("sink not written on 5xx: %v", err)
 	}
 }
+
+func countKind(evs []map[string]any, kind string) int {
+	n := 0
+	for _, e := range evs {
+		if e["kind"] == kind {
+			n++
+		}
+	}
+	return n
+}
+
+func appendLine(t *testing.T, path, line string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if _, err := f.WriteString(line + "\n"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildEventsStopSystemReminderDedup(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("AGENT_LENS_CURSOR_DIR", filepath.Join(tmp, "cursors"))
+	path := filepath.Join(tmp, "tx.jsonl")
+
+	stop := func() ([]map[string]any, func() error) {
+		return buildEvents(&claudeHookInput{HookEventName: "Stop", SessionID: "s1", TranscriptPath: path})
+	}
+
+	// Turn 1: a static system-reminder + assistant text.
+	appendLine(t, path, `{"type":"user","message":{"content":"<system-reminder>auto-memory header</system-reminder>"}}`)
+	appendLine(t, path, `{"type":"assistant","message":{"id":"m1","content":[{"type":"text","text":"ok"}]}}`)
+	evs, commit := stop()
+	if got := countKind(evs, "context_transform"); got != 1 {
+		t.Fatalf("turn1 context_transform = %d, want 1", got)
+	}
+	var ct map[string]any
+	for _, e := range evs {
+		if e["kind"] == "context_transform" {
+			ct = e
+		}
+	}
+	p := ct["payload"].(map[string]any)
+	if p["sub_kind"] != "system_reminder_injection" {
+		t.Errorf("sub_kind = %v", p["sub_kind"])
+	}
+	if after := p["after"].(map[string]any); after["injected_text"] != "auto-memory header" {
+		t.Errorf("injected_text = %v", after["injected_text"])
+	}
+	if lh := p["loss_hint"].(map[string]any); lh["confidence"] != "observed" {
+		t.Errorf("confidence = %v, want observed", lh["confidence"])
+	}
+	if actor := ct["actor"].(map[string]any); actor["type"] != "system" {
+		t.Errorf("actor.type = %v, want system", actor["type"])
+	}
+	if err := commit(); err != nil {
+		t.Fatalf("commit: %v", err)
+	}
+
+	// Turn 2: SAME reminder re-injected (static) → deduped, no new event.
+	appendLine(t, path, `{"type":"user","message":{"content":"<system-reminder>auto-memory header</system-reminder>"}}`)
+	appendLine(t, path, `{"type":"assistant","message":{"id":"m2","content":[{"type":"text","text":"again"}]}}`)
+	evs2, commit2 := stop()
+	if got := countKind(evs2, "context_transform"); got != 0 {
+		t.Errorf("turn2 context_transform = %d, want 0 (static reminder deduped)", got)
+	}
+	if err := commit2(); err != nil {
+		t.Fatalf("commit2: %v", err)
+	}
+
+	// Turn 3: a DIFFERENT reminder → emitted (distinct hash).
+	appendLine(t, path, `{"type":"user","message":{"content":"<system-reminder>todo changed</system-reminder>"}}`)
+	evs3, _ := stop()
+	if got := countKind(evs3, "context_transform"); got != 1 {
+		t.Errorf("turn3 context_transform = %d, want 1 (distinct reminder)", got)
+	}
+}

--- a/internal/transcript/reader.go
+++ b/internal/transcript/reader.go
@@ -12,9 +12,15 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 )
+
+// reSystemReminder matches a harness-injected <system-reminder> block in a
+// user message (ADR 0005 D3). Non-greedy + dotall so a multi-line reminder is
+// captured whole and multiple reminders in one message are matched separately.
+var reSystemReminder = regexp.MustCompile(`(?s)<system-reminder>(.*?)</system-reminder>`)
 
 // TokenUsage is the vendor-neutral token-counting shape per ADR 0002 D2.
 // Field names match the JSON keys the hook will emit on payload.usage so
@@ -25,16 +31,16 @@ import (
 // doesn't have a notion of cache writes (e.g. OpenAI) just omits them
 // rather than reporting zeros that look like real-but-empty buckets.
 type TokenUsage struct {
-	Vendor             string          `json:"vendor"`
-	Model              string          `json:"model"`
-	ServiceTier        string          `json:"service_tier,omitempty"`
-	InputTokens        int             `json:"input_tokens"`
-	OutputTokens       int             `json:"output_tokens"`
-	CacheReadTokens    int             `json:"cache_read_tokens,omitempty"`
-	CacheWrite5mTokens int             `json:"cache_write_5m_tokens,omitempty"`
-	CacheWrite1hTokens int             `json:"cache_write_1h_tokens,omitempty"`
-	WebSearchCalls     int             `json:"web_search_calls,omitempty"`
-	WebFetchCalls      int             `json:"web_fetch_calls,omitempty"`
+	Vendor             string `json:"vendor"`
+	Model              string `json:"model"`
+	ServiceTier        string `json:"service_tier,omitempty"`
+	InputTokens        int    `json:"input_tokens"`
+	OutputTokens       int    `json:"output_tokens"`
+	CacheReadTokens    int    `json:"cache_read_tokens,omitempty"`
+	CacheWrite5mTokens int    `json:"cache_write_5m_tokens,omitempty"`
+	CacheWrite1hTokens int    `json:"cache_write_1h_tokens,omitempty"`
+	WebSearchCalls     int    `json:"web_search_calls,omitempty"`
+	WebFetchCalls      int    `json:"web_fetch_calls,omitempty"`
 	// Raw is the verbatim vendor `usage` block, kept so we can re-derive
 	// fields if our normalization missed a column or if Anthropic's
 	// schema drifts. ADR 0002 D2 calls this "有意冗余" — a few hundred
@@ -57,7 +63,7 @@ type TokenUsage struct {
 // in turn / session aggregation. Carrier preference: first text block,
 // then first thinking block, else a synthesized stub text block.
 type Block struct {
-	Kind             string // "thinking" or "text"
+	Kind             string // "thinking", "text", or "system_reminder"
 	Content          string
 	MessageID        string
 	Model            string
@@ -127,6 +133,47 @@ func (r *Reader) Commit(sessionID string, offset int64) error {
 	}
 	path := filepath.Join(r.cursorDir, sessionID+".offset")
 	return os.WriteFile(path, []byte(strconv.FormatInt(offset, 10)), 0o600)
+}
+
+// SeenReminders loads the set of system-reminder content hashes already emitted
+// for sessionID, so a re-injected (static) reminder is emitted only once per
+// session (ADR 0005 D3). Missing file → empty set. Sidecar to the cursor,
+// persisted via AddSeenReminders only after a successful send.
+func (r *Reader) SeenReminders(sessionID string) (map[string]bool, error) {
+	path := filepath.Join(r.cursorDir, sessionID+".reminders")
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]bool{}, nil
+		}
+		return nil, err
+	}
+	set := map[string]bool{}
+	for _, line := range strings.Split(string(b), "\n") {
+		if h := strings.TrimSpace(line); h != "" {
+			set[h] = true
+		}
+	}
+	return set, nil
+}
+
+// AddSeenReminders appends newly-emitted reminder hashes to the session's
+// sidecar (append-only, one hex hash per line). No-op for an empty slice.
+func (r *Reader) AddSeenReminders(sessionID string, hashes []string) error {
+	if len(hashes) == 0 {
+		return nil
+	}
+	if err := os.MkdirAll(r.cursorDir, 0o700); err != nil {
+		return err
+	}
+	path := filepath.Join(r.cursorDir, sessionID+".reminders")
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	_, err = f.WriteString(strings.Join(hashes, "\n") + "\n")
+	return err
 }
 
 func (r *Reader) readCursor(sessionID string) (int64, error) {
@@ -247,7 +294,16 @@ func parseLine(line []byte) []Block {
 	if err := json.Unmarshal(line, &e); err != nil {
 		return nil
 	}
-	if e.Type != "assistant" || len(e.Message) == 0 {
+	if len(e.Message) == 0 {
+		return nil
+	}
+	// User messages carry harness-injected <system-reminder> blocks (ADR 0005
+	// D3). They're the only thing we extract from the user side; everything
+	// else below is assistant content.
+	if e.Type == "user" {
+		return parseUserReminders(e.Message)
+	}
+	if e.Type != "assistant" {
 		return nil
 	}
 	var msg assistantMessage
@@ -360,6 +416,65 @@ func parseLine(line []byte) []Block {
 	}
 
 	return out
+}
+
+// parseUserReminders extracts <system-reminder> blocks from a user message,
+// one Block per reminder. Dedup (emit each distinct reminder once per session,
+// ADR 0005 D3) is the caller's job — it needs cross-invocation state the reader
+// doesn't hold. Fail-soft: unparseable content yields no blocks.
+func parseUserReminders(message json.RawMessage) []Block {
+	var msg struct {
+		ID      string          `json:"id"`
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(message, &msg); err != nil {
+		return nil
+	}
+	text := userContentText(msg.Content)
+	if text == "" {
+		return nil
+	}
+	var out []Block
+	for _, m := range reSystemReminder.FindAllStringSubmatch(text, -1) {
+		rem := strings.TrimSpace(m[1])
+		if rem == "" {
+			continue
+		}
+		out = append(out, Block{Kind: "system_reminder", Content: rem, MessageID: msg.ID})
+	}
+	return out
+}
+
+// userContentText flattens a user message's content to text. Content is either
+// a JSON string or an array of blocks; we concatenate the text blocks (where
+// the harness injects reminders). tool_result blocks are intentionally skipped
+// — reminders ride in text, and tool_result bodies are large and noisy.
+func userContentText(content json.RawMessage) string {
+	if len(content) == 0 {
+		return ""
+	}
+	switch content[0] {
+	case '"':
+		var s string
+		if err := json.Unmarshal(content, &s); err != nil {
+			return ""
+		}
+		return s
+	case '[':
+		var blocks []contentBlock
+		if err := json.Unmarshal(content, &blocks); err != nil {
+			return ""
+		}
+		var b strings.Builder
+		for _, blk := range blocks {
+			if blk.Type == "text" && blk.Text != "" {
+				b.WriteString(blk.Text)
+				b.WriteString("\n")
+			}
+		}
+		return b.String()
+	}
+	return ""
 }
 
 func trimSpace(b []byte) []byte {

--- a/internal/transcript/reader_test.go
+++ b/internal/transcript/reader_test.go
@@ -461,3 +461,47 @@ func TestReadMissingTranscript(t *testing.T) {
 		t.Error("expected error for missing transcript, got nil")
 	}
 }
+
+func TestParseUserRemindersExtracts(t *testing.T) {
+	// String content with a reminder embedded.
+	b := parseLine([]byte(`{"type":"user","message":{"content":"before <system-reminder>todo: X</system-reminder> after"}}`))
+	if len(b) != 1 || b[0].Kind != "system_reminder" || b[0].Content != "todo: X" {
+		t.Fatalf("string content: got %+v", b)
+	}
+	// Array content: reminder rides in a text block.
+	b = parseLine([]byte(`{"type":"user","message":{"content":[{"type":"text","text":"x <system-reminder>auto-memory</system-reminder>"}]}}`))
+	if len(b) != 1 || b[0].Content != "auto-memory" {
+		t.Fatalf("array content: got %+v", b)
+	}
+	// Two reminders in one message → two blocks.
+	b = parseLine([]byte(`{"type":"user","message":{"content":"<system-reminder>a</system-reminder><system-reminder>b</system-reminder>"}}`))
+	if len(b) != 2 {
+		t.Fatalf("multiple: got %d, want 2", len(b))
+	}
+}
+
+func TestParseUserRemindersNone(t *testing.T) {
+	if b := parseLine([]byte(`{"type":"user","message":{"content":"just a normal prompt"}}`)); b != nil {
+		t.Errorf("plain user message yielded %+v, want nil", b)
+	}
+}
+
+func TestSeenRemindersRoundTrip(t *testing.T) {
+	r := NewReader(t.TempDir())
+	if seen, err := r.SeenReminders("s1"); err != nil || len(seen) != 0 {
+		t.Fatalf("initial: %v / %+v", err, seen)
+	}
+	if err := r.AddSeenReminders("s1", []string{"h1", "h2"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.AddSeenReminders("s1", []string{"h3"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := r.AddSeenReminders("s1", nil); err != nil {
+		t.Fatalf("empty append should be a no-op: %v", err)
+	}
+	seen, _ := r.SeenReminders("s1")
+	if len(seen) != 3 || !seen["h1"] || !seen["h2"] || !seen["h3"] {
+		t.Errorf("round-trip set = %+v, want {h1,h2,h3}", seen)
+	}
+}


### PR DESCRIPTION
ADR 0005 D3 落地——把 harness 注入的 `<system-reminder>` 升为 `context_transform` 事件。这是 **Phase 1 的零依赖那一半**(`context_transform` EventKind 已随 #131 落地)。

## 做法
- `internal/transcript/reader.go`:reader 现在**也扫 user 消息**里的 `<system-reminder>` 块;新增 `system_reminder` Block 种类。
- `makeStopEvents`:每个 reminder 派生一条 `context_transform`(`sub_kind=system_reminder_injection`、`confidence=observed`、`after.injected_text` 过 `redactText` §12)。
- **去重(D3)**:按内容 hash + per-session sidecar(`.reminders`)。静态 reminder 只记一次;动态各记一次。sidecar 仅在 send 成功后随 cursor commit 落盘。

## 暂缓
- `truncation`(D4)**暂缓**:抓样显示本仓自身内容(redaction 代码、ADR 示例、diff)致字符串匹配严重假阳;需先精确锚定 harness 截断标记契约。

## 验证
- `go test ./...` **358 passed**;vet/gofmt 干净;无 proto/graphql/web/schema 改动。
- 测试:reader 提取、seen-hash round-trip、跨 turn 去重。

## 路径
- 仅 `cmd/agent-lens-hook` + `internal/transcript` → `/self-review` 足够。实现已 Accepted 的 0005 D3;不改 ADR/SPEC。

🤖 Generated with [Claude Code](https://claude.com/claude-code)