### PR TITLE
feat(hook): 接受并实现 ADR 0013 — PreCompact/PostCompact compaction 采集

### DIFF
--- a/.claude/settings.example.json
+++ b/.claude/settings.example.json
@@ -63,6 +63,22 @@
           {"type": "command", "command": "agent-lens-hook claude", "timeout": 5}
         ]
       }
+    ],
+    "PreCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "agent-lens-hook claude", "timeout": 5}
+        ]
+      }
+    ],
+    "PostCompact": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {"type": "command", "command": "agent-lens-hook claude", "timeout": 5}
+        ]
+      }
     ]
   },
   "worktree": {

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,7 +1,9 @@
 # Agent Lens — 项目 SPEC
 
-> 版本：v0.8（2026-05-31）
+> 版本：v0.9（2026-06-01）
 > 状态：草案 / 规划阶段
+>
+> v0.9 变更：订阅 `PreCompact` / `PostCompact` hook，把 compaction 从启发式 inferred 提到一手 observed——`PreCompact` 发 `context_transform.compaction`（`confidence=provisional`、`triggered_by`、`before.compact_instructions`），`PostCompact` 确认升 `observed`；进程崩溃则停在 `provisional`。`loss_hint.confidence` 集合增 `provisional` 档。详见 `docs/ADR/0013-precompact-context-transform.md`。
 >
 > v0.8 变更：填上 `test_run` EventKind 的空产出方——`PostToolUse`(Bash)首-token 识别本地测试命令派生 `test_run`，结果可解析时带 pass/fail/计数、否则仅 ran，裁决一律 `confidence=inferred`。详见 `docs/ADR/0011-local-test-run-capture.md`。
 >
@@ -188,7 +190,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 - 可选 MCP server，把 Lens 查询能力反哺给 Agent。
 - **配置快照**（SessionStart + 配置漂移）：每次 SessionStart 起一条 `agent_config_snapshot` 事件，bundle 内容走 artifact store。`UserPromptSubmit` / `PreToolUse` 时若指令文件 / settings hash 漂移，补发新快照。`hook_binary_sha256` 在 SessionStart 算一次，与 bundle 同事件入 hash chain，作为 capture-time attestation。详见 ADR 0003。
 - **人工干预**（PreToolUse 派生 + Stop 启发式 + GitHub webhook 派生）：`PreToolUse` permission decision 派生 `human_intervention.permission_decision`（与 tool_call 共存，via `target_event_id` 链回）；`Stop` 时按 `stop_reason == null` 且无后续 tool_result 启发式推断 `interrupt`；GitHub `pull_request_review` handler 派生 `review_decision`，merge 事件回扫 request_changes 状态派生 `merge_override`。详见 ADR 0004 D2 / D3 / D5。
-- **上下文变换**（transcript 解析 + PostToolUse 截断检测）：transcript 解析新增识别 compaction（降级为启发式）、system reminder 注入（以 hash 去重发首次）；PostToolUse 检测 tool_result 截断占位符并发 `context_transform.truncation`。详见 ADR 0005 D3 / D4 / D5。
+- **上下文变换**（`PreCompact`/`PostCompact` hook + transcript 解析）：`PreCompact` 派生 `context_transform.compaction`（`confidence=provisional`、`triggered_by`、`before.compact_instructions` 过脱敏），`PostCompact` 确认升 `observed`、崩溃停 `provisional`（ADR 0013，取代 0005 D5 的 token-budget 启发式为主路径——后者降为两 hook 未触发时的 fallback）；`system reminder 注入` 由 transcript 解析按 hash 去重发首次（ADR 0005 D3，已落地）。`truncation`（0005 D4）暂缓——本仓自指内容致字符串匹配假阳，待锚定 harness 截断标记契约。详见 ADR 0005 / 0013。
 - **测试执行**（PostToolUse Bash 识别）：`PostToolUse` 时对 `Bash` 命令做首-token 识别（剥 `cd &&`/`env`/`sudo`/`npx`/`bash -c` 等包装器与启动器、拒绝 `echo`/`cat`/`grep` 等假阳），命中测试运行器则派生 `test_run` 事件（与 `tool_result` 共存）；能解析 exit/stdout 时带 pass/fail/计数、否则仅 `ran` + `exit_code`，裁决一律 `confidence=inferred`（本地路径无 observed 级）。`command` 姿态随 `tool_result`（verbatim）。详见 ADR 0011。
 
 **Thinking 捕获条件**：仅当 Claude Code 在该轮启用了 extended thinking，transcript 中才会有 `thinking` block 可读。本路径不主动开启该选项，也不强制其存在。
@@ -200,7 +202,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 - `<synthetic>` 模型标记的消息（Claude Code 自身注入的 stop-sequence 占位，usage 全 0）按已知形态跳过 usage 提取，不报错、不丢消息体。
 - **思考内容（thinking 文本）**：Claude Code 写 transcript 时只保留 `signature` 字段，**原文不持久化**。§10.1 拿不到原文。每条 assistant 消息中被丢弃的 thinking 块**数量**显式记录在派生 DECISION 事件的 `payload.thinking_redacted_by_claude_code`，避免审计报告把"被吞"误读为"无思考"。要拿原文得走 §10.4。
 - **工具空间与采样参数**：本轮可用工具集合（active MCP server、tool catalog）、permission mode 即时值、thinking budget、temperature 等 model_params 在 hook 路径不可得。`agent_config_snapshot` 事件中这两块字段标 `null` 并在 metadata 列入 `unknown_fields`，审计端能区分"工具空间为空" vs "采集路径看不到"。要拿到这些得走 §10.4。详见 ADR 0003 D4。
-- **Compaction 边界**：harness 自动 compaction 在 transcript 里是否显式标记**未经系统验证**，首版按 token-budget 启发式推断，生成 `context_transform.compaction` 事件并置 `loss_hint.confidence = "inferred"`。验证通过则 confidence 升到 `observed`；Truncation 与 system reminder 注入在 transcript 中可见，直接观测。详见 ADR 0005 D5。
+- **Compaction 边界**：`PreCompact`/`PostCompact` hook 给 compaction 一手锚点——`PreCompact` 标 `provisional`、`PostCompact` 确认 `observed`、进程崩溃停 `provisional`（"开始过、未确认完成"，镜像 `SessionEnd` 崩溃缺口）。token-budget 启发式（`inferred`）降为两 hook 未触发/未装时的 fallback。仍待 §10.4 的：compaction **summary 文本**的精确捕获（本路径只锚前后时点 + 触发者，内容仍由 transcript 旁路补采）。详见 ADR 0013 / 0005 D5。
 - **手工编辑归因**：agent 改完代码 → 人手在 IDE 微调 → commit 这条混合贡献路径，在 §10.1 路径不可还原。`HumanIntervention.manual_edit` 与 `code_change.contributor_mix` 字段位预留，等 IDE 插件层（M4+）。详见 ADR 0004 D4。
 - 仍**没有**的能力：实时拦截 / token 流式即时反馈 / policy gate。要这些得走 §10.4。
 - **Sub-agent 派发**（Agent 工具）：父侧 tool_call/result 完整捕获（含 `response.agentId` 等元数据，UI 显式 surface）。子 session 在 user-global hook 装好（`agent-lens-hook setup --personal`）的前提下以独立 UUID session 捕获；`SubagentStart` / `SubagentStop` 生命周期事件以 `decision` marker 捕获，子侧带 `agent_id`，构成父→子桥接的子侧一半（预期与父侧 `tool_result.response.agentId` 配对——待 v0.2 实证）。自动 emit `delegates` link（含 `RELATION_DELEGATES` schema）仍留 v0.2，详见 ADR 0008 与追踪 issue #85。在此之前 audit reader 通过 timestamp + prompt 文本人眼对应。
@@ -286,7 +288,7 @@ v1 不计算 / 不存储费用。事件层面只承载原始 token 数,turn / se
 | R5 | 与现有 OpenTelemetry-GenAI / Langfuse 等观测系统的关系：互补还是重叠？ |
 | R6 | attestation 的密钥管理：自托管下用本地 KMS 还是 Sigstore（需外网）？ |
 | R7 | 跨厂商 TokenUsage 可比性：OpenCode / Cursor / 自研 Agent 的 usage schema 不一致——尤其 cache 语义(Anthropic 是 TTL 分桶 + 写入按倍率,OpenAI 是缓存输入打折)无法用同一字段名表达。SDK 层定义最小公约数 `TokenUsage`(input / output 通用,cache 字段按需扩展),vendor 字段保留出处,聚合时按 vendor 分组而非强行求和。详见 ADR 0002 D2。 |
-| R8 | Compaction 与部分 context 变换在 §10.1 hook 路径仅能启发式探测，精确建模等 §10.4 代理深模式或 IDE 插件层。事件载体（`context_transform`）已就位，`loss_hint.confidence = inferred / observed` 标记区分，审计端不会被静默漏报。详见 ADR 0005 D5。 |
+| R8 | Compaction **触发**已由 `PreCompact`/`PostCompact` hook 一手 observed（ADR 0013）；剩余缺口收窄为:(a) compaction **summary 文本**的精确捕获仍部分依赖 transcript 旁路 / §10.4;(b) 两 hook 未触发/未装时回落 token-budget 启发式（`inferred`);(c) `PreCompact` 无配对 `PostCompact` 时停 `provisional`（开始未确认）。`truncation`（0005 D4）暂未落地。`loss_hint.confidence = provisional / observed / inferred` 三档对审计端显式区分,不静默漏报。详见 ADR 0013 / 0005 D5。 |
 | R9 | 「某 skill 的指令正文是否进入了某一轮 context」无法从 §10.1 hook 路径验证——hook 不暴露 system prompt / context 窗口，Claude Code 也没有 skill-load hook。可得的只有两个间接信号：skill 文件在磁盘上的存在性（ADR 0003 `agent_config_snapshot` config bundle 快照）与 skill 被**调用**（`Skill` 工具的 PreToolUse / PostToolUse，见 issue #101）。精确的「context 此刻含 skill X 指令」断言等 §10.4 代理深模式。审计端据此把 skill **可用性** 与 skill **调用** 分别建模，不假装能证明 context 成分。 |
 | R10 | `SessionEnd` 在进程崩溃 / 被 kill 时不发（hook 没机会运行）——会话闭边界靠「有 `session_start` 无对应 `session_end` 收尾」反推。正常退出（`reason=prompt_input_exit`）、`/clear`（`clear`）、会话内 `/resume` 切走（`resume`）均已实测发 `session_end`（2026-05-31 抓样）；同一 `session_id` 跨多次退出 / resume 续接可发**多条** `session_end`。详见 ADR 0012。 |
 | R11 | 本地 `test_run`（ADR 0011）裁决**一律 `inferred`**：首-token 识别可能漏冷门 runner（`./run-tests.sh`/`tox`/`gradle test` 等→静默欠计，「无 `test_run`」≠「没跑测试」）、exit code 可能被管道 / `tee` / `; echo` 掩盖（解析错位），且看不进 Makefile / 脚本内部（`make test` 实跑 lint→伪 pass）。审计端不得把本地 `test_run` 当 observed 真值；observed 级留给 wrapper-CLI 后续路径。 |

