### PR TITLE
docs(adr): 回写 2026-06-03 dogfood 验证结果(0010/0013 §验证)

### DIFF
--- a/docs/ADR/0010-permission-capture.md
+++ b/docs/ADR/0010-permission-capture.md
@@ -43,6 +43,13 @@ Claude Code 官方 hooks 文档(https://code.claude.com/docs/en/hooks,2026-05-29
 
 落地 PR 按 ADR 0002 同款做覆盖度记录:抓一份 `default` 模式下发生过权限对话框(含一次 allow、一次 deny)与一份 `bypassPermissions` 模式的真实 session 核对上表。
 
+**抓样核对结果(2026-06-03,dogfood dump-hook)**:
+
+- ✅ `PermissionRequest` 实测携带 **`tool_name`**(=`Bash`)——`makePermissionGate` 读工具信息成立,0010 放弃"最近未配对 PreToolUse"脆弱关联、直接用 `PermissionRequest` 作主锚的前提坐实。
+- ✅ 失败工具(`cat` 不存在文件)实测走 **`PostToolUseFailure`**(非 `PostToolUse`)且带 `tool_name`——失败工具不漏,`buildEvents` 合并分支成立。
+- ✅ `default`/ask 模式下 `PermissionRequest` 连续触发(每个非 allowlist 工具一次);**未见 `PermissionDenied`**——预期内,它只在 auto 模式分类器拒绝时触发。
+- ⏳ "交互式 deny 后既无 `PostToolUse` 也无 `PostToolUseFailure`"本次未直接验(未做一次 deny);`allow`/`unresolved` 的关联判定归 linker 后续(见 §落地)。
+
 ## 决定
 
 ### D1. **只在 `PermissionRequest` 触发时**派生 `permission_decision`;自动放行不记为人类干预

--- a/docs/ADR/0013-precompact-context-transform.md
+++ b/docs/ADR/0013-precompact-context-transform.md
@@ -35,6 +35,12 @@ Claude Code 官方 hooks 文档(https://code.claude.com/docs/en/hooks,2026-05-29
 
 落地 PR 按 ADR 0002 / 0005 同款记录覆盖度:用一份发生过自动 compaction、以及一次手动 `/compact` 的真实 session 核对上述三项。
 
+**抓样核对结果(2026-06-03,dogfood dump-hook)**:
+
+- ✅ `PreCompact` 实测携带 `trigger`(手动 `/compact` = `manual`)+ **`custom_instructions`**(手动带内容、`PostCompact` 不带)——`makeCompaction` 读 `trigger` / `custom_instructions` 的假设成立(该字段早期草案曾据二手摘要误判不存在,实测坐实存在)。
+- ✅ 手动 `/compact` 实测 `PreCompact` → `PostCompact` 成对触发,均 `trigger=manual`。
+- ⏳ 自动 compaction 的 Pre/Post 顺序、`PreCompact` 无配对 `PostCompact` 的崩溃形态、`PostCompact` 后 summary 落点——本次(手动 `/compact`)未触发到,保留为后续;D1 的"崩溃停 `provisional`"设计已兜底。
+
 ## 决定
 
 ### D1. `PreCompact` 派生 provisional 的 `context_transform.compaction`,`PostCompact` 确认升 observed


### PR DESCRIPTION
本轮 6 个新产出方上线后,用 dogfood dump-hook 抓真实 Claude Code payload 核对了 0010/0013 §验证 里"待抓样"的字段假设——**全部坐实,无需改码**。把结论回写进两份 ADR 的 §验证(带日期),关闭待抓样环。

## 实测结论
- **0013**:`PreCompact` 真带 `trigger`(manual)+ `custom_instructions`;手动 `/compact` 实测 `PreCompact→PostCompact` 成对。(自动 compaction / 崩溃形态 / summary 落点本次未触发到,保留后续。)
- **0010**:`PermissionRequest` 真带 `tool_name`(0010 主锚的前提);失败工具走 `PostToolUseFailure` 且带 `tool_name`;default 模式每个非 allowlist 工具触发一次 PermissionRequest;无 PermissionDenied(预期:仅 auto 模式)。

docs-only,无代码改动。