### PR TITLE
feat(ingest): 落地 ADR 0014 — 每事件 idempotency_key 去重 (#81)

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3,7 +3,7 @@
 > 版本：v0.11（2026-06-03）
 > 状态：草案 / 规划阶段
 >
-> v0.11 变更：接受 ADR 0014（每事件 `idempotency_key` 去重,与 `id`/哈希链排序解耦）——`Event` 增 `idempotency_key` 字段(§7)。**设计已锁定、实现延后**(gate 在 #81 真触发);hook 重放幂等是其目标。详见 `docs/ADR/0014-idempotency-key-dedup.md`。
+> v0.11 变更：落地 ADR 0014（每事件 `idempotency_key` 去重,与 `id`/哈希链排序解耦）——`Event` 增 `idempotency_key` 字段(§7);`id` 一律服务端 ULID,去重轴搬到 `idempotency_key`(server `ON CONFLICT DO NOTHING`,批量遇重跳过续行,`/v1/events` 由 409 翻为 200 `{accepted}`)。hook / git / GitHub / deploy 产出方各自填键;`replay` 对升级后事件可安全重跑。详见 `docs/ADR/0014-idempotency-key-dedup.md`(#81)。
 >
 > v0.10 变更：给 `human_intervention` 第一个产出方——订阅 `PermissionRequest`（→ `permission_decision` 记权限 gate 出现，一手证据）、`PermissionDenied`（→ `decision=deny` auto 拒绝，observed）、`PostToolUseFailure`（→ `tool_result` 补齐失败工具）。`permission_mode` 入 `tool_call.authorization`。修正 0004 D2 的 `PreToolUse` 来源声明、给 `decision` 集合增 `unresolved`。allow/unresolved 的关联判定留 linker 后续。详见 `docs/ADR/0010-permission-capture.md`。
 >
@@ -93,7 +93,7 @@ Event {
   refs:    [artifact_id]
   hash, prev_hash          // 哈希链
   sig?                     // 可选签名
-  idempotency_key?         // 每事件去重键（ADR 0014，已接受、待落地）
+  idempotency_key?         // 每事件去重键(ADR 0014);产出方生成,与 id/哈希链解耦
 }
 
 Artifact {

--- a/cmd/agent-lens-hook/claude.go
+++ b/cmd/agent-lens-hook/claude.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/oklog/ulid/v2"
+
 	"github.com/dong-qiu/agent-lens/internal/redact"
 	"github.com/dong-qiu/agent-lens/internal/transcript"
 )
@@ -544,6 +546,13 @@ func baseEvent(in *claudeHookInput, actor map[string]any, kind string, payload m
 		"actor":      actor,
 		"kind":       kind,
 		"payload":    payload,
+		// Per-event ULID dedup key (ADR 0014 D2). Generated here, once per
+		// event — so a Stop that emits several thinking/text/turn_end events
+		// in one hook call gets a distinct key each — and carried verbatim
+		// through transport and the NDJSON fallback sink, so a replay re-POSTs
+		// the same key and the server drops the duplicate. The server still
+		// assigns the ordering/hash-chain `id`; this never becomes the id.
+		"idempotency_key": ulid.Make().String(),
 	}
 }
 

--- a/cmd/agent-lens-hook/git.go
+++ b/cmd/agent-lens-hook/git.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"strings"
 	"time"
+
+	"github.com/oklog/ulid/v2"
 )
 
 // runGitPostCommit is invoked from a git post-commit hook (typically
@@ -66,6 +68,9 @@ func buildGitCommitEvent(workdir string) (map[string]any, error) {
 		"session_id": gitSessionID(repo),
 		"actor":      map[string]any{"type": "human", "id": email},
 		"kind":       "commit",
+		// Per-event dedup key (ADR 0014 D2): like baseEvent, generated at
+		// build time so a replay of the frozen fallback file is idempotent.
+		"idempotency_key": ulid.Make().String(),
 		"payload": map[string]any{
 			"sha":     sha,
 			"subject": subject,

--- a/cmd/agent-lens-hook/replay.go
+++ b/cmd/agent-lens-hook/replay.go
@@ -40,16 +40,18 @@ Example:
   agent-lens-hook replay --dry-run
   agent-lens-hook replay --remove-on-success --url http://localhost:8787
 
-Important — re-running creates duplicates in v0.1:
+Important — --remove-on-success is still required during the upgrade window:
 
-  v0.1 ingest does not dedup on event ULID; the server overrides the
-  client-supplied id with a fresh server-side ULID on every POST. So
-  re-running replay over a file that was already accepted will insert
-  duplicate events into the database (visible as doubled event counts
-  in Lens UI / GraphQL).
+  The server now dedups on a per-event idempotency key (ADR 0014): for
+  events produced by an up-to-date hook, re-running replay over an
+  already-accepted file is a no-op — the server returns 200 and skips the
+  duplicates (accepted: 0).
 
-  Always use --remove-on-success unless you have an independent
-  idempotency control. Tracking issue: #81.
+  But fallback files written before the hook gained the key carry no key,
+  so they are NOT deduplicated and re-running replay over them WILL insert
+  duplicates. A single replay run can mix old (keyless) and new files, so
+  until you're certain no pre-upgrade files remain on disk, keep using
+  --remove-on-success. Tracking issue: #81.
 `
 
 func runReplay(args []string) {

--- a/cmd/agent-lens-hook/transport.go
+++ b/cmd/agent-lens-hook/transport.go
@@ -96,7 +96,7 @@ func (t *transport) warnFallback(sessionID string, batchSize int, reason string)
 		}
 		path := filepath.Join(homeDir(), ".agent-lens", "sessions", sid+".ndjson")
 		fmt.Fprintf(os.Stderr,
-			"agent-lens-hook: ingest at %s unavailable (%s); falling back to %s (this batch: %d events). Run `agent-lens-hook replay --remove-on-success` after the server is back up to flush the backlog (the flag prevents duplicates if you re-run; see issue #81).\n",
+			"agent-lens-hook: ingest at %s unavailable (%s); falling back to %s (this batch: %d events). Run `agent-lens-hook replay --remove-on-success` after the server is back up to flush the backlog (these events carry a dedup key so a re-run is idempotent, but --remove-on-success is still recommended while pre-upgrade keyless files may remain; see issue #81).\n",
 			t.url, reason, path, batchSize,
 		)
 	})

--- a/docs/ADR/0014-idempotency-key-dedup.md
+++ b/docs/ADR/0014-idempotency-key-dedup.md
@@ -1,7 +1,7 @@
 # ADR 0014:用每事件幂等键去重,与事件 id / 哈希链排序解耦
 
-- 状态:Accepted(设计锁定;**实现延后**——见 § 落地)
-- 日期:2026-06-03
+- 状态:Accepted + **Implemented**(2026-06-04,#81——见 § 落地 末「实现记录」)
+- 日期:2026-06-03(接受)/ 2026-06-04(落地)
 - 取代:—
 
 ## 背景
@@ -101,3 +101,17 @@
 **落地触发条件**(任一):dogfood 实际观测到重放重复;或第二个产出方需要跨路径去重;或着手做依赖"事件至多一条"的下游(如某些 linker 聚合)。届时按 § Scope 一个 PR 落,走**强制 `/review`**(触及 `internal/hashchain` 推理与 store)。本设计已经两轮独立检视(2026-06-03)。
 
 接受本 ADR 时,SPEC §7 把 `idempotency_key` 列为 `Event` 的(已接受、待落地)字段,与 0003–0005 EventKind "Accepted-but-unlanded" 同例;§10.1 标注"replay 幂等:设计已接受(ADR 0014),实现 gate 在 #81"。
+
+### 实现记录(2026-06-04,#81)
+
+落地触发为「主动前置消债」(D2/D3 早已两轮检视,且去重缺口已成 0010–0013 §后果反复引用的悬空承诺),按 § Scope 一个 PR 落,走强制 `/review`:
+
+- **schema/codegen**:`proto/event.proto` 增 `idempotency_key = 13`(`make proto`);`schema.graphql` 增 `idempotencyKey: String`(`make gqlgen`)。
+- **store**(D1/D3/D5):`store.Event.IdempotencyKey`;migration `0003_idempotency_key`(列 + **partial unique index** `WHERE idempotency_key IS NOT NULL`);postgres `AppendEvent` 走 `ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL DO NOTHING`,`RowsAffected()==0`→`ErrDuplicate`,id PK 冲突仍 `ErrDuplicate`;memory 新增 `byKey` 索引去重;四个全列 SELECT + `scanEvent` 透出键。
+- **ingest**(D1/D3):`WireEvent.IdempotencyKey`(`omitempty`,使无键事件 canonical 不变);`id` **无条件**服务端 ULID(移除 `if in.ID==""`);`IngestNDJSON` 遇 `ErrDuplicate` **跳过续行 + 结构化日志**,`{accepted}` 为真实入库数;`/v1/events` 由 409 翻为 200。
+- **producers**(D2):hook `baseEvent` 每事件 `ulid.Make()` 填键;git post-commit 事件同样填键(也走 fallback/replay);GitHub 四个 mapper + deploy mapper 把 deliveryID / `Idempotency-Key` 头从 `id` 改挂 `idempotency_key`(顺带修 §验证 末条的 `id` 不变量违反)。
+- **replay/transport**(D4):`replayUsage` / `warnFallback` 措辞改为「升级后事件可安全重跑,过渡窗内仍须 `--remove-on-success`」;`postNDJSON` 本就以 2xx 为成功,200 `{accepted:0}` 自然成功,退出码语义无需改。
+- **query**(后果):`toGQLEvent` 透出 `idempotencyKey`。
+- **测试**:重写 `TestIngestOverridesSubmittedID`(id 必服务端赋)/ `TestIngestDedupesOnIdempotencyKey`(200+accepted:0)/ `TestIngestMixedBatchSkipsDupKeepsRest`;webhook redelivery 断言改 `idempotency_key`(D5 回归守卫);`TestEventLinksDataLoaderBatches` 改按服务端 id 建链;新增 `TestPostgresDedupesOnIdempotencyKey`(integration,需 Docker)。
+- **未验证**:postgres integration 测试因本机无 Docker 未实跑(代码 + `go vet -tags integration` 通过);`ON CONFLICT … WHERE … DO NOTHING` 的 partial-index 推理依赖 Postgres 标准语义。
+- **后续仍开口**:旧 keyless fallback 文件无法回填键,过渡窗内 `--remove-on-success` 仍必须(D4)。

--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -97,15 +97,21 @@ func (h *Handler) AfterAppend(fn func(context.Context, *WireEvent)) {
 // proto/event.proto but uses json.RawMessage for payload so we don't
 // re-marshal user content before hashing.
 type WireEvent struct {
-	ID        string          `json:"id,omitempty"`
-	TS        time.Time       `json:"ts"`
-	SessionID string          `json:"session_id"`
-	TurnID    string          `json:"turn_id,omitempty"`
-	Actor     WireActor       `json:"actor"`
-	Kind      string          `json:"kind"`
-	Payload   json.RawMessage `json:"payload,omitempty"`
-	Parents   []string        `json:"parents,omitempty"`
-	Refs      []string        `json:"refs,omitempty"`
+	ID string `json:"id,omitempty"`
+	// IdempotencyKey is the producer's per-event dedup key (ADR 0014). It
+	// rides the wire and the NDJSON fallback sink so a replayed event keeps
+	// the same key and the server can drop the re-POST. omitempty keeps the
+	// canonical (hashed) form byte-identical to the pre-0014 shape for
+	// keyless events, so their hashes don't shift.
+	IdempotencyKey string          `json:"idempotency_key,omitempty"`
+	TS             time.Time       `json:"ts"`
+	SessionID      string          `json:"session_id"`
+	TurnID         string          `json:"turn_id,omitempty"`
+	Actor          WireActor       `json:"actor"`
+	Kind           string          `json:"kind"`
+	Payload        json.RawMessage `json:"payload,omitempty"`
+	Parents        []string        `json:"parents,omitempty"`
+	Refs           []string        `json:"refs,omitempty"`
 }
 
 type WireActor struct {
@@ -133,6 +139,17 @@ func (h *Handler) IngestNDJSON(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if err := h.Append(r.Context(), &ev); err != nil {
+			// A duplicate is the expected replay / retried-POST case (ADR
+			// 0014 D3): skip the line and keep going rather than failing the
+			// whole batch with 409. The key is a per-event ULID, so a
+			// collision means "this exact frozen event was re-sent" — never
+			// two different events — and dropping it is always correct.
+			if errors.Is(err, store.ErrDuplicate) {
+				slog.Info("ingest dedup skip",
+					"idempotency_key", ev.IdempotencyKey,
+					"session", ev.SessionID, "kind", ev.Kind)
+				continue
+			}
 			h.writeAppendError(w, err)
 			return
 		}
@@ -178,9 +195,12 @@ func (h *Handler) appendLocked(ctx context.Context, in *WireEvent) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	if in.ID == "" {
-		in.ID = ulid.Make().String()
-	}
+	// id is ALWAYS server-assigned (ADR 0014 D1): it is the ordering +
+	// hash-chain head anchor, and chain integrity needs it monotonic in
+	// append order. A producer-supplied id (cross-process, clock-skewed)
+	// would let a late event get an id below the chain head and break the
+	// chain. Dedup rides idempotency_key instead, which never touches id.
+	in.ID = ulid.Make().String()
 	if in.TS.IsZero() {
 		in.TS = time.Now().UTC()
 	}
@@ -200,19 +220,20 @@ func (h *Handler) appendLocked(ctx context.Context, in *WireEvent) error {
 	hash := hashchain.Compute(prev, canonical)
 
 	ev := &store.Event{
-		ID:         in.ID,
-		TS:         in.TS,
-		SessionID:  in.SessionID,
-		TurnID:     in.TurnID,
-		ActorType:  in.Actor.Type,
-		ActorID:    in.Actor.ID,
-		ActorModel: in.Actor.Model,
-		Kind:       in.Kind,
-		Payload:    in.Payload,
-		Parents:    in.Parents,
-		Refs:       in.Refs,
-		Hash:       hash,
-		PrevHash:   prev,
+		ID:             in.ID,
+		TS:             in.TS,
+		SessionID:      in.SessionID,
+		TurnID:         in.TurnID,
+		ActorType:      in.Actor.Type,
+		ActorID:        in.Actor.ID,
+		ActorModel:     in.Actor.Model,
+		Kind:           in.Kind,
+		Payload:        in.Payload,
+		Parents:        in.Parents,
+		Refs:           in.Refs,
+		Hash:           hash,
+		PrevHash:       prev,
+		IdempotencyKey: in.IdempotencyKey,
 	}
 	if err := h.st.AppendEvent(ctx, ev); err != nil {
 		// Cache is intentionally not updated on append failure so the

--- a/internal/ingest/handler_test.go
+++ b/internal/ingest/handler_test.go
@@ -88,12 +88,15 @@ func TestIngestRejectsMissingFields(t *testing.T) {
 	}
 }
 
-func TestIngestPreservesSubmittedID(t *testing.T) {
+// TestIngestOverridesSubmittedID locks ADR 0014 D1: id is ALWAYS
+// server-assigned, even when the client supplies one. The submitted id
+// is ignored; the producer's idempotency_key is what's preserved.
+func TestIngestOverridesSubmittedID(t *testing.T) {
 	st := store.NewMemory()
 	srv := httptest.NewServer(NewRouter(st))
 	defer srv.Close()
 
-	body := `{"id":"01HSAMPLE","session_id":"s2","actor":{"type":"human","id":"alice"},"kind":"prompt"}`
+	body := `{"id":"01HSAMPLE","idempotency_key":"key-sample","session_id":"s2","actor":{"type":"human","id":"alice"},"kind":"prompt"}`
 	resp, err := http.Post(srv.URL+"/events", "application/x-ndjson", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("post: %v", err)
@@ -103,12 +106,23 @@ func TestIngestPreservesSubmittedID(t *testing.T) {
 		t.Fatalf("status: %d", resp.StatusCode)
 	}
 
-	got, err := st.GetEvent(context.Background(), "01HSAMPLE")
-	if err != nil {
-		t.Fatalf("get: %v", err)
+	// The client-supplied id must NOT be used.
+	if _, err := st.GetEvent(context.Background(), "01HSAMPLE"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("GetEvent(submitted id) err = %v, want ErrNotFound (id should be server-assigned)", err)
 	}
-	if got.ID != "01HSAMPLE" {
-		t.Errorf("id = %q, want %q", got.ID, "01HSAMPLE")
+
+	events, err := st.ListBySession(context.Background(), "s2", 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("stored %d events, want 1", len(events))
+	}
+	if events[0].ID == "01HSAMPLE" || events[0].ID == "" {
+		t.Errorf("id = %q, want a fresh server-assigned ULID", events[0].ID)
+	}
+	if events[0].IdempotencyKey != "key-sample" {
+		t.Errorf("idempotency_key = %q, want %q", events[0].IdempotencyKey, "key-sample")
 	}
 }
 
@@ -235,12 +249,17 @@ func TestIngestConcurrentWritesPreserveChain(t *testing.T) {
 	}
 }
 
-func TestIngestReturns409OnDuplicateID(t *testing.T) {
+// TestIngestDedupesOnIdempotencyKey locks ADR 0014 D3: re-POSTing an
+// event with an already-seen idempotency_key is a no-op — the server
+// returns 200 (not 409) and reports accepted:0 (the actual inserted
+// count, which excludes the skipped duplicate). This is the HTTP
+// contract flip that makes `replay` safe to re-run.
+func TestIngestDedupesOnIdempotencyKey(t *testing.T) {
 	st := store.NewMemory()
 	srv := httptest.NewServer(NewRouter(st))
 	defer srv.Close()
 
-	body := `{"id":"01HDUPEVENT","session_id":"s1","actor":{"type":"human","id":"alice"},"kind":"prompt"}`
+	body := `{"idempotency_key":"01HDUPKEY","session_id":"s1","actor":{"type":"human","id":"alice"},"kind":"prompt"}`
 	resp, err := http.Post(srv.URL+"/events", "application/x-ndjson", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("first post: %v", err)
@@ -252,12 +271,19 @@ func TestIngestReturns409OnDuplicateID(t *testing.T) {
 		t.Fatalf("second post: %v", err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode != http.StatusConflict {
-		t.Errorf("status = %d, want 409", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 (dedup skip, not 409)", resp.StatusCode)
+	}
+	var got struct{ Accepted int }
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Accepted != 0 {
+		t.Errorf("accepted = %d, want 0 (duplicate skipped)", got.Accepted)
 	}
 
 	// Sanity: the store still has exactly one event for the session, and
-	// the head-cache wasn't advanced past the failed insert.
+	// the head-cache wasn't advanced past the skipped insert.
 	events, err := st.ListBySession(context.Background(), "s1", 0)
 	if err != nil {
 		t.Fatalf("list: %v", err)
@@ -267,6 +293,49 @@ func TestIngestReturns409OnDuplicateID(t *testing.T) {
 	}
 }
 
+// TestIngestMixedBatchSkipsDupKeepsRest verifies a batch that contains a
+// duplicate continues past it (ADR 0014 D3): the dup is skipped, fresh
+// lines still land, and accepted reflects only the inserts.
+func TestIngestMixedBatchSkipsDupKeepsRest(t *testing.T) {
+	st := store.NewMemory()
+	srv := httptest.NewServer(NewRouter(st))
+	defer srv.Close()
+
+	first := `{"idempotency_key":"k1","session_id":"sm","actor":{"type":"human","id":"alice"},"kind":"prompt"}`
+	if resp, err := http.Post(srv.URL+"/events", "application/x-ndjson", strings.NewReader(first)); err != nil {
+		t.Fatalf("seed post: %v", err)
+	} else {
+		resp.Body.Close()
+	}
+
+	// Batch: k1 (dup) then k2 (new). Expect accepted:1, two events total.
+	batch := strings.Join([]string{
+		first,
+		`{"idempotency_key":"k2","session_id":"sm","actor":{"type":"agent","id":"claude-code"},"kind":"thought"}`,
+	}, "\n")
+	resp, err := http.Post(srv.URL+"/events", "application/x-ndjson", strings.NewReader(batch))
+	if err != nil {
+		t.Fatalf("batch post: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var got struct{ Accepted int }
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Accepted != 1 {
+		t.Errorf("accepted = %d, want 1 (k1 skipped, k2 inserted)", got.Accepted)
+	}
+	events, err := st.ListBySession(context.Background(), "sm", 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(events) != 2 {
+		t.Errorf("stored %d events, want 2", len(events))
+	}
+}
 
 // TestAppendDirectChainsAndDedupes exercises the public Handler.Append
 // contract: chained writes preserve the per-session head, validation
@@ -278,16 +347,16 @@ func TestAppendDirectChainsAndDedupes(t *testing.T) {
 	ctx := context.Background()
 
 	a := &WireEvent{
-		ID:        "01HAPPENDA",
-		SessionID: "s-direct",
-		Actor:     WireActor{Type: "human", ID: "alice"},
-		Kind:      "prompt",
+		IdempotencyKey: "key-a",
+		SessionID:      "s-direct",
+		Actor:          WireActor{Type: "human", ID: "alice"},
+		Kind:           "prompt",
 	}
 	b := &WireEvent{
-		ID:        "01HAPPENDB",
-		SessionID: "s-direct",
-		Actor:     WireActor{Type: "human", ID: "alice"},
-		Kind:      "prompt",
+		IdempotencyKey: "key-b",
+		SessionID:      "s-direct",
+		Actor:          WireActor{Type: "human", ID: "alice"},
+		Kind:           "prompt",
 	}
 	if err := h.Append(ctx, a); err != nil {
 		t.Fatalf("append a: %v", err)
@@ -317,18 +386,24 @@ func TestAppendDirectChainsAndDedupes(t *testing.T) {
 		t.Errorf("invalid kind err = %v, want errInvalidKind", err)
 	}
 
-	// Duplicate ID returns ErrDuplicate; head cache must not advance
-	// past the failed insert.
-	dup := *a
-	if err := h.Append(ctx, &dup); !errors.Is(err, store.ErrDuplicate) {
-		t.Errorf("duplicate id err = %v, want ErrDuplicate", err)
+	// A re-sent event (same idempotency_key) returns ErrDuplicate; the
+	// head cache must not advance past the skipped insert. Note id is
+	// always server-assigned, so dedup rides the key, not the id.
+	dup := &WireEvent{
+		IdempotencyKey: "key-a",
+		SessionID:      "s-direct",
+		Actor:          WireActor{Type: "human", ID: "alice"},
+		Kind:           "prompt",
+	}
+	if err := h.Append(ctx, dup); !errors.Is(err, store.ErrDuplicate) {
+		t.Errorf("duplicate key err = %v, want ErrDuplicate", err)
 	}
 
 	c := &WireEvent{
-		ID:        "01HAPPENDC",
-		SessionID: "s-direct",
-		Actor:     WireActor{Type: "human", ID: "alice"},
-		Kind:      "prompt",
+		IdempotencyKey: "key-c",
+		SessionID:      "s-direct",
+		Actor:          WireActor{Type: "human", ID: "alice"},
+		Kind:           "prompt",
 	}
 	if err := h.Append(ctx, c); err != nil {
 		t.Fatalf("append c: %v", err)

--- a/internal/ingest/handler_test.go
+++ b/internal/ingest/handler_test.go
@@ -333,7 +333,14 @@ func TestIngestMixedBatchSkipsDupKeepsRest(t *testing.T) {
 		t.Fatalf("list: %v", err)
 	}
 	if len(events) != 2 {
-		t.Errorf("stored %d events, want 2", len(events))
+		t.Fatalf("stored %d events, want 2", len(events))
+	}
+	// The chain must stay intact across the skipped duplicate: k2 chains
+	// onto k1 (the real head), and skipping k1 must not have advanced or
+	// corrupted the head cache.
+	if events[1].PrevHash != events[0].Hash {
+		t.Errorf("chain broke across skipped dup: k2.prev_hash = %q, want k1.hash %q",
+			events[1].PrevHash, events[0].Hash)
 	}
 }
 

--- a/internal/migrate/sql/0003_idempotency_key.down.sql
+++ b/internal/migrate/sql/0003_idempotency_key.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS events_idempotency_key_uidx;
+ALTER TABLE events DROP COLUMN IF EXISTS idempotency_key;

--- a/internal/migrate/sql/0003_idempotency_key.up.sql
+++ b/internal/migrate/sql/0003_idempotency_key.up.sql
@@ -1,0 +1,12 @@
+-- ADR 0014: per-event idempotency key, decoupled from id / the hash chain.
+-- `id` stays the server-assigned ordering + chain anchor; `idempotency_key`
+-- is the producer-supplied dedup axis that survives a fallback replay.
+ALTER TABLE events ADD COLUMN idempotency_key TEXT;
+
+-- Partial unique index: only non-NULL keys are constrained, so pre-0014
+-- events (key NULL) and keyless webhook deliveries coexist without
+-- conflicting. ON CONFLICT inference in AppendEvent targets this index via
+-- the matching `WHERE idempotency_key IS NOT NULL` predicate.
+CREATE UNIQUE INDEX events_idempotency_key_uidx
+    ON events (idempotency_key)
+    WHERE idempotency_key IS NOT NULL;

--- a/internal/pb/event.pb.go
+++ b/internal/pb/event.pb.go
@@ -166,21 +166,27 @@ func (EventKind) EnumDescriptor() ([]byte, []int) {
 // Event is the canonical record for one observable action in the human-agent
 // coding pipeline. Events are append-only and form a hash chain via prev_hash.
 type Event struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"` // ULID
-	Ts            *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=ts,proto3" json:"ts,omitempty"`
-	SessionId     string                 `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
-	TurnId        string                 `protobuf:"bytes,4,opt,name=turn_id,json=turnId,proto3" json:"turn_id,omitempty"`
-	Actor         *Actor                 `protobuf:"bytes,5,opt,name=actor,proto3" json:"actor,omitempty"`
-	Kind          EventKind              `protobuf:"varint,6,opt,name=kind,proto3,enum=agentlens.v1.EventKind" json:"kind,omitempty"`
-	Payload       *structpb.Struct       `protobuf:"bytes,7,opt,name=payload,proto3" json:"payload,omitempty"`                    // kind-specific
-	Parents       []string               `protobuf:"bytes,8,rep,name=parents,proto3" json:"parents,omitempty"`                    // causal upstream event IDs
-	Refs          []string               `protobuf:"bytes,9,rep,name=refs,proto3" json:"refs,omitempty"`                          // referenced artifact IDs
-	Hash          string                 `protobuf:"bytes,10,opt,name=hash,proto3" json:"hash,omitempty"`                         // hash(serialized event - hash - sig)
-	PrevHash      string                 `protobuf:"bytes,11,opt,name=prev_hash,json=prevHash,proto3" json:"prev_hash,omitempty"` // hash of previous event in chain
-	Sig           []byte                 `protobuf:"bytes,12,opt,name=sig,proto3" json:"sig,omitempty"`                           // optional ed25519 signature
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	state     protoimpl.MessageState `protogen:"open.v1"`
+	Id        string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"` // ULID
+	Ts        *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=ts,proto3" json:"ts,omitempty"`
+	SessionId string                 `protobuf:"bytes,3,opt,name=session_id,json=sessionId,proto3" json:"session_id,omitempty"`
+	TurnId    string                 `protobuf:"bytes,4,opt,name=turn_id,json=turnId,proto3" json:"turn_id,omitempty"`
+	Actor     *Actor                 `protobuf:"bytes,5,opt,name=actor,proto3" json:"actor,omitempty"`
+	Kind      EventKind              `protobuf:"varint,6,opt,name=kind,proto3,enum=agentlens.v1.EventKind" json:"kind,omitempty"`
+	Payload   *structpb.Struct       `protobuf:"bytes,7,opt,name=payload,proto3" json:"payload,omitempty"`                    // kind-specific
+	Parents   []string               `protobuf:"bytes,8,rep,name=parents,proto3" json:"parents,omitempty"`                    // causal upstream event IDs
+	Refs      []string               `protobuf:"bytes,9,rep,name=refs,proto3" json:"refs,omitempty"`                          // referenced artifact IDs
+	Hash      string                 `protobuf:"bytes,10,opt,name=hash,proto3" json:"hash,omitempty"`                         // hash(serialized event - hash - sig)
+	PrevHash  string                 `protobuf:"bytes,11,opt,name=prev_hash,json=prevHash,proto3" json:"prev_hash,omitempty"` // hash of previous event in chain
+	Sig       []byte                 `protobuf:"bytes,12,opt,name=sig,proto3" json:"sig,omitempty"`                           // optional ed25519 signature
+	// Producer-generated per-event ULID used solely as the dedup key (ADR
+	// 0014). Decoupled from `id`: `id` is the server-assigned ordering /
+	// hash-chain anchor, `idempotency_key` is what survives a replay so the
+	// server can drop a re-POSTed event. NULL/empty for pre-0014 events and
+	// for webhook deliveries without an Idempotency-Key header.
+	IdempotencyKey string `protobuf:"bytes,13,opt,name=idempotency_key,json=idempotencyKey,proto3" json:"idempotency_key,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *Event) Reset() {
@@ -297,6 +303,13 @@ func (x *Event) GetSig() []byte {
 	return nil
 }
 
+func (x *Event) GetIdempotencyKey() string {
+	if x != nil {
+		return x.IdempotencyKey
+	}
+	return ""
+}
+
 type Actor struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Type          ActorType              `protobuf:"varint,1,opt,name=type,proto3,enum=agentlens.v1.ActorType" json:"type,omitempty"`
@@ -361,7 +374,7 @@ var File_event_proto protoreflect.FileDescriptor
 
 const file_event_proto_rawDesc = "" +
 	"\n" +
-	"\vevent.proto\x12\fagentlens.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xf7\x02\n" +
+	"\vevent.proto\x12\fagentlens.v1\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa0\x03\n" +
 	"\x05Event\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12*\n" +
 	"\x02ts\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\x02ts\x12\x1d\n" +
@@ -376,7 +389,8 @@ const file_event_proto_rawDesc = "" +
 	"\x04hash\x18\n" +
 	" \x01(\tR\x04hash\x12\x1b\n" +
 	"\tprev_hash\x18\v \x01(\tR\bprevHash\x12\x10\n" +
-	"\x03sig\x18\f \x01(\fR\x03sig\"Z\n" +
+	"\x03sig\x18\f \x01(\fR\x03sig\x12'\n" +
+	"\x0fidempotency_key\x18\r \x01(\tR\x0eidempotencyKey\"Z\n" +
 	"\x05Actor\x12+\n" +
 	"\x04type\x18\x01 \x01(\x0e2\x17.agentlens.v1.ActorTypeR\x04type\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12\x14\n" +

--- a/internal/query/generated.go
+++ b/internal/query/generated.go
@@ -44,20 +44,21 @@ type ComplexityRoot struct {
 	}
 
 	Event struct {
-		Actor      func(childComplexity int) int
-		Hash       func(childComplexity int) int
-		ID         func(childComplexity int) int
-		Kind       func(childComplexity int) int
-		Links      func(childComplexity int) int
-		Parents    func(childComplexity int) int
-		Payload    func(childComplexity int) int
-		PrevHash   func(childComplexity int) int
-		Refs       func(childComplexity int) int
-		SessionID  func(childComplexity int) int
-		StopReason func(childComplexity int) int
-		Ts         func(childComplexity int) int
-		TurnID     func(childComplexity int) int
-		Usage      func(childComplexity int) int
+		Actor          func(childComplexity int) int
+		Hash           func(childComplexity int) int
+		ID             func(childComplexity int) int
+		IdempotencyKey func(childComplexity int) int
+		Kind           func(childComplexity int) int
+		Links          func(childComplexity int) int
+		Parents        func(childComplexity int) int
+		Payload        func(childComplexity int) int
+		PrevHash       func(childComplexity int) int
+		Refs           func(childComplexity int) int
+		SessionID      func(childComplexity int) int
+		StopReason     func(childComplexity int) int
+		Ts             func(childComplexity int) int
+		TurnID         func(childComplexity int) int
+		Usage          func(childComplexity int) int
 	}
 
 	Link struct {
@@ -162,6 +163,12 @@ func (e *executableSchema) Complexity(ctx context.Context, typeName, field strin
 		}
 
 		return e.ComplexityRoot.Event.ID(childComplexity), true
+	case "Event.idempotencyKey":
+		if e.ComplexityRoot.Event.IdempotencyKey == nil {
+			break
+		}
+
+		return e.ComplexityRoot.Event.IdempotencyKey(childComplexity), true
 	case "Event.kind":
 		if e.ComplexityRoot.Event.Kind == nil {
 			break
@@ -531,6 +538,8 @@ func (ec *executionContext) childFields_Event(ctx context.Context, field graphql
 		return ec.fieldContext_Event_hash(ctx, field)
 	case "prevHash":
 		return ec.fieldContext_Event_prevHash(ctx, field)
+	case "idempotencyKey":
+		return ec.fieldContext_Event_idempotencyKey(ctx, field)
 	case "links":
 		return ec.fieldContext_Event_links(ctx, field)
 	case "usage":
@@ -1223,6 +1232,29 @@ func (ec *executionContext) _Event_prevHash(ctx context.Context, field graphql.C
 	)
 }
 func (ec *executionContext) fieldContext_Event_prevHash(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	return graphql.NewScalarFieldContext("Event", field, false, false, errors.New("field of type String does not have child fields"))
+}
+
+func (ec *executionContext) _Event_idempotencyKey(ctx context.Context, field graphql.CollectedField, obj *Event) (ret graphql.Marshaler) {
+	return graphql.ResolveField(
+		ctx,
+		ec.OperationContext,
+		field,
+		func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return ec.fieldContext_Event_idempotencyKey(ctx, field)
+		},
+		func(ctx context.Context) (any, error) {
+			return obj.IdempotencyKey, nil
+		},
+		nil,
+		func(ctx context.Context, selections ast.SelectionSet, v *string) graphql.Marshaler {
+			return ec.marshalOString2ᚖstring(ctx, selections, v)
+		},
+		true,
+		false,
+	)
+}
+func (ec *executionContext) fieldContext_Event_idempotencyKey(_ context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
 	return graphql.NewScalarFieldContext("Event", field, false, false, errors.New("field of type String does not have child fields"))
 }
 
@@ -3248,6 +3280,8 @@ func (ec *executionContext) _Event(ctx context.Context, sel ast.SelectionSet, ob
 			}
 		case "prevHash":
 			out.Values[i] = ec._Event_prevHash(ctx, field, obj)
+		case "idempotencyKey":
+			out.Values[i] = ec._Event_idempotencyKey(ctx, field, obj)
 		case "links":
 			field := field
 

--- a/internal/query/mapper.go
+++ b/internal/query/mapper.go
@@ -41,6 +41,10 @@ func toGQLEvent(se *store.Event) *Event {
 		p := se.PrevHash
 		ev.PrevHash = &p
 	}
+	if se.IdempotencyKey != "" {
+		k := se.IdempotencyKey
+		ev.IdempotencyKey = &k
+	}
 	if len(se.Payload) > 0 {
 		var p map[string]any
 		if err := json.Unmarshal(se.Payload, &p); err == nil {
@@ -91,10 +95,10 @@ func toGQLLink(l *store.Link) *Link {
 // Adding a new TokenUsage field requires touching FOUR places, kept
 // in lock-step intentionally so a stale producer / consumer / shape
 // fails loudly rather than dropping data:
-//   1. internal/transcript/reader.go           — TokenUsage struct + extractUsage mapping (producer)
-//   2. internal/query/mapper.go (this file)    — wireUsage struct + decodePayloadUsage assignment + aggregateSessionUsage accumulator
-//   3. internal/query/schema.graphql           — TokenUsage type (regen via `make gqlgen`)
-//   4. web/src/types.ts + UI chips             — TokenUsage type + chip / tooltip rendering
+//  1. internal/transcript/reader.go           — TokenUsage struct + extractUsage mapping (producer)
+//  2. internal/query/mapper.go (this file)    — wireUsage struct + decodePayloadUsage assignment + aggregateSessionUsage accumulator
+//  3. internal/query/schema.graphql           — TokenUsage type (regen via `make gqlgen`)
+//  4. web/src/types.ts + UI chips             — TokenUsage type + chip / tooltip rendering
 //
 // TestTokenUsageGraphQLShape catches drift on (3); the others rely on
 // build-time field alignment between wireUsage / TokenUsage. Keep

--- a/internal/query/models_gen.go
+++ b/internal/query/models_gen.go
@@ -28,6 +28,13 @@ type Event struct {
 	Refs      []string       `json:"refs"`
 	Hash      string         `json:"hash"`
 	PrevHash  *string        `json:"prevHash,omitempty"`
+	// Producer-supplied per-event ULID dedup key (ADR 0014). Distinct from
+	// `id` (the server-assigned ordering / hash-chain anchor): this is the
+	// value that survives a fallback replay so the server can drop a re-POST.
+	// Null for pre-0014 events and webhook deliveries without an
+	// Idempotency-Key header. Events dropped as duplicates have no row to
+	// query — "what got deduped" lives only in the server's skip logs.
+	IdempotencyKey *string `json:"idempotencyKey,omitempty"`
 	// All links touching this event in either direction (from/to).
 	Links []*Link `json:"links"`
 	// Token usage of the assistant message that derived this event. Present

--- a/internal/query/router_test.go
+++ b/internal/query/router_test.go
@@ -60,10 +60,10 @@ func TestVerticalSliceIngestThenQuery(t *testing.T) {
 	var got struct {
 		Data struct {
 			Events []struct {
-				ID    string         `json:"id"`
-				Kind  string         `json:"kind"`
-				Actor struct{ Type, Model string } `json:"actor"`
-				Payload map[string]any `json:"payload"`
+				ID      string                       `json:"id"`
+				Kind    string                       `json:"kind"`
+				Actor   struct{ Type, Model string } `json:"actor"`
+				Payload map[string]any               `json:"payload"`
 			} `json:"events"`
 		} `json:"data"`
 		Errors []map[string]any `json:"errors"`
@@ -279,7 +279,6 @@ func TestEventLinksResolver(t *testing.T) {
 		t.Errorf("inferred_by = %q", link.InferredBy)
 	}
 }
-
 
 // TestLinkedEventsResolver covers the BFS by session id: two sessions
 // share a `git:<sha>` ref; the linker emits a cross-session link. A
@@ -756,11 +755,12 @@ func TestEventLinksDataLoaderBatches(t *testing.T) {
 	srv := httptest.NewServer(r)
 	defer srv.Close()
 
-	// Five events in one session with explicit ids so we can link two of them.
+	// Five events in one session. Ids are server-assigned (ADR 0014), so we
+	// read them back after ingest and link two of them by their real ids.
 	lines := make([]string, 0, 5)
 	for i := 0; i < 5; i++ {
 		lines = append(lines, fmt.Sprintf(
-			`{"id":"01EVT%d","session_id":"s1","actor":{"type":"agent","id":"c"},"kind":"tool_call","payload":{"name":"E%d"}}`, i, i))
+			`{"session_id":"s1","actor":{"type":"agent","id":"c"},"kind":"tool_call","payload":{"name":"E%d"}}`, i))
 	}
 	resp, err := http.Post(srv.URL+"/v1/events", "application/x-ndjson", strings.NewReader(strings.Join(lines, "\n")))
 	if err != nil {
@@ -771,8 +771,17 @@ func TestEventLinksDataLoaderBatches(t *testing.T) {
 		t.Fatalf("ingest status = %d, want 200", resp.StatusCode)
 	}
 
+	seeded, err := st.ListBySession(context.Background(), "s1", 0)
+	if err != nil {
+		t.Fatalf("list seeded: %v", err)
+	}
+	if len(seeded) != 5 {
+		t.Fatalf("seeded %d events, want 5", len(seeded))
+	}
+	evt0, evt1, evt2 := seeded[0].ID, seeded[1].ID, seeded[2].ID
+
 	if err := st.AppendLink(context.Background(), &store.Link{
-		FromEvent: "01EVT0", ToEvent: "01EVT1", Relation: "references", Confidence: 1, InferredBy: "test",
+		FromEvent: evt0, ToEvent: evt1, Relation: "references", Confidence: 1, InferredBy: "test",
 	}); err != nil {
 		t.Fatalf("AppendLink: %v", err)
 	}
@@ -817,10 +826,10 @@ func TestEventLinksDataLoaderBatches(t *testing.T) {
 	for _, e := range got.Data.Events {
 		links[e.ID] = len(e.Links)
 	}
-	if links["01EVT0"] != 1 || links["01EVT1"] != 1 {
-		t.Errorf("linked endpoints: 01EVT0=%d 01EVT1=%d, want 1 each", links["01EVT0"], links["01EVT1"])
+	if links[evt0] != 1 || links[evt1] != 1 {
+		t.Errorf("linked endpoints: %s=%d %s=%d, want 1 each", evt0, links[evt0], evt1, links[evt1])
 	}
-	if links["01EVT2"] != 0 {
-		t.Errorf("unlinked event 01EVT2 has %d links, want 0", links["01EVT2"])
+	if links[evt2] != 0 {
+		t.Errorf("unlinked event %s has %d links, want 0", evt2, links[evt2])
 	}
 }

--- a/internal/query/schema.graphql
+++ b/internal/query/schema.graphql
@@ -13,6 +13,15 @@ type Event {
   refs: [ID!]!
   hash: String!
   prevHash: String
+  """
+  Producer-supplied per-event ULID dedup key (ADR 0014). Distinct from
+  `id` (the server-assigned ordering / hash-chain anchor): this is the
+  value that survives a fallback replay so the server can drop a re-POST.
+  Null for pre-0014 events and webhook deliveries without an
+  Idempotency-Key header. Events dropped as duplicates have no row to
+  query — "what got deduped" lives only in the server's skip logs.
+  """
+  idempotencyKey: String
   """All links touching this event in either direction (from/to)."""
   links: [Link!]!
   """

--- a/internal/store/memory.go
+++ b/internal/store/memory.go
@@ -13,12 +13,18 @@ type Memory struct {
 	mu     sync.Mutex
 	events []*Event
 	byID   map[string]*Event
-	links  map[string]Link // key: from|to|relation
+	// byKey indexes events by idempotency_key for dedup (ADR 0014 D5).
+	// Distinct from byID: ids are now always unique server ULIDs, so byID
+	// no longer detects the duplicates the webhook-redelivery / replay
+	// paths produce — only byKey does. Keyless events are absent here.
+	byKey map[string]*Event
+	links map[string]Link // key: from|to|relation
 }
 
 func NewMemory() *Memory {
 	return &Memory{
 		byID:  map[string]*Event{},
+		byKey: map[string]*Event{},
 		links: map[string]Link{},
 	}
 }
@@ -52,12 +58,26 @@ func (m *Memory) Close() error { return nil }
 func (m *Memory) AppendEvent(_ context.Context, e *Event) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// Dedup on idempotency_key (ADR 0014 D3/D5): a non-empty key already
+	// seen is the expected replay / webhook-redelivery duplicate. Keyless
+	// events (empty key) are never deduped, mirroring Postgres's partial
+	// unique index that excludes NULL keys.
+	if e.IdempotencyKey != "" {
+		if _, exists := m.byKey[e.IdempotencyKey]; exists {
+			return ErrDuplicate
+		}
+	}
+	// id collisions remain a should-not-happen bug (ids are fresh server
+	// ULIDs); keep rejecting them to mirror the Postgres PRIMARY KEY.
 	if _, exists := m.byID[e.ID]; exists {
 		return ErrDuplicate
 	}
 	cp := *e
 	m.events = append(m.events, &cp)
 	m.byID[cp.ID] = &cp
+	if cp.IdempotencyKey != "" {
+		m.byKey[cp.IdempotencyKey] = &cp
+	}
 	return nil
 }
 

--- a/internal/store/postgres.go
+++ b/internal/store/postgres.go
@@ -73,21 +73,39 @@ func (p *Postgres) AppendEvent(ctx context.Context, e *Event) error {
 	const q = `
 		INSERT INTO events
 		  (id, ts, session_id, turn_id, actor_type, actor_id, actor_model,
-		   kind, payload, parents, refs, hash, prev_hash, sig)
+		   kind, payload, parents, refs, hash, prev_hash, sig, idempotency_key)
 		VALUES
-		  ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14)
+		  ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)
+		ON CONFLICT (idempotency_key) WHERE idempotency_key IS NOT NULL
+		  DO NOTHING
 	`
-	_, err := p.pool.Exec(ctx, q,
+	// ON CONFLICT DO NOTHING (ADR 0014 D3) makes a re-POSTed event a no-op
+	// rather than an error: a duplicate idempotency_key inserts zero rows,
+	// which we report as ErrDuplicate so the HTTP path skips-and-continues
+	// instead of failing the batch. The conflict target carries the partial
+	// index's `WHERE idempotency_key IS NOT NULL` predicate so PG can infer
+	// the right (partial) unique index. A NULL key never conflicts, so
+	// keyless events always insert (RowsAffected == 1).
+	tag, err := p.pool.Exec(ctx, q,
 		e.ID, e.TS, e.SessionID, nullable(e.TurnID),
 		e.ActorType, e.ActorID, nullable(e.ActorModel),
 		e.Kind, e.Payload, emptyIfNil(e.Parents), emptyIfNil(e.Refs),
-		e.Hash, nullable(e.PrevHash), e.Sig,
+		e.Hash, nullable(e.PrevHash), e.Sig, nullable(e.IdempotencyKey),
 	)
-	var pgErr *pgconn.PgError
-	if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
+	if err != nil {
+		// A PRIMARY KEY (id) violation still lands here, not via ON CONFLICT
+		// — ids are now always fresh server ULIDs, so this is a
+		// should-not-happen collision; surface it as ErrDuplicate too.
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
+			return ErrDuplicate
+		}
+		return err
+	}
+	if tag.RowsAffected() == 0 {
 		return ErrDuplicate
 	}
-	return err
+	return nil
 }
 
 func emptyIfNil(s []string) []string {
@@ -99,7 +117,7 @@ func emptyIfNil(s []string) []string {
 
 func (p *Postgres) GetEvent(ctx context.Context, id string) (*Event, error) {
 	const q = `SELECT id, ts, session_id, turn_id, actor_type, actor_id, actor_model,