--- a/cmd/agent-lens-hook/claude.go
+++ b/cmd/agent-lens-hook/claude.go
@@ -46,6 +46,10 @@ type claudeHookInput struct {
 	// carries reason (clear/resume/logout/prompt_input_exit/...). ADR 0012.
 	Source string `json:"source,omitempty"`
 	Reason string `json:"reason,omitempty"`
+	// PreCompact / PostCompact carry trigger (manual/auto); PreCompact also
+	// carries custom_instructions (what the user passed to /compact). ADR 0013.
+	Trigger            string `json:"trigger,omitempty"`
+	CustomInstructions string `json:"custom_instructions,omitempty"`
 }
 
 // runClaude reads a Claude Code hook payload on stdin and forwards a wire
@@ -116,8 +120,53 @@ func buildEvents(in *claudeHookInput) (events []map[string]any, commit func() er
 		return []map[string]any{makeSubagentLifecycle(in, "subagent_start")}, nil
 	case "SubagentStop":
 		return []map[string]any{makeSubagentLifecycle(in, "subagent_stop")}, nil
+	case "PreCompact":
+		return []map[string]any{makeCompaction(in, "provisional")}, nil
+	case "PostCompact":
+		return []map[string]any{makeCompaction(in, "observed")}, nil
 	}
 	return nil, nil
