### PR TITLE
fix(scripts): resolve hook binary via go env, not hardcoded ~/go

### DIFF
--- a/scripts/verify-backup-integrity.sh
+++ b/scripts/verify-backup-integrity.sh
@@ -60,11 +60,13 @@ swap_db() {
   echo "${prefix}/${new}${query}"
 }
 
-# Resolve hook binary: explicit env > known dev path > $PATH.
+# Resolve hook binary: explicit env > GOBIN/GOPATH dev path > $PATH.
+gobin="$(go env GOBIN 2>/dev/null)"
+[[ -z "$gobin" ]] && gobin="$(go env GOPATH 2>/dev/null)/bin"
 if [[ -n "${AGENT_LENS_HOOK_BIN:-}" ]]; then
   hook="$AGENT_LENS_HOOK_BIN"
-elif [[ -x "$HOME/go/bin/agent-lens-hook" ]]; then
-  hook="$HOME/go/bin/agent-lens-hook"
+elif [[ -n "$gobin" && -x "$gobin/agent-lens-hook" ]]; then
+  hook="$gobin/agent-lens-hook"
 elif command -v agent-lens-hook >/dev/null 2>&1; then
   hook="$(command -v agent-lens-hook)"
 else


### PR DESCRIPTION
## What

`scripts/verify-backup-integrity.sh` hardcoded `$HOME/go/bin/agent-lens-hook`
as its dev fallback for locating the hook binary. Resolve the bin directory
dynamically from `go env GOBIN` (falling back to `go env GOPATH`/bin) instead.

## Why

The hardcoded `~/go` path is brittle. Relocating GOPATH (in my case `~/go`
→ `~/Dev/env/go`) leaves that `elif` branch permanently dead — the script
silently degrades to `$PATH` lookup and, if the hook isn't on `$PATH`, errors
out even though the binary exists. Reading `go env` makes the fallback track
the actual toolchain config wherever it points.

## Verification

- `bash -n scripts/verify-backup-integrity.sh` passes.
- Resolution logic yields `/Users/dongqiu/Dev/env/go/bin`, where an installed
  `agent-lens-hook` is present and now correctly matched.

Resolution order is unchanged: explicit `AGENT_LENS_HOOK_BIN` env > GOBIN/GOPATH
dev path > `$PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)