-		kind, payload, parents, refs, hash, prev_hash, sig
+		kind, payload, parents, refs, hash, prev_hash, sig, idempotency_key
 		FROM events WHERE id = $1`
 	row := p.pool.QueryRow(ctx, q, id)
 	e, err := scanEvent(row)
@@ -116,7 +134,7 @@ func (p *Postgres) ListBySession(ctx context.Context, sessionID string, limit in
 	// already-appended event's ts — sorting by ts then walks the hash chain
 	// in the wrong order. See issue #38.
 	const q = `SELECT id, ts, session_id, turn_id, actor_type, actor_id, actor_model,
-		kind, payload, parents, refs, hash, prev_hash, sig
+		kind, payload, parents, refs, hash, prev_hash, sig, idempotency_key
 		FROM events WHERE session_id = $1 ORDER BY id ASC LIMIT $2`
 	// limit <= 0 means "no limit"; PG would otherwise treat 0 literally.
 	if limit <= 0 {
@@ -148,7 +166,7 @@ func (p *Postgres) EventsBeforeID(ctx context.Context, sessionID, eventID string
 	const q = `
 		WITH window_events AS (
 			SELECT id, ts, session_id, turn_id, actor_type, actor_id, actor_model,
-			       kind, payload, parents, refs, hash, prev_hash, sig
+			       kind, payload, parents, refs, hash, prev_hash, sig, idempotency_key
 			FROM events
 			WHERE session_id = $1 AND id < $2
 			ORDER BY id DESC
@@ -188,7 +206,7 @@ func (p *Postgres) HeadHash(ctx context.Context, sessionID string) (string, erro
 
 func (p *Postgres) EventsByRef(ctx context.Context, ref string) ([]*Event, error) {
 	const q = `SELECT id, ts, session_id, turn_id, actor_type, actor_id, actor_model,
-		kind, payload, parents, refs, hash, prev_hash, sig
+		kind, payload, parents, refs, hash, prev_hash, sig, idempotency_key
 		FROM events WHERE $1 = ANY(refs) ORDER BY ts ASC, id ASC`
 	rows, err := p.pool.Query(ctx, q, ref)
 	if err != nil {
@@ -340,11 +358,11 @@ type scanner interface {
 
 func scanEvent(s scanner) (*Event, error) {
 	var e Event
-	var turn, model, prev *string
+	var turn, model, prev, idemKey *string
 	if err := s.Scan(&e.ID, &e.TS, &e.SessionID, &turn,
 		&e.ActorType, &e.ActorID, &model,
 		&e.Kind, &e.Payload, &e.Parents, &e.Refs,
-		&e.Hash, &prev, &e.Sig); err != nil {
+		&e.Hash, &prev, &e.Sig, &idemKey); err != nil {
 		return nil, err
 	}
 	if turn != nil {
@@ -355,6 +373,9 @@ func scanEvent(s scanner) (*Event, error) {
 	}
 	if prev != nil {
 		e.PrevHash = *prev
+	}
+	if idemKey != nil {
+		e.IdempotencyKey = *idemKey
 	}
 	return &e, nil
 }

--- a/internal/store/postgres_integration_test.go
+++ b/internal/store/postgres_integration_test.go
@@ -176,6 +176,51 @@ func TestPostgresRejectsDuplicateID(t *testing.T) {
 	}
 }
 
+// TestPostgresDedupesOnIdempotencyKey locks ADR 0014 D3/D5 against the
+// real backend: two events with DISTINCT ids but the SAME non-empty
+// idempotency_key — the replay / webhook-redelivery shape — must collapse
+// to one row (ON CONFLICT DO NOTHING → ErrDuplicate), while keyless
+// events with distinct ids both insert (the partial unique index excludes
+// NULL). Memory mirrors this; see the ingest/webhook handler tests.
+func TestPostgresDedupesOnIdempotencyKey(t *testing.T) {
+	ctx := context.Background()
+	st, cleanup := openPostgresWithSchema(ctx, t)
+	defer cleanup()
+
+	mk := func(id, key string) *Event {
+		return &Event{
+			ID: id, TS: time.Now().UTC(), SessionID: "s-key",
+			ActorType: "system", ActorID: "deploy", Kind: "deploy",
+			Hash: id, IdempotencyKey: key,
+		}
+	}
+
+	// Same key, different ids → second is a dropped duplicate.
+	if err := st.AppendEvent(ctx, mk("01KEYAAAA", "dup-key")); err != nil {
+		t.Fatalf("first keyed append: %v", err)
+	}
+	if err := st.AppendEvent(ctx, mk("01KEYBBBB", "dup-key")); !errors.Is(err, ErrDuplicate) {
+		t.Errorf("second keyed append err = %v, want ErrDuplicate", err)
+	}
+
+	// Keyless events (NULL key) are never deduped, even with distinct ids.
+	if err := st.AppendEvent(ctx, mk("01NULLAAA", "")); err != nil {
+		t.Fatalf("first keyless append: %v", err)
+	}
+	if err := st.AppendEvent(ctx, mk("01NULLBBB", "")); err != nil {
+		t.Errorf("second keyless append err = %v, want success (NULL keys don't conflict)", err)
+	}
+
+	got, err := st.ListBySession(ctx, "s-key", 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	// 1 keyed (dup dropped) + 2 keyless = 3.
+	if len(got) != 3 {
+		t.Errorf("stored %d events, want 3 (1 keyed survivor + 2 keyless)", len(got))
+	}
+}
+
 // openPostgresWithSchema is the shared setup used by the integration tests.
 // It spins up a fresh container, applies the embedded schema, and returns
 // the store along with a teardown.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,27 +7,36 @@ import (
 )
 
 var (
-	ErrNotFound  = errors.New("event not found")
-	ErrDuplicate = errors.New("event id already exists")
+	ErrNotFound = errors.New("event not found")
+	// ErrDuplicate is returned when an append is rejected as a duplicate.
+	// Post-ADR-0014 the dedup axis is idempotency_key, not id: id is now
+	// always a fresh server ULID, so an id collision is a should-not-happen
+	// bug while a key collision is the expected replay / webhook-redelivery
+	// case the dedup exists to absorb.
+	ErrDuplicate = errors.New("event already exists")
 )
 
 // Event is the storage-layer representation. It mirrors proto/event.proto but
 // keeps payload as raw JSON so the store does not depend on generated pb.
 type Event struct {
-	ID        string
-	TS        time.Time
-	SessionID string
-	TurnID    string
-	ActorType string
-	ActorID   string
+	ID         string
+	TS         time.Time
+	SessionID  string
+	TurnID     string
+	ActorType  string
+	ActorID    string
 	ActorModel string
-	Kind      string
-	Payload   []byte // canonical JSON
-	Parents   []string
-	Refs      []string
-	Hash      string
-	PrevHash  string
-	Sig       []byte
+	Kind       string
+	Payload    []byte // canonical JSON
+	Parents    []string
+	Refs       []string
+	Hash       string
+	PrevHash   string
+	Sig        []byte
+	// IdempotencyKey is the producer-supplied per-event dedup key (ADR
+	// 0014). Empty for pre-0014 events and for webhook deliveries with no
+	// Idempotency-Key header; such events are never deduplicated.
+	IdempotencyKey string
 }
 
 // SessionSummary is an aggregated view of a single session: when it

--- a/internal/webhooks/deploy/handler_test.go
+++ b/internal/webhooks/deploy/handler_test.go
@@ -46,8 +46,11 @@ func TestMapDeployHappyPath(t *testing.T) {
 	if ev.SessionID != "deploy:production" {
 		t.Errorf("session_id = %q (must be per-environment)", ev.SessionID)
 	}
-	if ev.ID != "deploy-1" {
-		t.Errorf("id = %q, want deploy-1", ev.ID)
+	if ev.IdempotencyKey != "deploy-1" {
+		t.Errorf("idempotency_key = %q, want deploy-1", ev.IdempotencyKey)
+	}
+	if ev.ID != "" {
+		t.Errorf("id = %q, want empty (server assigns the id, ADR 0014)", ev.ID)
 	}
 	if ev.Actor.Type != "system" || ev.Actor.ID != "alice" {
 		t.Errorf("actor = %+v", ev.Actor)
@@ -112,8 +115,11 @@ func TestHandlerHappyPath(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("got %d events, want 1", len(events))
 	}
-	if events[0].ID != "deploy-key-1" {
-		t.Errorf("event id = %q, want idempotency key", events[0].ID)
+	if events[0].IdempotencyKey != "deploy-key-1" {
+		t.Errorf("event idempotency_key = %q, want %q", events[0].IdempotencyKey, "deploy-key-1")
+	}
+	if events[0].ID == "" || events[0].ID == "deploy-key-1" {
+		t.Errorf("event id = %q, want a server-assigned ULID distinct from the key", events[0].ID)
 	}
 }
 

--- a/internal/webhooks/deploy/mapper.go
+++ b/internal/webhooks/deploy/mapper.go
@@ -33,15 +33,16 @@ type payload struct {
 const maxEnvironmentLen = 64
 
 // maxIdempotencyKeyLen caps the Idempotency-Key header so an attacker
-// can't smuggle a multi-MB key into the events.id column. ULIDs are
-// 26 chars, UUIDs are 36; 128 is comfortable headroom.
+// can't smuggle a multi-MB key into the events.idempotency_key column.
+// ULIDs are 26 chars, UUIDs are 36; 128 is comfortable headroom.
 const maxIdempotencyKeyLen = 128
 
 // mapDeploy parses the body, derives session_id / actor / refs, and
-// returns a wire event ready for ingest. eventID is the optional
-// Idempotency-Key header value; empty falls back to a server-assigned
-// ULID and the call won't be deduplicated.
-func mapDeploy(raw json.RawMessage, eventID string) (*ingest.WireEvent, error) {
+// returns a wire event ready for ingest. idempotencyKey is the optional
+// Idempotency-Key header value, set as the event's dedup key (ADR 0014);
+// empty means the delivery won't be deduplicated. The `id` is always
+// server-assigned regardless.
+func mapDeploy(raw json.RawMessage, idempotencyKey string) (*ingest.WireEvent, error) {
 	var p payload
 	if err := json.Unmarshal(raw, &p); err != nil {
 		return nil, fmt.Errorf("decode deploy: %w", err)
@@ -52,8 +53,8 @@ func mapDeploy(raw json.RawMessage, eventID string) (*ingest.WireEvent, error) {
 	if len(p.Environment) > maxEnvironmentLen {
 		return nil, fmt.Errorf("deploy environment too long (got %d, max %d)", len(p.Environment), maxEnvironmentLen)
 	}
-	if len(eventID) > maxIdempotencyKeyLen {
-		return nil, fmt.Errorf("Idempotency-Key too long (got %d, max %d)", len(eventID), maxIdempotencyKeyLen)
+	if len(idempotencyKey) > maxIdempotencyKeyLen {
+		return nil, fmt.Errorf("Idempotency-Key too long (got %d, max %d)", len(idempotencyKey), maxIdempotencyKeyLen)
 	}
 	if p.GitSHA == "" && p.ImageDigest == "" {
 		return nil, fmt.Errorf("deploy must include at least one of git_sha or image_digest")
@@ -73,9 +74,9 @@ func mapDeploy(raw json.RawMessage, eventID string) (*ingest.WireEvent, error) {
 	}
 
 	return &ingest.WireEvent{
-		ID:        eventID,
-		TS:        time.Now().UTC(),
-		SessionID: fmt.Sprintf("deploy:%s", p.Environment),
+		IdempotencyKey: idempotencyKey,
+		TS:             time.Now().UTC(),
+		SessionID:      fmt.Sprintf("deploy:%s", p.Environment),
 		Actor: ingest.WireActor{
 			Type: "system",
 			ID:   actorID,

--- a/internal/webhooks/github/handler.go
+++ b/internal/webhooks/github/handler.go
@@ -109,9 +109,10 @@ func (h *Handler) forward(
 		slog.Info("github webhook accepted", "event", event, "delivery", deliveryID, "session", ev.SessionID)
 		w.WriteHeader(http.StatusAccepted)
 	case errors.Is(err, store.ErrDuplicate):
-		// GitHub redelivery: the delivery UUID is our event ID, so this
-		// is a true duplicate. Ack 200 so GitHub stops retrying without
-		// the operator seeing it as a webhook failure.
+		// GitHub redelivery: the delivery UUID is the event's
+		// idempotency_key (ADR 0014), so this is a true duplicate. Ack 200
+		// so GitHub stops retrying without the operator seeing it as a
+		// webhook failure.
 		slog.Info("github webhook duplicate", "event", event, "delivery", deliveryID, "session", ev.SessionID)
 		w.WriteHeader(http.StatusOK)
 	default:

--- a/internal/webhooks/github/handler_test.go
+++ b/internal/webhooks/github/handler_test.go
@@ -85,8 +85,11 @@ func TestMapPullRequestSetsDerivedFields(t *testing.T) {
 	if ev.SessionID != "github-pr:acme/widget/42" {
 		t.Errorf("session_id = %q (must use slash-separated number, not #)", ev.SessionID)
 	}
-	if ev.ID != sampleDeliveryID {
-		t.Errorf("id = %q, want delivery uuid %q", ev.ID, sampleDeliveryID)
+	if ev.IdempotencyKey != sampleDeliveryID {
+		t.Errorf("idempotency_key = %q, want delivery uuid %q", ev.IdempotencyKey, sampleDeliveryID)
+	}
+	if ev.ID != "" {
+		t.Errorf("id = %q, want empty (server assigns the id, ADR 0014)", ev.ID)
 	}
 	if ev.Actor.Type != "human" || ev.Actor.ID != "alice" {
 		t.Errorf("actor = %+v", ev.Actor)
@@ -155,8 +158,11 @@ func TestHandlerHappyPath(t *testing.T) {
 	if len(events) != 1 {
 		t.Fatalf("got %d events, want 1", len(events))
 	}
-	if events[0].ID != sampleDeliveryID {
-		t.Errorf("event id = %q, want %q", events[0].ID, sampleDeliveryID)
+	if events[0].IdempotencyKey != sampleDeliveryID {
+		t.Errorf("event idempotency_key = %q, want %q", events[0].IdempotencyKey, sampleDeliveryID)
+	}
+	if events[0].ID == "" || events[0].ID == sampleDeliveryID {
+		t.Errorf("event id = %q, want a server-assigned ULID distinct from the delivery uuid", events[0].ID)
 	}
 	if events[0].Kind != "pr" {
 		t.Errorf("event kind = %q", events[0].Kind)
@@ -311,8 +317,8 @@ func TestMapPullRequestReview(t *testing.T) {
 	if ev.SessionID != "github-pr:acme/widget/42" {
 		t.Errorf("session_id = %q (must match the PR's session)", ev.SessionID)
 	}
-	if ev.ID != "delivery-review-1" {
-		t.Errorf("id = %q, want delivery", ev.ID)
+	if ev.IdempotencyKey != "delivery-review-1" {
+		t.Errorf("idempotency_key = %q, want delivery", ev.IdempotencyKey)
 	}
 	if ev.Actor.ID != "bob" {
 		t.Errorf("actor.id = %q, want bob", ev.Actor.ID)
@@ -539,8 +545,8 @@ func TestMapWorkflowRun(t *testing.T) {
 	if ev.SessionID != "github-build:acme/widget/123456789" {
 		t.Errorf("session_id = %q (must key on run id)", ev.SessionID)
 	}
-	if ev.ID != "delivery-wf-1" {
-		t.Errorf("id = %q, want delivery", ev.ID)
+	if ev.IdempotencyKey != "delivery-wf-1" {
+		t.Errorf("idempotency_key = %q, want delivery", ev.IdempotencyKey)
 	}
 	if ev.Actor.Type != "system" {
 		t.Errorf("actor.type = %q, want system", ev.Actor.Type)

--- a/internal/webhooks/github/mapper.go
+++ b/internal/webhooks/github/mapper.go
@@ -34,8 +34,9 @@ type pullRequestPayload struct {
 
 // mapPullRequest derives a wire event from a `pull_request` webhook
 // body. deliveryID (from the X-GitHub-Delivery header) is set as the
-// event ID so duplicate deliveries hit ErrDuplicate at the store
-// layer; if empty, the ingest pipeline assigns a ULID.
+// event's idempotency_key so a GitHub redelivery hits ErrDuplicate at
+// the store layer (ADR 0014 D2/D5); the `id` is always server-assigned.
+// If deliveryID is empty the delivery is not deduplicated.
 //
 // session_id: `github-pr:<owner>/<repo>/<number>`. Slashes are
 // query-string-safe, so the format survives `?session=...` in the
@@ -61,9 +62,9 @@ func mapPullRequest(raw json.RawMessage, deliveryID string) (*ingest.WireEvent, 
 	}
 
 	return &ingest.WireEvent{
-		ID:        deliveryID,
-		TS:        time.Now().UTC(),
-		SessionID: fmt.Sprintf("github-pr:%s/%d", p.Repository.FullName, p.Number),
+		IdempotencyKey: deliveryID,
+		TS:             time.Now().UTC(),
+		SessionID:      fmt.Sprintf("github-pr:%s/%d", p.Repository.FullName, p.Number),
 		Actor: ingest.WireActor{
 			Type: "human",
 			ID:   actorID,
@@ -117,9 +118,9 @@ func mapPullRequestReview(raw json.RawMessage, deliveryID string) (*ingest.WireE
 	}
 
 	return &ingest.WireEvent{
-		ID:        deliveryID,
-		TS:        time.Now().UTC(),
-		SessionID: fmt.Sprintf("github-pr:%s/%d", p.Repository.FullName, p.PullRequest.Number),
+		IdempotencyKey: deliveryID,
+		TS:             time.Now().UTC(),
+		SessionID:      fmt.Sprintf("github-pr:%s/%d", p.Repository.FullName, p.PullRequest.Number),
 		Actor: ingest.WireActor{
 			Type: "human",
 			ID:   actorID,
@@ -202,9 +203,9 @@ func mapPush(raw json.RawMessage, deliveryID string) (*ingest.WireEvent, error) 
 	}
 
 	return &ingest.WireEvent{
-		ID:        deliveryID,
-		TS:        time.Now().UTC(),
-		SessionID: fmt.Sprintf("github-push:%s/%s", p.Repository.FullName, branch),
+		IdempotencyKey: deliveryID,
+		TS:             time.Now().UTC(),
+		SessionID:      fmt.Sprintf("github-push:%s/%s", p.Repository.FullName, branch),
 		Actor: ingest.WireActor{
 			Type: "human",
 			ID:   actorID,
@@ -262,9 +263,9 @@ func mapWorkflowRun(raw json.RawMessage, deliveryID string) (*ingest.WireEvent, 
 	}
 
 	return &ingest.WireEvent{
-		ID:        deliveryID,
-		TS:        time.Now().UTC(),
-		SessionID: fmt.Sprintf("github-build:%s/%d", p.Repository.FullName, p.WorkflowRun.ID),
+		IdempotencyKey: deliveryID,
+		TS:             time.Now().UTC(),
+		SessionID:      fmt.Sprintf("github-build:%s/%d", p.Repository.FullName, p.WorkflowRun.ID),
 		Actor: ingest.WireActor{
 			Type: "system",
 			ID:   actorID,

--- a/proto/event.proto
+++ b/proto/event.proto
@@ -22,6 +22,12 @@ message Event {
   string hash = 10;                           // hash(serialized event - hash - sig)
   string prev_hash = 11;                      // hash of previous event in chain
   bytes sig = 12;                             // optional ed25519 signature
+  // Producer-generated per-event ULID used solely as the dedup key (ADR
+  // 0014). Decoupled from `id`: `id` is the server-assigned ordering /
+  // hash-chain anchor, `idempotency_key` is what survives a replay so the
+  // server can drop a re-POSTed event. NULL/empty for pre-0014 events and
+  // for webhook deliveries without an Idempotency-Key header.
+  string idempotency_key = 13;
 }
 
 message Actor {


### PR DESCRIPTION
实现 #81 / 落地 ADR 0014:把事件 `id` 与去重**解耦**——`id` 一律服务端 ULID(哈希链排序锚不变),去重改挂产出方生成的每事件 `idempotency_key`。重放(`replay`)与 webhook redelivery 因此变成幂等可重跑。

## 关键决策(ADR 0014)
- **否决** #81 候选 A/B(保留产出方 ULID 当 `id` + 409/`ON CONFLICT`):把跨进程、时钟有偏移的 ULID 当 `id` 会破坏哈希链头单调性。去重不该以牺牲完整性为代价。
- **采用** 每事件 ULID `idempotency_key` 作唯一去重键,`id` 永远服务端生成。

## 改动
| 层 | 内容 |
|---|---|
| schema | `Event` 增 `idempotency_key`(proto + GraphQL,已 `make proto`/`make gqlgen`) |
| store | migration `0003`(列 + **partial unique index** `WHERE idempotency_key IS NOT NULL`);postgres `ON CONFLICT … DO NOTHING` + `RowsAffected==0→ErrDuplicate`;memory 新增 `byKey` 索引;全列 SELECT/scan 透出键 |
| ingest | `id` **无条件**服务端赋值(D1);NDJSON 遇重**跳过续行 + 结构化日志**;`{accepted}` 为真实入库数;`/v1/events` 由 **409 翻为 200** |
| producers | hook `baseEvent` / git post-commit 每事件 `ulid.Make()` 填键;GitHub 4 mapper + deploy mapper 把 deliveryID / `Idempotency-Key` 头从 `id` 改挂 `idempotency_key`(顺带修既有 `id` 不变量违反) |
| replay/transport | 措辞改为「升级后事件可安全重跑,过渡窗内仍须 `--remove-on-success`」 |
| query | `toGQLEvent` 透出 `idempotencyKey` |
| docs | SPEC §6/§7 标为已落地;ADR 0014 状态改 Implemented + 追加实现记录 |

## 测试
- 重写 `TestIngestOverridesSubmittedID` / `TestIngestDedupesOnIdempotencyKey`,新增 `TestIngestMixedBatchSkipsDupKeepsRest`
- webhook redelivery 断言改 `idempotency_key`(**D5 机制搬移的回归守卫**)
- `TestEventLinksDataLoaderBatches` 改按服务端 id 建链
- 新增 integration `TestPostgresDedupesOnIdempotencyKey`
- `go build` / `go test`(366 passed)/ `go vet` 全绿,Go 1.25 gofmt 干净

## ⚠️ 合并前注意
- **强制 `/review`**:触及 `internal/hashchain` 完整性推理与 `internal/store`(ADR 0014 自身 + 项目策略要求)。
- **integration 未实跑**:`TestPostgresDedupesOnIdempotencyKey` 需 Docker,本机无 Docker 未跑(`go vet -tags integration` 通过);`ON CONFLICT … WHERE … DO NOTHING` 的 partial-index 推理依赖 Postgres 标准语义,建议有 Docker 处跑一次 `make test-integration`。

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)