+}
+
+// makeCompaction captures a PreCompact (confidence=provisional, before the
+// compaction runs) or PostCompact (confidence=observed, after it completes)
+// hook as a context_transform.compaction event (ADR 0013). The two bracket one
+// compaction; a PreCompact with no matching PostCompact (process died mid-
+// compaction) stays provisional. triggered_by maps the trigger matcher; the
+// PreCompact's custom_instructions (what the user passed to /compact) is
+// captured through the redaction pipeline. Linker pairing into one logical
+// record + summary back-fill (ADR 0005 D2) are follow-ups.
+func makeCompaction(in *claudeHookInput, confidence string) map[string]any {
+	payload := map[string]any{
+		"sub_kind":     "compaction",
+		"triggered_by": compactionTrigger(in.Trigger),
+		"loss_hint":    map[string]any{"confidence": confidence},
+	}
+	if in.CustomInstructions != "" {
+		text, n := redactText(in.CustomInstructions)
+		before := map[string]any{"compact_instructions": text}
+		if n > 0 {
+			before["redacted_count"] = n
+		}
+		payload["before"] = before
+	}
+	return baseEvent(in, map[string]any{"type": "system", "id": "claude-code"}, "context_transform", payload)
+}
+
+// compactionTrigger maps the Claude Code trigger matcher to the ADR 0005 D1
+// triggered_by vocabulary. Unknown values pass through so an unexpected trigger
+// is recorded verbatim rather than silently mislabeled.
+func compactionTrigger(trigger string) string {
+	switch trigger {
+	case "manual":
+		return "user_explicit"
+	case "auto":
+		return "harness_auto"
+	case "":
+		return "harness_auto" // PostCompact / unspecified default
+	default:
+		return trigger
+	}
 }
 
 // makeSubagentLifecycle captures a Claude Code SubagentStart / SubagentStop

