### PR TITLE
fix(metrics): count dedup skips on their own series, not ingest failures

### DIFF
--- a/internal/ingest/handler.go
+++ b/internal/ingest/handler.go
@@ -171,7 +171,16 @@ func (h *Handler) IngestNDJSON(w http.ResponseWriter, r *http.Request) {
 // any) runs after the lock is released.
 func (h *Handler) Append(ctx context.Context, in *WireEvent) error {
 	if err := h.appendLocked(ctx, in); err != nil {
-		metrics.IngestFailure(failureReason(err))
+		// A duplicate is an expected idempotent skip (ADR 0014 D3), not a
+		// failure — a single replay can dedup a whole file at once. Count it
+		// on its own series so ingest-failure alerting isn't inflated. Both
+		// ingest entry points (NDJSON loop, webhooks) funnel through here, so
+		// the split is applied once for all callers.
+		if errors.Is(err, store.ErrDuplicate) {
+			metrics.IngestDeduped(in.Kind)
+		} else {
+			metrics.IngestFailure(failureReason(err))
+		}
 		return err
 	}
 	if h.after != nil {
@@ -246,14 +255,14 @@ func (h *Handler) appendLocked(ctx context.Context, in *WireEvent) error {
 	return nil
 }
 
-// failureReason maps an append error to a low-cardinality metric label,
-// mirroring writeAppendError's HTTP-status classification.
+// failureReason maps an append error to a low-cardinality metric label.
+// ErrDuplicate is deliberately absent: dedup skips are not failures and are
+// counted on the events_deduped series by Append (see ADR 0014). Every other
+// error classifies here, mirroring writeAppendError's HTTP-status split.
 func failureReason(err error) string {
 	switch {
 	case errors.Is(err, errMissingField), errors.Is(err, errInvalidKind):
 		return "validation"
-	case errors.Is(err, store.ErrDuplicate):
-		return "duplicate"
 	default:
 		return "store"
 	}

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -25,8 +25,13 @@ var (
 
 	ingestFailures = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "agent_lens_ingest_failures_total",
-		Help: "Ingest attempts that failed, by reason (decode, validation, duplicate, store).",
+		Help: "Ingest attempts that failed, by reason (decode, validation, store).",
 	}, []string{"reason"})
+
+	eventsDeduped = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "agent_lens_events_deduped_total",
+		Help: "Events skipped as idempotent duplicates (ADR 0014), by kind. Expected during replay; not a failure.",
+	}, []string{"kind"})
 
 	sessionHeadCacheSize = promauto.NewGauge(prometheus.GaugeOpts{
 		Name: "agent_lens_session_head_cache_size",
@@ -46,6 +51,11 @@ func EventIngested(kind string) { eventsIngested.WithLabelValues(kind).Inc() }
 // IngestFailure increments the per-reason failure counter. reason must come
 // from a small fixed set (see IngestFailures' Help) so cardinality stays bounded.
 func IngestFailure(reason string) { ingestFailures.WithLabelValues(reason).Inc() }
+
+// IngestDeduped increments the per-kind idempotent-skip counter. A dedup skip
+// is the expected replay / retried-POST outcome (ADR 0014), not a failure, so
+// it is counted on its own series to keep ingest-failure alerting clean.
+func IngestDeduped(kind string) { eventsDeduped.WithLabelValues(kind).Inc() }
 
 // SetSessionHeadCacheSize records the current head-hash cache entry count.
 func SetSessionHeadCacheSize(n int) { sessionHeadCacheSize.Set(float64(n)) }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -28,6 +28,18 @@ func TestEventIngestedAndFailureCounters(t *testing.T) {
 	if d := testutil.ToFloat64(fail) - beforeFail; d != 1 {
 		t.Errorf("ingest_failures{reason=decode} delta = %v, want 1", d)
 	}
+
+	// A dedup skip lands on its own series, not ingest_failures (#138).
+	dedup := eventsDeduped.WithLabelValues("prompt")
+	beforeDedup := testutil.ToFloat64(dedup)
+	failBefore := testutil.ToFloat64(ingestFailures.WithLabelValues("duplicate"))
+	IngestDeduped("prompt")
+	if d := testutil.ToFloat64(dedup) - beforeDedup; d != 1 {
+		t.Errorf("events_deduped{kind=prompt} delta = %v, want 1", d)
+	}
+	if d := testutil.ToFloat64(ingestFailures.WithLabelValues("duplicate")) - failBefore; d != 0 {
+		t.Errorf("ingest_failures{reason=duplicate} delta = %v, want 0 (dedup must not touch failures)", d)
+	}
 }
 
 func TestSetSessionHeadCacheSize(t *testing.T) {
@@ -69,6 +81,7 @@ func TestHandlerServesExposition(t *testing.T) {
 	// Touch each collector so its series is present in the exposition.
 	EventIngested("commit")
 	IngestFailure("store")
+	IngestDeduped("commit")
 	SetSessionHeadCacheSize(1)
 	graphqlRequestDuration.Observe(0.01)
 
@@ -81,6 +94,7 @@ func TestHandlerServesExposition(t *testing.T) {
 	for _, name := range []string{
 		"agent_lens_events_ingested_total",
 		"agent_lens_ingest_failures_total",
+		"agent_lens_events_deduped_total",
 		"agent_lens_session_head_cache_size",
 		"agent_lens_graphql_request_duration_seconds",
 	} {


### PR DESCRIPTION
Closes #138.

## Problem

ADR 0014 (#137) made `store.ErrDuplicate` an **expected, potentially bulk**
outcome — a single `replay` can dedup a whole file's events. But `Append`
routed `ErrDuplicate` through `metrics.IngestFailure("duplicate")`, so the
ingest-failure series spiked after every replay and failure-rate
dashboards/alerts read false.

## Fix (issue option B)

- Add `agent_lens_events_deduped_total{kind}` and send `ErrDuplicate` there
  instead of to the failure counter.
- The split lives in `Append` — the single choke point both the NDJSON loop
  and webhooks funnel through — so both ingest entry points are covered at once.
- `failureReason` no longer classifies `"duplicate"` (now unreachable), and the
  `ingest_failures` Help text drops it from the reason list.
- `session` is intentionally **not** a metric label (unbounded cardinality);
  the existing `slog.Info("ingest dedup skip", …)` line already carries session.

## Notes

- No in-repo dashboard/alert references `reason="duplicate"`, so nothing
  downstream needs updating (verified by grep over `deploy/` + `docs/`).
- Behavior is unchanged: `Append` still returns `ErrDuplicate`, the NDJSON loop
  still skips-and-continues, accepted counts and chain integrity are untouched.

## Test

- New assertions: a dedup skip increments `events_deduped{kind}` by 1 **and**
  leaves `ingest_failures{reason=duplicate}` at 0.
- Exposition test now asserts the new series is scraped.
- `go build ./...`, `go vet`, and `go test ./internal/metrics/... ./internal/ingest/...` (14 tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)