--- a/cmd/agent-lens-hook/claude_test.go
+++ b/cmd/agent-lens-hook/claude_test.go
@@ -585,3 +585,68 @@ func TestBuildEventsStopSystemReminderDedup(t *testing.T) {
 		t.Errorf("turn3 context_transform = %d, want 1 (distinct reminder)", got)
 	}
 }
+
+func TestBuildEventsPreCompact(t *testing.T) {
+	evs, commit := buildEvents(&claudeHookInput{
+		HookEventName:      "PreCompact",
+		SessionID:          "s1",
+		CWD:                "/repo",
+		Trigger:            "manual",
+		CustomInstructions: "keep the API design discussion",
+	})
+	if commit != nil {
+		t.Errorf("PreCompact should not return a commit fn")
+	}
+	if len(evs) != 1 || evs[0]["kind"] != "context_transform" {
+		t.Fatalf("got %+v, want one context_transform event", evs)
+	}
+	ev := evs[0]
+	if actor := ev["actor"].(map[string]any); actor["type"] != "system" {
+		t.Errorf("actor.type = %v, want system", actor["type"])
+	}
+	p := ev["payload"].(map[string]any)
+	if p["sub_kind"] != "compaction" {
+		t.Errorf("sub_kind = %v, want compaction", p["sub_kind"])
+	}
+	if p["triggered_by"] != "user_explicit" {
+		t.Errorf("triggered_by = %v, want user_explicit (manual)", p["triggered_by"])
+	}
+	if lh := p["loss_hint"].(map[string]any); lh["confidence"] != "provisional" {
+		t.Errorf("confidence = %v, want provisional", lh["confidence"])
+	}
+	before := p["before"].(map[string]any)
+	if before["compact_instructions"] != "keep the API design discussion" {
+		t.Errorf("compact_instructions = %v", before["compact_instructions"])
+	}
+}
+
+func TestBuildEventsPostCompactObserved(t *testing.T) {
+	evs, _ := buildEvents(&claudeHookInput{
+		HookEventName: "PostCompact",
+		SessionID:     "s1",
+		Trigger:       "auto",
+	})
+	if len(evs) != 1 || evs[0]["kind"] != "context_transform" {
+		t.Fatalf("got %+v, want one context_transform event", evs)
+	}
+	p := evs[0]["payload"].(map[string]any)
+	if lh := p["loss_hint"].(map[string]any); lh["confidence"] != "observed" {
+		t.Errorf("confidence = %v, want observed", lh["confidence"])
+	}
+	if p["triggered_by"] != "harness_auto" {
+		t.Errorf("triggered_by = %v, want harness_auto (auto)", p["triggered_by"])
+	}
+	// PostCompact carries no custom_instructions → no before block.
+	if _, ok := p["before"]; ok {
+		t.Errorf("PostCompact should have no before block: %+v", p)
+	}
+}
+
+func TestCompactionTriggerMapping(t *testing.T) {
+	cases := map[string]string{"manual": "user_explicit", "auto": "harness_auto", "": "harness_auto", "weird": "weird"}
+	for in, want := range cases {
+		if got := compactionTrigger(in); got != want {
+			t.Errorf("compactionTrigger(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cmd/agent-lens-hook/setup.go
+++ b/cmd/agent-lens-hook/setup.go
@@ -72,6 +72,10 @@ var setupHookEvents = []string{
 	// bridge the linker needs for the `delegates` link (issue #85).
 	"SubagentStart",
 	"SubagentStop",
+	// Compaction boundary (ADR 0013): PreCompact (before) + PostCompact (after)
+	// bracket a context compaction into a `context_transform` event.
+	"PreCompact",
+	"PostCompact",
 }
 
 func runSetup(args []string) {

--- a/docs/ADR/0005-context-transform-events.md
+++ b/docs/ADR/0005-context-transform-events.md
@@ -1,6 +1,6 @@
 # ADR 0005:把 context 变换升为头等事件
 
-- 状态:Accepted
+- 状态:Accepted — `loss_hint.confidence` 集合由 ADR 0013 增 `provisional` 档(compaction 经 `PreCompact` 触发、`PostCompact` 未确认时);compaction 采集主路径由 0013 的 `PreCompact`/`PostCompact` 取代 D5 的 token-budget 启发式(后者降为 fallback)。
 - 日期:2026-05-12
 - 取代:—
 - 修订:SPEC §5、§7、§10.1、§15、§17

--- a/docs/ADR/0013-precompact-context-transform.md
+++ b/docs/ADR/0013-precompact-context-transform.md
@@ -1,0 +1,99 @@
+# ADR 0013:订阅 PreCompact / PostCompact,把 compaction 从 inferred 提到 observed
+
+- 状态:Accepted
+- 日期:2026-05-29
+- 取代:—(精化 ADR 0005 D5 的 compaction confidence 阶梯,见 § 后果)
+
+## 背景
+
+ADR 0005 D1 立了 `context_transform.compaction`,但 D5 给的采集只有三档:transcript 标记(疑似可见)、token-budget 启发式(inferred、假阳)、等 §10.4 proxy。0005 写作时**未考虑 `PreCompact` / `PostCompact` hook**——它们是 harness 在压缩**前 / 后**触发的一手信号,带 `trigger`(manual / auto),能把 compaction 从 inferred 直接提到 observed,且完全不需要 §10.4。这是 0005 决策当时信息不全留下的缺口。
+
+§10.1 "已知局限" 当前写的是"compaction 首版按 token-budget 启发式推断,置 `loss_hint.confidence = inferred`"。本 ADR 用现成的 `PreCompact` + `PostCompact` 把这条局限缩小。
+
+> 本 ADR 与 ADR 0012(SessionEnd)同源拆分。两者均为"Claude Code 提供了 hook、我们没订阅"的生命周期盲区,但接受时机不同:0012 复用既有 `decision` marker、可独立接受;本 ADR 依赖 ADR 0005 的 `context_transform` EventKind 先落地。早期草案曾借用 0012 `SessionStart.source=compact` 作"后括号";核对官方文档后发现存在专门的 `PostCompact` hook(更直接的后括号),故改用之,**本 ADR 不再依赖 0012**(详见 D2)。
+
+## 验证
+
+Claude Code 官方 hooks 文档(https://code.claude.com/docs/en/hooks,2026-05-29 抓取核对,以原始页面为准):
+
+| Hook | 触发时机 | 文档化 payload / matcher | 可否 block |
+|---|---|---|---|
+| `PreCompact` | context 压缩**之前**(`/compact` 手动或自动) | `trigger`(manual / auto)+ **`custom_instructions`**(`manual` 携带用户传给 `/compact` 的内容;`auto` 为空) | 可(exit 2 / `decision:block`) |
+| `PostCompact` | context 压缩**完成之后** | `trigger`(manual / auto);结构同 `PreCompact` | 不可(纯 side-effect) |
+
+关键观察:
+
+- `PreCompact` 文档化 payload **包含 `custom_instructions`**(`manual` 带内容、`auto` 空)——故 D3 据实抓取并脱敏,**不**作为待定字段处理。
+- `PreCompact`(压缩前)与 `PostCompact`(压缩后)形成 compaction 的"前…后"括号,二者均带 `trigger`,可交叉确认。
+- 两个 hook 都**不带压缩产物(summary)**——summary 仍归 ADR 0005 D2 由 transcript 旁路在 `PostCompact` 之后补采。
+
+**仍未决、落地前必须抓样核对**:
+
+- 自动 compaction 是否**一定**先发 `PreCompact`、后发 `PostCompact`(若 harness 某些路径跳过 `PreCompact`,则 0005 D5 的 token-budget 启发式仍需作为 fallback 兜底)。
+- `PreCompact` 触发后、`PostCompact` 触发前进程崩溃 / 被 kill 时,记录形态(见 D1 的 provisional / confirmed 处理与 §后果 的崩溃缺口)。
+- `PostCompact` 之后 transcript 中 summary 的实际落点形态(供 0005 D2 补采定位)。
+
+落地 PR 按 ADR 0002 / 0005 同款记录覆盖度:用一份发生过自动 compaction、以及一次手动 `/compact` 的真实 session 核对上述三项。
+
+## 决定
+
+### D1. `PreCompact` 派生 provisional 的 `context_transform.compaction`,`PostCompact` 确认升 observed
+
+`buildEvents` 增 `PreCompact` 分支,按 ADR 0005 D1 的 `context_transform` shape 填:`sub_kind=compaction`、`applied_at=PreCompact ts`、`triggered_by` 由 `trigger` 映射(`manual → user_explicit`、`auto → harness_auto`)。
+
+confidence 分两步,避免"压缩开始即断言压缩完成":
+
+- `PreCompact` 触发时事件标 **`loss_hint.confidence = provisional`**(压缩已开始、是否完成未知)。
+- 配对的 `PostCompact`(D2)到达后,linker 把该 compaction 升 **`confidence = observed`**。
+- 若 `PreCompact` 后始终无配对 `PostCompact`(进程在压缩中崩溃),事件停在 `provisional`——审计端据此知道"压缩开始过但未确认完成",不被误读为一次干净的 observed 压缩(见 §后果)。
+
+`PreCompact` 拿不到 `after.summary_text`——summary 仍按 0005 D2 由 transcript 旁路在 `PostCompact` 之后补采,二者以 `session_id` + 时间窗关联拼成完整的 before/after。本 ADR 只负责"compaction 发生了、何时、谁触发、是否完成"的锚点;summary 文本的内容寻址 / redaction 仍归 0005 D2 / D6。
+
+**否决备选**:只靠 0005 D5 的 token-budget 启发式。inferred、假阳率随长 session 升高;`PreCompact` / `PostCompact` 是免费的一手信号,没理由不用。它不删除 D5——D5 降级为"两 hook 未触发 / 未装时的 fallback"(见 § 后果)。
+**否决备选**:`PreCompact` 触发即标 `observed`。压缩可能中途失败 / 崩溃,`PreCompact` 只证明"压缩将开始",不证明"压缩完成";provisional→observed 两步把这个区别如实表达。
+
+### D2. 订阅 `PostCompact` 作 compaction 的后括号与确认信号,**取代借用 0012 的方案**
+
+`PostCompact` 在压缩完成后触发,是比 `SessionStart.source=compact` 更直接的"后括号":它与同 `session_id` 的 `PreCompact`(D1)按 `trigger` + 时间窗配对,界定 compaction 的精确时间区间、把事件从 provisional 升 observed,并作为 0005 D2 transcript 旁路补采 summary 的触发时点。
+
+采用 `PostCompact` 后,**本 ADR 不再依赖 ADR 0012**;`SessionStart.source=compact`(0012)仍可作辅助佐证,但不是本 ADR 的必需前置。
+
+**否决备选**:沿用早期草案借 0012 的 `source=compact`。它在 0012 落地前不可用,且语义间接(借另一 hook 的字段推断"刚压缩过");`PostCompact` 是专门的一手后括号,直接、无跨 ADR 依赖。
+
+### D3. `PreCompact.custom_instructions` 过 redaction 入 payload
+
+`custom_instructions` 是文档化字段:手动 `/compact` 携带用户传入的指令、auto 为空。它记录"人对这次压缩的显式意图",属审计相关。非空则过 redaction(与 ADR 0005 D6 的 summary 同档,可能含语义 / PII)后入 `payload.before.compact_instructions`;为空则不发该字段。
+
+**否决备选**:丢弃 `custom_instructions`。它记录了人主动塑形 context 的意图,丢了就少一条"为什么这次 context 被这样重写"的线索。
+**否决备选**:把它当待定字段、抓样确认前不发(早期草案据二手摘要误判该字段不存在而采此路)。官方原始页面已确认字段存在并含 manual/auto 语义,故据实抓取;以原始文档为准,不据摘要降级。
+
+### D4. 纯观测、绝不 block、fail-soft
+
+`PreCompact` 文档上可 block(exit 2 / `decision:block`),但 agent-lens hook **绝不 block**——纯观测,一律 `os.Exit(0)`,与现有所有 hook 分支一致(`claude.go:80`)。`PostCompact` 本就不可 block。解析失败 warn 到 stderr,不中断 Claude Code 的压缩流程。
+
+## Scope
+
+本 ADR 只做文档。落地涉及:
+
+- `proto/event.proto`:**不变**——复用 ADR 0005 的 `context_transform` EventKind(其落地仍挂 0005)。`loss_hint.confidence` 增 `provisional` 值(payload 内字符串,非 proto enum);该值同样登记到 0005 的 confidence 集合(见 §后果)。
+- `cmd/agent-lens-hook/setup.go`:hook 订阅列表增 `PreCompact`、`PostCompact`。
+- `cmd/agent-lens-hook/claude.go`:`buildEvents` 增 `PreCompact` / `PostCompact` 分支;`custom_instructions` 走既有 `redactText` 出口。
+- `internal/linking/`:compaction 前后括号关联(PreCompact ↔ PostCompact),provisional→observed 升级,以及 ↔ transcript summary 补采。
+- GraphQL + Lens UI:compaction 节点显式区分 `provisional`(开始未确认)/ `observed`(已确认完成)。
+
+**本 ADR 文档本身不带代码改动;落地实现与接受同 PR(见 § 落地)。**
+
+## 后果
+
+- §10.1 Hook 直采列表增 `PreCompact`、`PostCompact`;"已知局限" 的 **Compaction 边界** bullet 改写——从"首版 token-budget 启发式 inferred"升为"首版 `PreCompact`(provisional)+ `PostCompact`(确认 observed),summary 仍由 transcript 旁路补采;两 hook 未触发时回落 0005 D5 启发式"。
+- §7 `EventKind` 不变(复用 0005 `context_transform`)。
+- §15:R8("compaction 仅能启发式探测,精确建模等 §10.4")**缩小**——compaction 触发已 observed,仅 summary 内容的精确捕获仍部分依赖 transcript / §10.4。**另加一条已知局限**:`PreCompact` 触发后进程崩溃 / 压缩中断时,无配对 `PostCompact`,compaction 事件停在 `provisional`——表示"压缩开始过、未确认完成",镜像 ADR 0012 对 `SessionEnd` 崩溃缺口的处理。
+- 与 ADR 0005 的关系:**精化 D5 的 confidence 阶梯**,并给 D1 的 `loss_hint.confidence` 集合增 `provisional` 值(observed 与 inferred 之间的"开始未确认"档)。0005 D5 把 observed 路径留给"等 §10.4 proxy",本 ADR 用 `PreCompact` / `PostCompact` 把 observed 提前到 §10.1 hook 路径;D5 的 token-budget 启发式从"首版主路径"降为"fallback"。不取代 0005 D1 的 shape、D2 的 summary 存储、D6 的 redaction。`修订(待 Accepted)` 的 SPEC 改动落地时,同步在 ADR 0005 的 confidence 集合注记 `provisional`。
+- 与 ADR 0012 的关系:改用 `PostCompact` 后**已解除对 0012 的依赖**(D2);两份 ADR 现可完全独立接受,无依赖方向。
+- 重放幂等:`PreCompact` / `PostCompact` 经 hook transport 的 at-least-once 通道(NDJSON fallback + `replay`)可能重复投递,与既有 hook 事件通性一致;compaction 事件带 `applied_at` + `trigger` + 时间窗,可在 linker 侧按 (session_id, triggered_by, 时间窗) 配对/去重。`context_transform` EventKind 已随 #131(Phase 0)落地;provisional↔observed 的配对收敛(把一次 compaction 的前后两条事件合成一条逻辑记录)归 `internal/linking` 后续。
+- 数据量:`compaction` 每 session 0–N 条(长 session 多次),observed 模式下比 0005 D5 inferred 模式更少假阳。整体仍远低于 tool_call。
+- 显式留给后续:compaction summary 文本的 observed 捕获(本 ADR 只锚前后时点,内容仍 transcript 旁路)、§10.4 proxy 下 compaction 全貌——归 ADR 0005 / §10.4 各自的修订,本 ADR 不越权。
+
+## 落地
+
+实现与接受同 PR:`PreCompact` / `PostCompact` 订阅(setup.go)+ `buildEvents` 两个分支(claude.go)——`PreCompact` 发 `context_transform.compaction`(`confidence=provisional`、`triggered_by` 由 `trigger` 映射、`before.compact_instructions` 过脱敏),`PostCompact` 发确认事件(`confidence=observed`),actor=system。`internal/linking` 的 provisional↔observed 配对收敛、以及 0005 D2 的 summary 补采,为后续子项。

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -136,7 +136,8 @@ Patch 文件的硬性约束:
 - **0008 Sub-agent 自动 link fallback**(草案):v0.1 K1 实证,撤回 `delegates`,落地 fallback。
 - **0009 Sub-agent 父→子自动链接(`delegates`)**(草案):SubagentStart.agent_id ↔ tool_result.agentId 桥接;v0.2 恢复 ADR 0007 D4 / 取代 ADR 0008 D3。
 - **0011 本地测试执行的采集**(Accepted):填 proto 既有但无产出方的 `test_run`;`PostToolUse`(Bash)首-token 识别派生,裁决均 `inferred`,不新增 EventKind。
-- **0012 订阅 SessionEnd 补齐会话边界**(Accepted):`SessionEnd` 派生 `decision.session_end`(`reason`)、`SessionStart` 增采 `source`;复用既有 `decision` marker,不新增 EventKind。(0010/0011/0013 草案见 PR #124。)
+- **0012 订阅 SessionEnd 补齐会话边界**(Accepted):`SessionEnd` 派生 `decision.session_end`(`reason`)、`SessionStart` 增采 `source`;复用既有 `decision` marker,不新增 EventKind。
+- **0013 订阅 PreCompact / PostCompact**(Accepted):compaction 从启发式 inferred 提到一手 observed;`PreCompact` 标 `provisional`、`PostCompact` 确认 `observed`、崩溃停 `provisional`;复用 0005 `context_transform`,给其 confidence 集合增 `provisional`。
 
 (0003–0005 接受时的 `spec-patches-pending-0003-0005.md` 已随 #100 合入删除。)
 


### PR DESCRIPTION
接受并实现 **ADR 0013**(从草案 PR #124 拆出)。把 compaction 从启发式 inferred 提到一手 observed。两个 commit:

1. **接受(原子,文档)**:0013 翻 `草案→Accepted`;SPEC §10.1(compaction 改为 PreCompact provisional + PostCompact observed、启发式降 fallback)+ §15 R8 收窄;`v0.8→v0.9` + 版本注;给 **0005** 加 provenance 注记(confidence 集合增 `provisional`,主路径由 0013 取代 D5 启发式——同 0010→0004 的 C1 模式)。
2. **实现**:
   - 订阅 `PreCompact` + `PostCompact`(setup.go + settings.example.json,两边同步——#127 守卫测试强制)。
   - `makeCompaction`:`PreCompact` 发 `context_transform.compaction`(`confidence=provisional`、`triggered_by`(manual→user_explicit/auto→harness_auto)、`before.compact_instructions` 过脱敏);`PostCompact` 发 `confidence=observed`。actor=system。
   - **崩溃语义**:PreCompact 无配对 PostCompact → 停 `provisional`(开始未确认),不被读成干净 compaction。

## 验证
- `go test ./...` **361 passed**;vet/gofmt 干净;example 覆盖守卫(#127)通过;无 proto/graphql/web/schema 改动。
- 测试:PreCompact provisional+trigger+instructions、PostCompact observed、trigger 映射。

## 留后续
- `internal/linking` 把 provisional↔observed 前后两条收敛成一条逻辑记录;0005 D2 的 compaction summary 文本补采。

## 路径
- 仅 `cmd/agent-lens-hook` + `.claude/settings.example.json`(非 main.go/attest/hashchain/release/proto/graphql)→ `/self-review` 足够。

🤖 Generated with [Claude Code](https://claude.com/claude-code)